### PR TITLE
ATB-1209: Update functionNames to use values from template

### DIFF
--- a/feature-tests/README.md
+++ b/feature-tests/README.md
@@ -18,6 +18,7 @@ Set up the following env vars.
 cd feature-tests
 yarn install && yarn build
 export TEST_ENVIRONMENT=dev
+export SAM_STACK_NAME=ais-main
 export AWS_REGION=eu-west-2
 export AWS_PROFILE=dev
 ```
@@ -50,6 +51,8 @@ once the docker image is built, run the following the execute the dockerfile
 docker run account-intervention-service-feature-tests-image:latest
 ```
 
+## Environment configuration
+If new values are added to **endpoints.ts**, associated values will then need to be added to the main template
 
 ## ESLint for Typescript
 ES Lint has been configured for the typescript code within the framework

--- a/feature-tests/apiEndpoints/endpoints.ts
+++ b/feature-tests/apiEndpoints/endpoints.ts
@@ -1,4 +1,12 @@
 export default class EndPoints {
-  public static AIS_BASE_URL = 'https://072ifz6cp9.execute-api.eu-west-2.amazonaws.com/v1';
+  public static AIS_BASE_URL =
+    process.env.TEST_ENVIRONMENT === 'dev'
+      ? `https://072ifz6cp9.execute-api.${process.env.AWS_REGION}.amazonaws.com/v1`
+      : process.env.CFN_PrivateApiEndpoint;
+  public static SQS_QUEUE_URL =
+    process.env.TEST_ENVIRONMENT === 'dev'
+      ? `https://sqs.${process.env.AWS_REGION}.amazonaws.com/013758878511/${process.env.SAM_STACK_NAME}-TxMAIngressQueue`
+      : process.env.CFN_SqsQueueUrl;
   public static PATH_AIS = '/ais/';
+  public static INVOKE_PRIVATE_API_GATEWAY = `${process.env.SAM_STACK_NAME}-InvokePrivateAPIGatewayFunction`;
 }

--- a/feature-tests/utils/invoke-apigateway-lambda.ts
+++ b/feature-tests/utils/invoke-apigateway-lambda.ts
@@ -6,7 +6,7 @@ export async function invokeGetAccountState(testUserId: string, historyValue: bo
   if (process.platform === 'darwin') {
     const client = new LambdaClient({});
     const command = new InvokeCommand({
-      FunctionName: 'ais-main-InvokePrivateAPIGatewayFunction',
+      FunctionName: EndPoints.INVOKE_PRIVATE_API_GATEWAY,
       Payload: JSON.stringify({ userId: testUserId, queryParameters: `history=${historyValue}` }),
     });
     const { Payload } = await client.send(command);

--- a/feature-tests/utils/send-sqs-message.ts
+++ b/feature-tests/utils/send-sqs-message.ts
@@ -1,9 +1,10 @@
 import { SQS } from '@aws-sdk/client-sqs';
 import { aisEvents } from './ais-events-array';
+import EndPoints from '../apiEndpoints/endpoints';
 
 export async function sendSQSEvent(testUserId: string, aisEventType: keyof typeof aisEvents) {
-  const sqs = new SQS({ apiVersion: '2012-11-05', region: 'eu-west-2' });
-  const queueURL = 'https://sqs.eu-west-2.amazonaws.com/013758878511/ais-main-TxMAIngressQueue';
+  const sqs = new SQS({ apiVersion: '2012-11-05', region: process.env.AWS_REGION });
+  const queueURL = EndPoints.SQS_QUEUE_URL;
   aisEvents[aisEventType][0]!.user.user_id = testUserId;
   const messageBody = JSON.stringify(aisEvents[aisEventType][0]);
 

--- a/src/infra/main/samconfig.toml
+++ b/src/infra/main/samconfig.toml
@@ -1,8 +1,8 @@
 version = 0.1
 [default.deploy.parameters]
-stack_name = "ais-main"
+stack_name = "main-lq-ais"
 resolve_s3 = true
-s3_prefix = "ais-main"
+s3_prefix = "main-lq-ais"
 region = "eu-west-2"
 confirm_changeset = true
 capabilities = "CAPABILITY_NAMED_IAM"

--- a/src/infra/main/template.yaml
+++ b/src/infra/main/template.yaml
@@ -930,3 +930,7 @@ Outputs:
   PrivateApiEndpoint:
     Description: "Private API Gateway endpoint URL for AIS methods"
     Value: !Sub "https://${PrivateRestApi}.execute-api.${AWS::Region}.amazonaws.com/${ApiStageName}"
+
+  SqsQueueUrl:
+    Description: "Endpoint URL for TxMA Egress Queue"
+    Value: !Ref TxMAEgressQueue


### PR DESCRIPTION
## Proposed changes
[ATB-1209](https://govukverify.atlassian.net/browse/ATB-1209)

### What changed
Update function values with references from main template rather than hardcoded

### Why did it change
To provide dynamic values in the test framework to enable ease of use and to protect certain values.

## Testing
All tests pass:
<img width="1042" alt="Screenshot 2023-12-07 at 13 06 42" src="https://github.com/govuk-one-login/account-interventions-service/assets/130994595/17045449-9b8c-4082-9518-80361b60fa53">

## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [x] Tested changes and included test evidence in the PR, if appropriate
- [ ] Included all required tags and other properties for any new resources in the SAM template
- [ ] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [ ] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [x] Ensured that no log lines include PII or other sensitive data
- [ ] Implemented unit testing for any new logic implemented, if appropriate
- [x] Ensured that all commits in this PR are signed
- [x] Ensured appropriate code coverage is maintained by unit tests
