### PR TITLE
ATB-1190: Ensure status-retriever can handle encoded path parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "engines": {
     "node": ">=18"
   },
-  "packageManager": "^yarn@1.22.19",
+  "packageManager": "^yarn@1.22.21",
   "scripts": {
     "test": "yarn test:unit",
     "test:unit": "jest --group=unit --coverage --runInBand",

--- a/src/handlers/status-retriever-handler.ts
+++ b/src/handlers/status-retriever-handler.ts
@@ -13,7 +13,7 @@ export const handle = async (event: APIGatewayEvent, context: Context): Promise<
   logger.addContext(context);
   logger.debug('Status-Retriever-Handler.');
 
-  if (!event.pathParameters || !event.pathParameters?.['userId']) {
+  if (!event.pathParameters || !event.pathParameters['userId']) {
     logAndPublishMetric(MetricNames.INVALID_SUBJECT_ID);
     return {
       statusCode: 400,

--- a/src/handlers/status-retriever-handler.ts
+++ b/src/handlers/status-retriever-handler.ts
@@ -13,14 +13,15 @@ export const handle = async (event: APIGatewayEvent, context: Context): Promise<
   logger.addContext(context);
   logger.debug('Status-Retriever-Handler.');
 
-  const userId = event.pathParameters?.['userId'];
-  if (!userId || !validateEvent(userId)) {
+  if (!event.pathParameters || !event.pathParameters?.['userId']) {
     logAndPublishMetric(MetricNames.INVALID_SUBJECT_ID);
     return {
       statusCode: 400,
       body: JSON.stringify({ message: 'Invalid Request.' }),
     };
   }
+
+  const userId = decodeURIComponent(validateEvent(event.pathParameters?.['userId']));
   const historyQuery = event.queryStringParameters?.['history'];
 
   try {

--- a/src/handlers/tests/status-retriever-handler.test.ts
+++ b/src/handlers/tests/status-retriever-handler.test.ts
@@ -189,7 +189,7 @@ describe('status-retriever-handler', () => {
 
   it('will return a standard 200 response when there is a request with an encoded user id', async () => {
     const suspendedRecord = {
-      pk: encodeURIComponent('test&User?ID'),
+      pk: 'test&User?ID',
       intervention: 'some intervention',
       updatedAt: 123455,
       appliedAt: 12345685809,

--- a/src/handlers/tests/status-retriever-handler.test.ts
+++ b/src/handlers/tests/status-retriever-handler.test.ts
@@ -189,7 +189,7 @@ describe('status-retriever-handler', () => {
 
   it('will return a standard 200 response when there is a request with an encoded user id', async () => {
     const suspendedRecord = {
-      pk: encodeURIComponent('testUserID'),
+      pk: encodeURIComponent('test&User?ID'),
       intervention: 'some intervention',
       updatedAt: 123455,
       appliedAt: 12345685809,
@@ -221,7 +221,7 @@ describe('status-retriever-handler', () => {
       auditLevel: 'standard',
     };
 
-    mockDynamoDBServiceRetrieveRecords(testEvent.pathParameters ? ['userId'] : encodeURIComponent('testUserID'));
+    mockDynamoDBServiceRetrieveRecords(testEvent.pathParameters ? ['userId'] : encodeURIComponent('test&User?ID'));
     mockDynamoDBServiceRetrieveRecords.mockResolvedValueOnce(suspendedRecord);
     const response = await handle(testEvent, mockConfig);
     expect(response.statusCode).toBe(200);

--- a/src/handlers/tests/status-retriever-handler.test.ts
+++ b/src/handlers/tests/status-retriever-handler.test.ts
@@ -176,7 +176,73 @@ describe('status-retriever-handler', () => {
     expect(JSON.parse(response.body)).toEqual({ intervention: accountIsNotSuspended });
   });
 
-  it('will return status 400 if the userId in the event is empty', async () => {
+  it('will return a 400 error if the request has a missing user id in path parameters', async () => {
+    const invalidPathParameters = {
+      proxy: '/ais/{user_id}',
+      userId: undefined,
+    };
+    const invalidTestEvent = { ...testEvent, pathParameters: invalidPathParameters };
+    const response = await handle(invalidTestEvent, mockConfig);
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.body)).toEqual({ message: 'Invalid Request.' });
+  });
+
+  it('will return a standard 200 response when there is a request with an encoded user id', async () => {
+    const suspendedRecord = {
+      pk: encodeURIComponent('testUserID'),
+      intervention: 'some intervention',
+      updatedAt: 123455,
+      appliedAt: 12345685809,
+      sentAt: 123456789,
+      reprovedIdentityAt: 849473,
+      resetPasswordAt: 5847392,
+      blocked: false,
+      suspended: true,
+      resetPassword: false,
+      reproveIdentity: false,
+      auditLevel: 'standard',
+      ttl: 1234567890,
+      history: 'some intervention',
+    };
+
+    const suspendedAccount = {
+      updatedAt: 123455,
+      appliedAt: 12345685809,
+      sentAt: 123456789,
+      description: suspendedRecord.intervention,
+      reprovedIdentityAt: 849473,
+      resetPasswordAt: 5847392,
+      state: {
+        blocked: false,
+        suspended: true,
+        resetPassword: false,
+        reproveIdentity: false,
+      },
+      auditLevel: 'standard',
+    };
+
+    mockDynamoDBServiceRetrieveRecords(testEvent.pathParameters ? ['userId'] : encodeURIComponent('testUserID'));
+    mockDynamoDBServiceRetrieveRecords.mockResolvedValueOnce(suspendedRecord);
+    const response = await handle(testEvent, mockConfig);
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toEqual({ intervention: suspendedAccount });
+  });
+
+  it('will return a default response if the userId contains whitespace and cannot find a userId that matches', async () => {
+    const accountNotFoundDefaultObject = {
+      updatedAt: 1685404800000,
+      appliedAt: 1685404800000,
+      sentAt: 1685404800000,
+      description: 'AIS_NO_INTERVENTION',
+      state: {
+        blocked: false,
+        suspended: false,
+        resetPassword: false,
+        reproveIdentity: false,
+      },
+      auditLevel: 'standard',
+    };
+
     const invalidPathParameters = {
       proxy: '/ais/{user_id}',
       userId: ' ',
@@ -184,9 +250,9 @@ describe('status-retriever-handler', () => {
     const invalidTestEvent = { ...testEvent, pathParameters: invalidPathParameters };
     const response = await handle(invalidTestEvent, mockConfig);
     expect(logger.warn).toBeCalledTimes(1);
-    expect(logger.warn).toBeCalledWith('Attribute invalid: user_id is empty.');
-    expect(response.statusCode).toBe(400);
-    expect(JSON.parse(response.body)).toEqual({ message: 'Invalid Request.' });
+    expect(logger.warn).toBeCalledWith('Attribute invalid: user_id is empty.')
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toEqual({ intervention: accountNotFoundDefaultObject });
   });
 
   it('will return the correct response if there is a problem with the query to dynamoDB', async () => {


### PR DESCRIPTION
## Proposed changes
[ATB-1190](https://govukverify.atlassian.net/browse/ATB-1190)

### What changed
Added logic and unit tests to cover the scenario of encoded path parameters along with updating unit tests to cover this.

### Why did it change
Currently the status retriever handler could not handle encoded path parameters, this change is to ensure it can.

## Testing
Locally, via unit tests. Full code coverage:
<img width="731" alt="Screenshot 2023-11-16 at 11 47 50" src="https://github.com/govuk-one-login/account-interventions-service/assets/130994595/01e7cb3b-331c-46ff-af7f-d30eaa9c3ec9">
API Gateway, correctly decodes the user Id and retrieves the record that is matched against it:
<img width="741" alt="Screenshot 2023-11-16 at 12 10 26" src="https://github.com/govuk-one-login/account-interventions-service/assets/130994595/fe989eda-e7e0-4d4a-a321-bc94fc7cb023">

## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [x] Tested changes and included test evidence in the PR, if appropriate
- [ ] Included all required tags and other properties for any new resources in the SAM template
- [ ] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [ ] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [x] Ensured that no log lines include PII or other sensitive data
- [x] Implemented unit testing for any new logic implemented, if appropriate
- [x] Ensured that all commits in this PR are signed
- [x] Ensured appropriate code coverage is maintained by unit tests


[ATB-1190]: https://govukverify.atlassian.net/browse/ATB-1190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ