### PR TITLE
ATB-1186: Added API endpoint urls except prod

### DIFF
--- a/src/specs/api.yaml
+++ b/src/specs/api.yaml
@@ -22,17 +22,17 @@ info:
     url: "https://github.com/govuk-one-login/account-interventions-service/blob/main/LICENCE.md"
 
 servers:
-  - url: "https://{environment}.account.gov.uk" # TODO
-    description: defaults to dev environment
+  - url: "https://{environment}.execute-api.eu-west-2.amazonaws.com/v1"
+    description: defaults to staging environment
     variables:
       environment:
-        default: credential-store.dev # TODO
-        enum: # TODO
-          - credential-store.dev
-          - credential-store.build
-          - credential-store.staging
-          - credential-store.integration
-          - credential-store             # Production
+        default: 6c8dsd04i1 # staging
+        enum:
+          - 072ifz6cp9 # dev
+          - wxn8p5hxkg # build
+          - 6c8dsd04i1 # staging
+          - kgsdlzd95d # integration
+          - please-ask # Production
 
 paths:
   /ais/{userId}:


### PR DESCRIPTION
## Proposed changes
Added API endpoint urls except prod

### What changed
API Spec

### Why did it change
Add information to allow integration with 3rd parties

### Issue tracking
- [ATB-1186](https://govukverify.atlassian.net/browse/ATB-1186)

## Testing
<img width="1636" alt="Screenshot 2023-11-15 at 08 57 36" src="https://github.com/govuk-one-login/account-interventions-service/assets/112074214/ef7ed90c-c82c-489a-8bec-8b32c3224599">


## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [x] Tested changes and included test evidence in the PR, if appropriate
- [ ] Included all required tags and other properties for any new resources in the SAM template
- [ ] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [ ] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [ ] Ensured that no log lines include PII or other sensitive data
- [ ] Implemented unit testing for any new logic implemented, if appropriate
- [x] Ensured that all commits in this PR are signed
- [ ] Ensured appropriate code coverage is maintained by unit tests
