### PR TITLE
ATB-1136 | Refactor account-deletion-processor

### DIFF
--- a/src/handlers/account-deletion-processor-handler.ts
+++ b/src/handlers/account-deletion-processor-handler.ts
@@ -55,8 +55,6 @@ function getUserId(record: SQSRecord) {
 async function updateDeleteStatusId(userId: string) {
   try {
     await ddbService.updateDeleteStatus(userId);
-    logger.info(`${LOGS_PREFIX_SENSITIVE_INFO} Account ${userId} marked as deleted`);
-    logAndPublishMetric(MetricNames.MARK_AS_DELETED_SUCCEEDED);
   } catch (error) {
     logger.error(`${LOGS_PREFIX_SENSITIVE_INFO} Error updating account ${userId}`, { error });
     logAndPublishMetric(MetricNames.MARK_AS_DELETED_FAILED);

--- a/src/handlers/tests/account-deletion-processor-handler.test.ts
+++ b/src/handlers/tests/account-deletion-processor-handler.test.ts
@@ -127,11 +127,4 @@ describe('Account Deletion Processor', () => {
     await expect (handler(mockEvent, mockContext)).rejects.toThrowError('Failed to update the account status.');
     expect(loggerErrorSpy).toHaveBeenCalledWith(`Sensitive info - Error updating account hello`, { error: 'Error' });
   });
-
-  it('should update the status of the userId in DynamoDB and log info', async () => {
-    mockDynamoDBServiceUpdateDeleteStatus.mockReturnValue(['1']);
-    const loggerInfoSpy = jest.spyOn(logger, 'info');
-    await handler(mockEvent, mockContext);
-    expect(loggerInfoSpy).toHaveBeenCalledWith(`Sensitive info - Account hello marked as deleted`);
-  });
 });

--- a/src/services/dynamo-database-service.ts
+++ b/src/services/dynamo-database-service.ts
@@ -130,7 +130,8 @@ export class DynamoDatabaseService {
         ':ttl': { N: ttl.toString() },
         ':false': { BOOL: false },
       },
-      ConditionExpression: 'attribute_not_exists(isAccountDeleted) OR isAccountDeleted = :false',
+      ConditionExpression:
+        'attribute_exists(pk) AND (attribute_not_exists(isAccountDeleted) OR isAccountDeleted = :false)',
     };
     const command = new UpdateItemCommand(commandInput);
     const response = await this.dynamoClient.send(command);

--- a/src/services/dynamo-database-service.ts
+++ b/src/services/dynamo-database-service.ts
@@ -136,6 +136,8 @@ export class DynamoDatabaseService {
     const command = new UpdateItemCommand(commandInput);
     try {
       const response = await this.dynamoClient.send(command);
+      logger.info(`${LOGS_PREFIX_SENSITIVE_INFO} Account ${userId} marked as deleted`);
+      logAndPublishMetric(MetricNames.MARK_AS_DELETED_SUCCEEDED);
       if (!response) {
         const errorMessage = 'DynamoDB may have failed to update items, returned a null response.';
         logger.error(errorMessage);

--- a/src/services/dynamo-database-service.ts
+++ b/src/services/dynamo-database-service.ts
@@ -136,7 +136,7 @@ export class DynamoDatabaseService {
     const command = new UpdateItemCommand(commandInput);
     try {
       const response = await this.dynamoClient.send(command);
-      logger.info(`${LOGS_PREFIX_SENSITIVE_INFO} Account ${userId} marked as deleted`);
+      logger.info(`${LOGS_PREFIX_SENSITIVE_INFO} Account ${userId} marked as deleted.`);
       logAndPublishMetric(MetricNames.MARK_AS_DELETED_SUCCEEDED);
       if (!response) {
         const errorMessage = 'DynamoDB may have failed to update items, returned a null response.';
@@ -145,7 +145,7 @@ export class DynamoDatabaseService {
       }
       return response;
     } catch {
-      const errorMessage = `${LOGS_PREFIX_SENSITIVE_INFO} Error updating item with pk ${userId}`;
+      const errorMessage = `${LOGS_PREFIX_SENSITIVE_INFO} Error updating item with pk ${userId}.`;
       logger.error(errorMessage);
       logAndPublishMetric(MetricNames.DB_UPDATE_ERROR);
     }

--- a/src/services/dynamo-database-service.ts
+++ b/src/services/dynamo-database-service.ts
@@ -145,7 +145,11 @@ export class DynamoDatabaseService {
       }
       logAndPublishMetric(MetricNames.MARK_AS_DELETED_SUCCEEDED);
       return response;
-    } catch {
+    } catch (error: any) {
+      console.log(error);
+      if (error.name === 'ValidationException') {
+        throw new Error();
+      }
       const errorMessage = `${LOGS_PREFIX_SENSITIVE_INFO} Error updating item with pk ${userId}.`;
       logger.error(errorMessage);
       logAndPublishMetric(MetricNames.DB_UPDATE_ERROR);

--- a/src/services/dynamo-database-service.ts
+++ b/src/services/dynamo-database-service.ts
@@ -134,12 +134,18 @@ export class DynamoDatabaseService {
         'attribute_exists(pk) AND (attribute_not_exists(isAccountDeleted) OR isAccountDeleted = :false)',
     };
     const command = new UpdateItemCommand(commandInput);
-    const response = await this.dynamoClient.send(command);
-    if (!response) {
-      const errorMessage = 'DynamoDB may have failed to update items, returned a null response.';
+    try {
+      const response = await this.dynamoClient.send(command);
+      if (!response) {
+        const errorMessage = 'DynamoDB may have failed to update items, returned a null response.';
+        logger.error(errorMessage);
+        logAndPublishMetric(MetricNames.DB_UPDATE_ERROR);
+      }
+      return response;
+    } catch {
+      const errorMessage = `Error updating item with pk ${userId}`;
       logger.error(errorMessage);
       logAndPublishMetric(MetricNames.DB_UPDATE_ERROR);
     }
-    return response;
   }
 }

--- a/src/services/dynamo-database-service.ts
+++ b/src/services/dynamo-database-service.ts
@@ -140,7 +140,7 @@ export class DynamoDatabaseService {
       logAndPublishMetric(MetricNames.MARK_AS_DELETED_SUCCEEDED);
       return response;
     } catch (error: any) {
-      if (!error.name || error.name != 'ConditionalCheckFailedException') {
+      if (!error.name || error.name !== 'ConditionalCheckFailedException') {
         logger.error(`${LOGS_PREFIX_SENSITIVE_INFO} Error updating item with pk ${userId}.`);
         logAndPublishMetric(MetricNames.DB_UPDATE_ERROR);
         throw new Error('Error was not a Conditional Check Exception.'); //Therefore re-driving message back to the queue.

--- a/src/services/dynamo-database-service.ts
+++ b/src/services/dynamo-database-service.ts
@@ -137,12 +137,13 @@ export class DynamoDatabaseService {
     try {
       const response = await this.dynamoClient.send(command);
       logger.info(`${LOGS_PREFIX_SENSITIVE_INFO} Account ${userId} marked as deleted.`);
-      logAndPublishMetric(MetricNames.MARK_AS_DELETED_SUCCEEDED);
       if (!response) {
         const errorMessage = 'DynamoDB may have failed to update items, returned a null response.';
         logger.error(errorMessage);
         logAndPublishMetric(MetricNames.DB_UPDATE_ERROR);
+        return;
       }
+      logAndPublishMetric(MetricNames.MARK_AS_DELETED_SUCCEEDED);
       return response;
     } catch {
       const errorMessage = `${LOGS_PREFIX_SENSITIVE_INFO} Error updating item with pk ${userId}.`;

--- a/src/services/dynamo-database-service.ts
+++ b/src/services/dynamo-database-service.ts
@@ -146,12 +146,13 @@ export class DynamoDatabaseService {
       logAndPublishMetric(MetricNames.MARK_AS_DELETED_SUCCEEDED);
       return response;
     } catch (error: any) {
-      if (error.name === 'ValidationException') {
-        throw new Error('The error was validation exception, thus retrying.');
+      if (error.name != 'ConditionalCheckFailedException') {
+        const errorMessage = `${LOGS_PREFIX_SENSITIVE_INFO} Error updating item with pk ${userId}.`;
+        logger.error(errorMessage);
+        logAndPublishMetric(MetricNames.DB_UPDATE_ERROR);
+        throw new Error('Error was not a Conditional Check Exception.'); //Therefore re-driving message back to the queue.
       }
-      const errorMessage = `${LOGS_PREFIX_SENSITIVE_INFO} Error updating item with pk ${userId}.`;
-      logger.error(errorMessage);
-      logAndPublishMetric(MetricNames.DB_UPDATE_ERROR);
+      logger.info('No intervention exists for this account.');
     }
   }
 }

--- a/src/services/dynamo-database-service.ts
+++ b/src/services/dynamo-database-service.ts
@@ -137,19 +137,15 @@ export class DynamoDatabaseService {
     try {
       const response = await this.dynamoClient.send(command);
       logger.info(`${LOGS_PREFIX_SENSITIVE_INFO} Account ${userId} marked as deleted.`);
-      if (!response) {
-        logger.error('DynamoDB may have failed to update items, returned a null response.');
-        logAndPublishMetric(MetricNames.DB_UPDATE_ERROR);
-      }
       logAndPublishMetric(MetricNames.MARK_AS_DELETED_SUCCEEDED);
       return response;
     } catch (error: any) {
-      if (!error.name || error.name !== 'ConditionalCheckFailedException') {
+      if (!error.name || error.name != 'ConditionalCheckFailedException') {
         logger.error(`${LOGS_PREFIX_SENSITIVE_INFO} Error updating item with pk ${userId}.`);
         logAndPublishMetric(MetricNames.DB_UPDATE_ERROR);
         throw new Error('Error was not a Conditional Check Exception.'); //Therefore re-driving message back to the queue.
       }
-      logger.info(`${LOGS_PREFIX_SENSITIVE_INFO} No intervention exists for this account.`, { userId });
+      logger.info(`${LOGS_PREFIX_SENSITIVE_INFO} No intervention exists for this account ${userId}.`);
     }
   }
 }

--- a/src/services/dynamo-database-service.ts
+++ b/src/services/dynamo-database-service.ts
@@ -146,9 +146,8 @@ export class DynamoDatabaseService {
       logAndPublishMetric(MetricNames.MARK_AS_DELETED_SUCCEEDED);
       return response;
     } catch (error: any) {
-      console.log(error);
       if (error.name === 'ValidationException') {
-        throw new Error();
+        throw new Error('The error was validation exception, thus retrying.');
       }
       const errorMessage = `${LOGS_PREFIX_SENSITIVE_INFO} Error updating item with pk ${userId}.`;
       logger.error(errorMessage);

--- a/src/services/dynamo-database-service.ts
+++ b/src/services/dynamo-database-service.ts
@@ -145,7 +145,7 @@ export class DynamoDatabaseService {
       }
       return response;
     } catch {
-      const errorMessage = `Error updating item with pk ${userId}`;
+      const errorMessage = `${LOGS_PREFIX_SENSITIVE_INFO} Error updating item with pk ${userId}`;
       logger.error(errorMessage);
       logAndPublishMetric(MetricNames.DB_UPDATE_ERROR);
     }

--- a/src/services/test/dynamo-database-service.test.ts
+++ b/src/services/test/dynamo-database-service.test.ts
@@ -174,6 +174,6 @@ describe('Dynamo DB Service', () => {
     const loggerInfoSpy = jest.spyOn(logger, 'info');
     const dynamoDBService = new DynamoDatabaseService('table_name')
     await dynamoDBService.updateDeleteStatus('hello');
-    expect(loggerInfoSpy).toHaveBeenCalledWith("Sensitive info - No intervention exists for this account.", {"userId": "hello"});
+    expect(loggerInfoSpy).toHaveBeenCalledWith("Sensitive info - No intervention exists for this account hello.");
   });
 });

--- a/src/services/test/dynamo-database-service.test.ts
+++ b/src/services/test/dynamo-database-service.test.ts
@@ -149,7 +149,7 @@ describe('Dynamo DB Service', () => {
         ':ttl': { N: '1685417145' },
         ':false': { BOOL: false },
       },
-      ConditionExpression: 'attribute_not_exists(isAccountDeleted) OR isAccountDeleted = :false',
+      ConditionExpression: 'attribute_exists(pk) AND (attribute_not_exists(isAccountDeleted) OR isAccountDeleted = :false)',
     };
     const dynamoDBService = new DynamoDatabaseService('table_name')
     await dynamoDBService.updateDeleteStatus('hello');

--- a/src/services/test/dynamo-database-service.test.ts
+++ b/src/services/test/dynamo-database-service.test.ts
@@ -156,16 +156,6 @@ describe('Dynamo DB Service', () => {
     expect(ddbMock).toHaveReceivedCommandWith(UpdateItemCommand, commandInput);
   });
 
-  it('should throw an error if response of the Dynamo Client is null / undefined.', async () => {
-    const mockedUpdateCommand = mockClient(DynamoDBClient).on(UpdateItemCommand);
-    mockedUpdateCommand.resolves(undefined as any);
-    const loggerErrorSpy = jest.spyOn(logger, 'error');
-    const dynamoDBService = new DynamoDatabaseService('table_name')
-    await dynamoDBService.updateDeleteStatus('hello');
-    expect(loggerErrorSpy).toHaveBeenCalledWith('DynamoDB may have failed to update items, returned a null response.');
-    expect(logAndPublishMetric).toHaveBeenCalledWith('DB_UPDATE_ERROR');
-  });
-
   it('throws an error when it fails to update the userId status.', async () => {
     const mockedUpdateCommand = mockClient(DynamoDBClient).on(UpdateItemCommand);
     mockedUpdateCommand.rejectsOnce("InternalServerError" || "InvalidEndpointException" || "ItemCollectionSizeLimitExceededException" || "ProvisionedThroughputExceededException" || "RequestLimitExceeded" || "ResourceNotFoundException" || "TransactionConflictException" || "DynamoDBServiceException" || undefined );

--- a/src/services/test/dynamo-database-service.test.ts
+++ b/src/services/test/dynamo-database-service.test.ts
@@ -71,7 +71,7 @@ describe('Dynamo DB Service', () => {
   };
 
 
-  it('should get all items successfully', async () => {
+  it('should get all items successfully.', async () => {
     queryCommandMock.resolves({ Items: items });
     const allItems = await new DynamoDatabaseService('abc').retrieveRecordsByUserId('abc');
     expect(allItems).toEqual({
@@ -82,13 +82,13 @@ describe('Dynamo DB Service', () => {
     });
   });
 
-  it('should return undefined if user has no record', async () => {
+  it('should return undefined if a user has no record.', async () => {
     queryCommandMock.resolves({ Items: [] });
     const allItems = await new DynamoDatabaseService('abc').retrieveRecordsByUserId('abc');
     expect(allItems).toEqual(undefined);
   });
 
-  it('should check the parameters are being called correctly', async () => {
+  it('should check the parameters are being called correctly.', async () => {
     const QueryCommandInput = {
       TableName: 'abc',
       KeyConditionExpression: '#pk = :id_value',
@@ -101,7 +101,7 @@ describe('Dynamo DB Service', () => {
     expect(ddbMock).toHaveReceivedCommandWith(QueryCommand, QueryCommandInput);
   });
 
-  it('should return expected response if update was successful', async () => {
+  it('should return expected response if update was successful.', async () => {
     queryCommandMock.resolvesOnce({ Items: items });
     updateCommandMock.resolvesOnce({
       $metadata: {
@@ -116,7 +116,7 @@ describe('Dynamo DB Service', () => {
     expect(logger.info).toHaveBeenCalledTimes(0);
   });
 
-  it('should throw a TooManyRecordsError error if more than one record is retrieved for one user id', async () => {
+  it('should throw a TooManyRecordsError error if more than one record is retrieved for one user id.', async () => {
     queryCommandMock.resolves({ Items: [{ key: { S: 'valueOne' } }, { key: { S: 'valueTwo' } }] });
     const service = await new DynamoDatabaseService('table_name');
     await expect(async () => await service.retrieveRecordsByUserId('userId')).rejects.toThrow(
@@ -125,7 +125,7 @@ describe('Dynamo DB Service', () => {
     expect(logAndPublishMetric).toHaveBeenLastCalledWith(MetricNames.DB_QUERY_ERROR_TOO_MANY_ITEMS);
   });
 
-  it('should throw an error if Items field is undefined in response from db', async () => {
+  it('should throw an error if Items field is undefined in response from DynamoDB.', async () => {
     queryCommandMock.resolves({ Items: undefined } as unknown as QueryCommandOutput);
     const service = await new DynamoDatabaseService('table_name');
     await expect(async () => await service.retrieveRecordsByUserId('userId')).rejects.toThrow(
@@ -134,7 +134,7 @@ describe('Dynamo DB Service', () => {
     expect(logAndPublishMetric).toHaveBeenLastCalledWith(MetricNames.DB_QUERY_ERROR_NO_RESPONSE);
   });
 
-  it('should update the isAccountDeleted status of the userId in DynamoDB and log info', async () => {
+  it('should update the isAccountDeleted status of the userId in DynamoDB and log info.', async () => {
     updateCommandMock.resolves({$metadata : { httpStatusCode: 200 }});
     const commandInput: UpdateItemCommandInput = {
       TableName: 'table_name',
@@ -156,7 +156,7 @@ describe('Dynamo DB Service', () => {
     expect(ddbMock).toHaveReceivedCommandWith(UpdateItemCommand, commandInput);
   });
 
-  it('should throw an error if response of the Dynamo Client is null / undefined', async () => {
+  it('should throw an error if response of the Dynamo Client is null / undefined.', async () => {
     const mockedUpdateCommand = mockClient(DynamoDBClient).on(UpdateItemCommand);
     mockedUpdateCommand.resolves(undefined as any);
     const loggerErrorSpy = jest.spyOn(logger, 'error');
@@ -166,7 +166,7 @@ describe('Dynamo DB Service', () => {
     expect(logAndPublishMetric).toHaveBeenCalledWith('DB_UPDATE_ERROR');
   });
 
-  it('should throw an error if response of the Dynamo Client is null / undefined', async () => {
+  it('should throw an error if response of the Dynamo Client is null / undefined.', async () => {
     const mockedUpdateCommand = mockClient(DynamoDBClient).on(UpdateItemCommand);
     mockedUpdateCommand.resolves(undefined as any);
     const loggerErrorSpy = jest.spyOn(logger, 'error');
@@ -176,7 +176,7 @@ describe('Dynamo DB Service', () => {
     expect(logAndPublishMetric).toHaveBeenCalledWith('DB_UPDATE_ERROR');
   });
 
-  it('throws an error when it fails to update the userId status', async () => {
+  it('throws an error when it fails to update the userId status.', async () => {
     const mockedUpdateCommand = mockClient(DynamoDBClient).on(UpdateItemCommand);
     mockedUpdateCommand.rejectsOnce("InternalServerError" || "InvalidEndpointException" || "ItemCollectionSizeLimitExceededException" || "ProvisionedThroughputExceededException" || "RequestLimitExceeded" || "ResourceNotFoundException" || "TransactionConflictException" || "DynamoDBServiceException" );
     const loggerErrorSpy = jest.spyOn(logger, 'error');
@@ -188,7 +188,7 @@ describe('Dynamo DB Service', () => {
     expect(logAndPublishMetric).toHaveBeenCalledWith('DB_UPDATE_ERROR');
   });
 
-  it('does not throw an error and logs an info when there is a Conditional Check Exception', async () => {
+  it('does not throw an error and logs an info when there is a Conditional Check Exception.', async () => {
     const mockedUpdateCommand = mockClient(DynamoDBClient).on(UpdateItemCommand);
     mockedUpdateCommand.rejectsOnce({ name: "ConditionalCheckFailedException" });
     const loggerInfoSpy = jest.spyOn(logger, 'info');

--- a/src/services/test/dynamo-database-service.test.ts
+++ b/src/services/test/dynamo-database-service.test.ts
@@ -11,7 +11,7 @@ import { getCurrentTimestamp } from '../../commons/get-current-timestamp';
 import logger from '../../commons/logger';
 import { TooManyRecordsError } from '../../data-types/errors';
 import { logAndPublishMetric } from '../../commons/metrics';
-import { MetricNames} from '../../data-types/constants';
+import { MetricNames } from '../../data-types/constants';
 
 jest.mock('@aws-lambda-powertools/logger');
 jest.mock('../../commons/metrics');
@@ -151,7 +151,7 @@ describe('Dynamo DB Service', () => {
       },
       ConditionExpression: 'attribute_exists(pk) AND (attribute_not_exists(isAccountDeleted) OR isAccountDeleted = :false)',
     };
-    const dynamoDBService = new DynamoDatabaseService('table_name')
+    const dynamoDBService = new DynamoDatabaseService('table_name');
     await dynamoDBService.updateDeleteStatus('hello');
     expect(ddbMock).toHaveReceivedCommandWith(UpdateItemCommand, commandInput);
   });

--- a/src/services/test/dynamo-database-service.test.ts
+++ b/src/services/test/dynamo-database-service.test.ts
@@ -178,11 +178,22 @@ describe('Dynamo DB Service', () => {
 
   it('throws an error when it fails to update the userId status', async () => {
     const mockedUpdateCommand = mockClient(DynamoDBClient).on(UpdateItemCommand);
-    mockedUpdateCommand.rejectsOnce();
+    mockedUpdateCommand.rejectsOnce("InternalServerError" || "InvalidEndpointException" || "ItemCollectionSizeLimitExceededException" || "ProvisionedThroughputExceededException" || "RequestLimitExceeded" || "ResourceNotFoundException" || "TransactionConflictException" || "DynamoDBServiceException" );
     const loggerErrorSpy = jest.spyOn(logger, 'error');
     const dynamoDBService = new DynamoDatabaseService('table_name')
-    await dynamoDBService.updateDeleteStatus('hello');
+    await expect(async () => await dynamoDBService.updateDeleteStatus('hello')).rejects.toThrow(
+      new Error('Error was not a Conditional Check Exception.'),
+    );
     expect(loggerErrorSpy).toHaveBeenCalledWith('Sensitive info - Error updating item with pk hello.');
     expect(logAndPublishMetric).toHaveBeenCalledWith('DB_UPDATE_ERROR');
+  });
+
+  it('does not throw an error and logs an info when there is a Conditional Check Exception', async () => {
+    const mockedUpdateCommand = mockClient(DynamoDBClient).on(UpdateItemCommand);
+    mockedUpdateCommand.rejectsOnce({ name: "ConditionalCheckFailedException" });
+    const loggerInfoSpy = jest.spyOn(logger, 'info');
+    const dynamoDBService = new DynamoDatabaseService('table_name')
+    await dynamoDBService.updateDeleteStatus('hello');
+    expect(loggerInfoSpy).toHaveBeenCalledWith('No intervention exists for this account.');
   });
 });

--- a/src/services/test/dynamo-database-service.test.ts
+++ b/src/services/test/dynamo-database-service.test.ts
@@ -11,7 +11,7 @@ import { getCurrentTimestamp } from '../../commons/get-current-timestamp';
 import logger from '../../commons/logger';
 import { TooManyRecordsError } from '../../data-types/errors';
 import { logAndPublishMetric } from '../../commons/metrics';
-import { MetricNames } from '../../data-types/constants';
+import { MetricNames} from '../../data-types/constants';
 
 jest.mock('@aws-lambda-powertools/logger');
 jest.mock('../../commons/metrics');
@@ -166,19 +166,9 @@ describe('Dynamo DB Service', () => {
     expect(logAndPublishMetric).toHaveBeenCalledWith('DB_UPDATE_ERROR');
   });
 
-  it('should throw an error if response of the Dynamo Client is null / undefined.', async () => {
-    const mockedUpdateCommand = mockClient(DynamoDBClient).on(UpdateItemCommand);
-    mockedUpdateCommand.resolves(undefined as any);
-    const loggerErrorSpy = jest.spyOn(logger, 'error');
-    const dynamoDBService = new DynamoDatabaseService('table_name')
-    await dynamoDBService.updateDeleteStatus('hello');
-    expect(loggerErrorSpy).toHaveBeenCalledWith('DynamoDB may have failed to update items, returned a null response.');
-    expect(logAndPublishMetric).toHaveBeenCalledWith('DB_UPDATE_ERROR');
-  });
-
   it('throws an error when it fails to update the userId status.', async () => {
     const mockedUpdateCommand = mockClient(DynamoDBClient).on(UpdateItemCommand);
-    mockedUpdateCommand.rejectsOnce("InternalServerError" || "InvalidEndpointException" || "ItemCollectionSizeLimitExceededException" || "ProvisionedThroughputExceededException" || "RequestLimitExceeded" || "ResourceNotFoundException" || "TransactionConflictException" || "DynamoDBServiceException" );
+    mockedUpdateCommand.rejectsOnce("InternalServerError" || "InvalidEndpointException" || "ItemCollectionSizeLimitExceededException" || "ProvisionedThroughputExceededException" || "RequestLimitExceeded" || "ResourceNotFoundException" || "TransactionConflictException" || "DynamoDBServiceException" || undefined );
     const loggerErrorSpy = jest.spyOn(logger, 'error');
     const dynamoDBService = new DynamoDatabaseService('table_name')
     await expect(async () => await dynamoDBService.updateDeleteStatus('hello')).rejects.toThrow(
@@ -194,6 +184,6 @@ describe('Dynamo DB Service', () => {
     const loggerInfoSpy = jest.spyOn(logger, 'info');
     const dynamoDBService = new DynamoDatabaseService('table_name')
     await dynamoDBService.updateDeleteStatus('hello');
-    expect(loggerInfoSpy).toHaveBeenCalledWith('No intervention exists for this account.');
+    expect(loggerInfoSpy).toHaveBeenCalledWith("Sensitive info - No intervention exists for this account.", {"userId": "hello"});
   });
 });

--- a/src/services/test/dynamo-database-service.test.ts
+++ b/src/services/test/dynamo-database-service.test.ts
@@ -165,4 +165,24 @@ describe('Dynamo DB Service', () => {
     expect(loggerErrorSpy).toHaveBeenCalledWith('DynamoDB may have failed to update items, returned a null response.');
     expect(logAndPublishMetric).toHaveBeenCalledWith('DB_UPDATE_ERROR');
   });
+
+  it('should throw an error if response of the Dynamo Client is null / undefined', async () => {
+    const mockedUpdateCommand = mockClient(DynamoDBClient).on(UpdateItemCommand);
+    mockedUpdateCommand.resolves(undefined as any);
+    const loggerErrorSpy = jest.spyOn(logger, 'error');
+    const dynamoDBService = new DynamoDatabaseService('table_name')
+    await dynamoDBService.updateDeleteStatus('hello');
+    expect(loggerErrorSpy).toHaveBeenCalledWith('DynamoDB may have failed to update items, returned a null response.');
+    expect(logAndPublishMetric).toHaveBeenCalledWith('DB_UPDATE_ERROR');
+  });
+
+  it('throws an error when it fails to update the userId status', async () => {
+    const mockedUpdateCommand = mockClient(DynamoDBClient).on(UpdateItemCommand);
+    mockedUpdateCommand.rejectsOnce();
+    const loggerErrorSpy = jest.spyOn(logger, 'error');
+    const dynamoDBService = new DynamoDatabaseService('table_name')
+    await dynamoDBService.updateDeleteStatus('hello');
+    expect(loggerErrorSpy).toHaveBeenCalledWith('Sensitive info - Error updating item with pk hello.');
+    expect(logAndPublishMetric).toHaveBeenCalledWith('DB_UPDATE_ERROR');
+  });
 });


### PR DESCRIPTION
## Proposed changes
<!-- Include the Jira ticket number in square brackets as prefix, eg `ATB-XXXX: Description of Change` -->

### What changed
<!-- Describe the changes in detail - the "what"-->
- Refactor/ change the condition expression
- Re-driving in the queue based on condition expression
- Updated UTs

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
- Make sure that a user is not re-driven in the queue when the user does not exist (ConditionalCheckFailedException)
- Make sure that the users are re-driven if the error is anything but a Conditional Check Exception.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- List any related PRs -->
- [ATB-1136](https://govukverify.atlassian.net/browse/ATB-1136)

## Testing
<!-- Please give an overview of how the changes were tested -->
<!-- Please specify if changes were tested locally and how, include evidence where relevant -->
<!-- Please specify if changes were deployed and tested in the AWS Account and how, include evidence where relevant -->

Scenario 1: When the user_id does not exist in the table, and an error is logged when the user_id is trying to be deleted.
![Screenshot 2023-11-02 at 15 27 13](https://github.com/govuk-one-login/account-interventions-service/assets/116578228/9fdb5feb-c0b1-4c46-9102-b37fd13105e7)
![Screenshot 2023-11-02 at 15 26 56](https://github.com/govuk-one-login/account-interventions-service/assets/116578228/ab5b5491-c61c-4bef-bf84-ff8a39d5f6f9)

Scenario 2: Adding user_id, deleting user_id, marks as deleted correctly.

![Screenshot 2023-11-02 at 15 29 13](https://github.com/govuk-one-login/account-interventions-service/assets/116578228/5fc6c8cc-f006-4b74-8e4d-f278c6d9aec4)
![Screenshot 2023-11-02 at 15 28 54](https://github.com/govuk-one-login/account-interventions-service/assets/116578228/e2497ec7-e19d-49b8-9fb8-01460a12c333)
![Screenshot 2023-11-02 at 15 29 36](https://github.com/govuk-one-login/account-interventions-service/assets/116578228/5b812e1d-28bd-4aac-8d14-b26c633a4edb)
![Screenshot 2023-11-02 at 15 29 59](https://github.com/govuk-one-login/account-interventions-service/assets/116578228/7f28c704-6c93-4ce1-8666-f21c8483fbd0)

UTs:
![Screenshot 2023-11-02 at 15 47 20](https://github.com/govuk-one-login/account-interventions-service/assets/116578228/d2f49b25-b5d6-407f-85e7-66c455ffeffc)

Logs (re; ConditionalCheckFailedException)
If it isn't a conditional check exception, the SQS record will be sent to the queue to be retried:
<img width="1296" alt="Screenshot 2023-11-07 at 14 54 17" src="https://github.com/govuk-one-login/account-interventions-service/assets/116578228/5cb0eee6-9e3c-49b2-89ff-1f1b060cc876">

When the user does not exist, a log line is logged, and the error is not retried:
<img width="1098" alt="Screenshot 2023-11-07 at 14 47 21" src="https://github.com/govuk-one-login/account-interventions-service/assets/116578228/049f41b8-8fdf-4e8a-8826-543120881344">

## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [x] Tested changes and included test evidence in the PR, if appropriate
- [x] Included all required tags and other properties for any new resources in the SAM template
- [x] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [x] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [x] Ensured that no log lines include PII or other sensitive data
- [x] Implemented unit testing for any new logic implemented, if appropriate
- [x] Ensured that all commits in this PR are signed
- [x] Ensured appropriate code coverage is maintained by unit tests


[ATB-1136]: https://govukverify.atlassian.net/browse/ATB-1136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ