### PR TITLE
ATB-1249: fixed local run error and reworded test scenario titles and matcher strings to improve readability

### DIFF
--- a/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-HappyPath.feature
+++ b/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-HappyPath.feature
@@ -1,9 +1,9 @@
 Feature: Invoke-APIGateway-HappyPath.feature
 
-    Scenario Outline: Happy Path - Get Request to /ais/userId - Returns Data for a userId
-        Given I send a request to sqs queue with <aisEventType> data
-        When I invoke apiGateway to retreive the status of the userId with <historyValue>
-        Then I should receive the appropriate <interventionType>, <blockedState>, <suspendedState>, <resetPassword> and <reproveIdentity> for the ais endpoint
+    Scenario Outline: Happy Path - Get Request to /ais/userId - Returns Expected Data
+        Given I send an <aisEventType> intervention message to the TxMA ingress SQS queue
+        When I invoke the API to retrieve the intervention status of the user's account. With history <historyValue>
+        Then I expect the intervention to be <interventionType>, with the following state settings <blockedState>, <suspendedState>, <resetPassword> and <reproveIdentity>
         Examples:
             | aisEventType     | historyValue | interventionType               | blockedState | suspendedState | resetPassword | reproveIdentity |
             | pswResetRequired | false        | AIS_FORCED_USER_PASSWORD_RESET | false        | true           | true          | false           |

--- a/feature-tests/utils/invoke-apigateway-lambda.ts
+++ b/feature-tests/utils/invoke-apigateway-lambda.ts
@@ -2,7 +2,7 @@ import { InvokeCommand, LambdaClient } from '@aws-sdk/client-lambda';
 import EndPoints from '../apiEndpoints/endpoints';
 import request from 'supertest';
 
-export async function invokePrivateApiGateWayAndLambdaFunction(testUserId: string, historyValue: boolean) {
+export async function invokeGetAccountState(testUserId: string, historyValue: boolean) {
   if (process.platform === 'darwin') {
     const client = new LambdaClient({});
     const command = new InvokeCommand({
@@ -10,9 +10,9 @@ export async function invokePrivateApiGateWayAndLambdaFunction(testUserId: strin
       Payload: JSON.stringify({ userId: testUserId, queryParameters: `history=${historyValue}` }),
     });
     const { Payload } = await client.send(command);
-    const resultFromLambda = Payload ? Buffer.from(Payload).toString() : '';
-    const obj = JSON.parse(resultFromLambda);
-    return obj.body;
+    const resultStringFromLambda = Payload ? Buffer.from(Payload).toString() : '';
+    const resultObjectFromLambda = JSON.parse(resultStringFromLambda);
+    return JSON.parse(resultObjectFromLambda.body);
   } else if (process.platform === 'linux') {
     const resultFromAPI = await request(EndPoints.AIS_BASE_URL)
       .get(EndPoints.PATH_AIS + testUserId)


### PR DESCRIPTION
## Proposed changes

### What changed
fixed local run error with SQS payload being a string instead of object and reworded test scenario titles and matcher strings to improve readability

### Why did it change
Local feature runs were failing

### Issue tracking
- [ATB-1249](https://govukverify.atlassian.net/browse/ATB-1249)

## Testing
![Screenshot 2023-12-06 at 12 45 35](https://github.com/govuk-one-login/account-interventions-service/assets/112074214/9743e31c-6183-4253-9bdb-ce95c097351a)


## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [x] Tested changes and included test evidence in the PR, if appropriate
- [ ] Included all required tags and other properties for any new resources in the SAM template
- [ ] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [ ] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [ ] Ensured that no log lines include PII or other sensitive data
- [ ] Implemented unit testing for any new logic implemented, if appropriate
- [x] Ensured that all commits in this PR are signed
- [ ] Ensured appropriate code coverage is maintained by unit tests


[ATB-1249]: https://govukverify.atlassian.net/browse/ATB-1249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ