### PR TITLE
ATB-1243: Enable API Gateway logging along with CSLS subscription

### DIFF
--- a/src/infra/main/template.yaml
+++ b/src/infra/main/template.yaml
@@ -1149,29 +1149,29 @@ Resources:
             - !FindInMap [ EnvConfig, !Ref Environment, AuthenticationVPCID ]
             - !FindInMap [ EnvConfig, !Ref Environment, OneLoginHomeVPCID ]
             - !FindInMap [ EnvConfig, !Ref Environment, OrchestrationVPCID ]
-      # AccessLogSetting:
-      #   Format: >-
-      #     {
-      #     "requestId": "$context.requestId",
-      #     "requestTime": "$context.requestTime",
-      #     "requestTimeEpoch": "$context.requestTimeEpoch",
-      #     "httpMethod": "$context.httpMethod",
-      #     "domainName": "$context.domainName",
-      #     "path": "$context.path",
-      #     "routeKey": "$context.routeKey",
-      #     "protocol": "$context.protocol",
-      #     "status": "$context.status",
-      #     "responseLength": "$context.responseLength",
-      #     "responseLatency": "$context.responseLatency",
-      #     "authorizerLatency": "$context.authorizer.latency",
-      #     "integrationStatus": "$context.integrationStatus",
-      #     "integrationLatency": "$context.integrationLatency",
-      #     "integrationErrorMessage": "$context.integrationErrorMessage",
-      #     "errorMessage": "$context.error.message",
-      #     "errorResponseType": "$context.error.responseType",
-      #     "validationErrorString": "$context.error.validationErrorString",
-      #     }
-      #   DestinationArn: !GetAtt PrivateAPIGatewayAccessLogGroup.Arn
+      AccessLogSetting:
+        Format: >-
+          {
+          "requestId": "$context.requestId",
+          "requestTime": "$context.requestTime",
+          "requestTimeEpoch": "$context.requestTimeEpoch",
+          "httpMethod": "$context.httpMethod",
+          "domainName": "$context.domainName",
+          "path": "$context.path",
+          "routeKey": "$context.routeKey",
+          "protocol": "$context.protocol",
+          "status": "$context.status",
+          "responseLength": "$context.responseLength",
+          "responseLatency": "$context.responseLatency",
+          "authorizerLatency": "$context.authorizer.latency",
+          "integrationStatus": "$context.integrationStatus",
+          "integrationLatency": "$context.integrationLatency",
+          "integrationErrorMessage": "$context.integrationErrorMessage",
+          "errorMessage": "$context.error.message",
+          "errorResponseType": "$context.error.responseType",
+          "validationErrorString": "$context.error.validationErrorString",
+          }
+        DestinationArn: !GetAtt PrivateAPIGatewayAccessLogGroup.Arn
       CacheClusterEnabled: false
       TracingEnabled: true
       EndpointConfiguration:
@@ -1198,27 +1198,49 @@ Resources:
         Owner: !Ref OwnerTagValue
         Source: !Ref SourceTagValue
 
-  # PrivateAPIGatewayAccessLogGroup:
-  #   Type: AWS::Logs::LogGroup
-  #   Properties:
-  #     LogGroupName: !Sub "/aws/apigateway/${PrivateRestApi}/${ApiStageName}"
-  #     RetentionInDays: 30
-  #     KmsKeyId: !GetAtt CloudWatchEncryptionKey.Arn
-  #     Tags:
-  #       - Key: Product
-  #         Value: !Ref ProductTagValue
-  #       - Key: System
-  #         Value: !Ref SystemTagValue
-  #       - Key: Environment
-  #         Value: !Ref Environment
-  #       - Key: Name
-  #         Value: PrivateApiGatewayAccessLogGroup
-  #       - Key: Owner
-  #         Value: !Ref OwnerTagValue
-  #       - Key: Source
-  #         Value: !Ref SourceTagValue
-  #       - Key: Name
-  #         Value: !Sub "/aws/apigateway/${PrivateRestApi}/${ApiStageName}"
+  PrivateAPIGatewayAccessLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/apigateway/${PrivateRestApi}/${ApiStageName}"
+      RetentionInDays: 30
+      KmsKeyId: !GetAtt CloudWatchEncryptionKey.Arn
+      Tags:
+        - Key: Product
+          Value: !Ref ProductTagValue
+        - Key: System
+          Value: !Ref SystemTagValue
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Name
+          Value: PrivateApiGatewayAccessLogGroup
+        - Key: Owner
+          Value: !Ref OwnerTagValue
+        - Key: Source
+          Value: !Ref SourceTagValue
+        - Key: Name
+          Value: !Sub "/aws/apigateway/${PrivateRestApi}/${ApiStageName}"
+
+  PrivateAPIAccessLogGroupNameSSM:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: The ARN of the PrivateAPIAccessLogGroup
+      Name: !Sub /${AWS::StackName}/PrivateRestAPI/Access/LogGroup/Name
+      Type: String
+      Value: !Sub /aws/apigateway/${PrivateRestApi}/${ApiStageName}
+      Tags:
+        Environment: !Ref Environment
+        Product: !Ref ProductTagValue
+        System: !Ref SystemTagValue
+        Owner: !Ref OwnerTagValue
+        Source: !Ref SourceTagValue
+
+  PrivateAPIGatewayLogsSubscriptionFilterCSLS:
+    Condition: IsProdOrInt
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: !Ref CSLSSubscriptionEndpointArn
+      LogGroupName: !Ref PrivateAPIGatewayAccessLogGroup
+      FilterPattern: "{$.message != \"Sensitive info*\"}"
 
   PrivateGatewayStatusRetrieverFunctionPermission:
     Type: AWS::Lambda::Permission

--- a/src/infra/main/template.yaml
+++ b/src/infra/main/template.yaml
@@ -1131,6 +1131,7 @@ Resources:
           Value: !Ref SourceTagValue
 
   InvokePrivateAPIGatewayFunctionPolicy:
+    Condition: IsInternal
     Type: AWS::IAM::Policy
     Properties:
       PolicyName: !Sub "${AWS::StackName}-InvokePrivateAPIGatewayFunctionPolicy"
@@ -1147,6 +1148,7 @@ Resources:
         - !Ref InvokePrivateAPIGatewayFunctionRole
 
   InvokePrivateAPIGatewayFunctionLogGroup:
+    Condition: IsInternal
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/lambda/${InvokePrivateAPIGatewayFunction}"
@@ -1171,7 +1173,7 @@ Resources:
     Type: AWS::Logs::SubscriptionFilter
     Properties:
       DestinationArn: !Ref CSLSSubscriptionEndpointArn
-      LogGroupName: !Ref InvokePrivateAPIGatewayFunctionLogGroup
+      LogGroupName: "/aws/lambda/InvokePrivateAPIGatewayFunction"
       FilterPattern: "{$.message != \"Sensitive info*\"}"
 
   # Private API Gateway resources

--- a/src/infra/main/template.yaml
+++ b/src/infra/main/template.yaml
@@ -1103,6 +1103,7 @@ Resources:
         Source: !Ref SourceTagValue
 
   InvokePrivateAPIGatewayFunctionRole:
+    Condition: IsInternal
     Type: AWS::IAM::Role
     Properties:
       RoleName:  !Sub '${AWS::StackName}-InvokePrivateAPIGatewayFunctionRole'

--- a/src/infra/main/template.yaml
+++ b/src/infra/main/template.yaml
@@ -1267,20 +1267,6 @@ Resources:
         - Key: Name
           Value: !Sub "/aws/apigateway/${PrivateRestApi}/${ApiStageName}"
 
-  PrivateAPIAccessLogGroupNameSSM:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Description: The ARN of the PrivateAPIAccessLogGroup
-      Name: !Sub /${AWS::StackName}/PrivateRestAPI/Access/LogGroup/Name
-      Type: String
-      Value: !Sub /aws/apigateway/${PrivateRestApi}/${ApiStageName}
-      Tags:
-        Environment: !Ref Environment
-        Product: !Ref ProductTagValue
-        System: !Ref SystemTagValue
-        Owner: !Ref OwnerTagValue
-        Source: !Ref SourceTagValue
-
   PrivateAPIGatewayLogsSubscriptionFilterCSLS:
     Condition: IsProdOrInt
     Type: AWS::Logs::SubscriptionFilter

--- a/src/infra/main/template.yaml
+++ b/src/infra/main/template.yaml
@@ -1169,7 +1169,7 @@ Resources:
           Value: !Sub "/aws/lambda/${InvokePrivateAPIGatewayFunction}"
 
   InvokePrivateAPIGatewayFunctionLogsSubscriptionFilterCSLS:
-    Condition: IsProdOrInt
+    Condition: IsInternal
     Type: AWS::Logs::SubscriptionFilter
     Properties:
       DestinationArn: !Ref CSLSSubscriptionEndpointArn
@@ -1268,7 +1268,6 @@ Resources:
           Value: !Sub "/aws/apigateway/${PrivateRestApi}/${ApiStageName}"
 
   PrivateAPIGatewayLogsSubscriptionFilterCSLS:
-    Condition: IsProdOrInt
     Type: AWS::Logs::SubscriptionFilter
     Properties:
       DestinationArn: !Ref CSLSSubscriptionEndpointArn

--- a/src/infra/main/template.yaml
+++ b/src/infra/main/template.yaml
@@ -982,6 +982,60 @@ Resources:
       Handler: status-retriever-handler.handle
       Role: !GetAtt StatusRetrieverFunctionRole.Arn
 
+  StatusRetrieverFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName:  !Sub '${AWS::StackName}-StatusRetrieverFunctionRole'
+      PermissionsBoundary: !If [ UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue ]
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action:
+              - "sts:AssumeRole"
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+      Tags:
+        - Key: Product
+          Value: !Ref ProductTagValue
+        - Key: System
+          Value: !Ref SystemTagValue
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Owner
+          Value: !Ref OwnerTagValue
+        - Key: Source
+          Value: !Ref SourceTagValue
+
+  StatusRetrieverFunctionPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub "${AWS::StackName}-StatusRetrieverFunctionPolicy"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - "logs:CreateLogStream"
+              - "logs:PutLogEvents"
+            Resource:
+              - !GetAtt StatusRetrieverFunctionLogGroup.Arn
+          - Effect: Allow
+            Action:
+              - "dynamodb:Query"
+            Resource:
+              - Fn::ImportValue: !Sub "${CoreStackName}-AccountStatusTableArn"
+          - Effect: Allow
+            Action:
+              - "kms:decrypt"
+            Resource:
+              - Fn::ImportValue: !Sub "${CoreStackName}-AccountStatusTableEncryptionKeyArn"
+      Roles:
+        - !Ref StatusRetrieverFunctionRole
+
   StatusRetrieverFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
@@ -1009,6 +1063,7 @@ Resources:
       LogGroupName: !Ref StatusRetrieverFunctionLogGroup
       FilterPattern: "{$.message != \"Sensitive info*\"}"
 
+  ### Invoke API Gateway ###
   InvokePrivateAPIGatewayFunction:
     Condition: IsInternal
     Type: AWS::Serverless::Function
@@ -1075,22 +1130,28 @@ Resources:
         - Key: Source
           Value: !Ref SourceTagValue
 
-  StatusRetrieverFunctionRole:
-    Type: AWS::IAM::Role
+  InvokePrivateAPIGatewayFunctionPolicy:
+    Type: AWS::IAM::Policy
     Properties:
-      RoleName:  !Sub '${AWS::StackName}-StatusRetrieverFunctionRole'
-      PermissionsBoundary: !If [ UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue ]
-      AssumeRolePolicyDocument:
+      PolicyName: !Sub "${AWS::StackName}-InvokePrivateAPIGatewayFunctionPolicy"
+      PolicyDocument:
         Version: "2012-10-17"
         Statement:
           - Effect: Allow
-            Principal:
-              Service: lambda.amazonaws.com
             Action:
-              - "sts:AssumeRole"
-      ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+              - "logs:CreateLogStream"
+              - "logs:PutLogEvents"
+            Resource:
+              - !GetAtt InvokePrivateAPIGatewayFunctionLogGroup.Arn
+      Roles:
+        - !Ref InvokePrivateAPIGatewayFunctionRole
+
+  InvokePrivateAPIGatewayFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${InvokePrivateAPIGatewayFunction}"
+      RetentionInDays: 30
+      KmsKeyId: !GetAtt CloudWatchEncryptionKey.Arn
       Tags:
         - Key: Product
           Value: !Ref ProductTagValue
@@ -1102,32 +1163,16 @@ Resources:
           Value: !Ref OwnerTagValue
         - Key: Source
           Value: !Ref SourceTagValue
+        - Key: Name
+          Value: !Sub "/aws/lambda/${InvokePrivateAPIGatewayFunction}"
 
-  StatusRetrieverFunctionPolicy:
-    Type: AWS::IAM::Policy
+  InvokePrivateAPIGatewayFunctionLogsSubscriptionFilterCSLS:
+    Condition: IsProdOrInt
+    Type: AWS::Logs::SubscriptionFilter
     Properties:
-      PolicyName: !Sub "${AWS::StackName}-StatusRetrieverFunctionPolicy"
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Action:
-              - "logs:CreateLogStream"
-              - "logs:PutLogEvents"
-            Resource:
-              - !GetAtt StatusRetrieverFunctionLogGroup.Arn
-          - Effect: Allow
-            Action:
-              - "dynamodb:Query"
-            Resource:
-              - Fn::ImportValue: !Sub "${CoreStackName}-AccountStatusTableArn"
-          - Effect: Allow
-            Action:
-              - "kms:decrypt"
-            Resource:
-              - Fn::ImportValue: !Sub "${CoreStackName}-AccountStatusTableEncryptionKeyArn"
-      Roles:
-        - !Ref StatusRetrieverFunctionRole
+      DestinationArn: !Ref CSLSSubscriptionEndpointArn
+      LogGroupName: !Ref InvokePrivateAPIGatewayFunctionLogGroup
+      FilterPattern: "{$.message != \"Sensitive info*\"}"
 
   # Private API Gateway resources
   PrivateRestApi:
@@ -1240,7 +1285,7 @@ Resources:
     Properties:
       DestinationArn: !Ref CSLSSubscriptionEndpointArn
       LogGroupName: !Ref PrivateAPIGatewayAccessLogGroup
-      FilterPattern: "{$.message != \"Sensitive info*\"}"
+      FilterPattern: ""
 
   PrivateGatewayStatusRetrieverFunctionPermission:
     Type: AWS::Lambda::Permission


### PR DESCRIPTION
## Proposed changes
[ATB-1243](https://govukverify.atlassian.net/browse/ATB-1243)

### What changed
Ensuring API GW Rest API log group has a subscription to CSLS

### Why did it change
Need to send logs to Cyber monitoring tool (Splunk)

## Testing
Currently no access to splunk to check if logs are successfully sent, will update this in due course

AccessLogGroup was successfully created, as seen in API GW:
<img width="905" alt="Screenshot 2023-12-13 at 10 59 17" src="https://github.com/govuk-one-login/account-interventions-service/assets/130994595/6115e697-4370-4910-8aa2-81ce5c494318">

Created log group for Invoke Private API function:
<img width="1240" alt="Screenshot 2023-12-13 at 16 10 56" src="https://github.com/govuk-one-login/account-interventions-service/assets/130994595/84b63bf1-834d-43cf-afa5-843253c7ef8e">

Successfully publishes logs to the log group when function is invoked:
<img width="1271" alt="Screenshot 2023-12-13 at 16 14 51" src="https://github.com/govuk-one-login/account-interventions-service/assets/130994595/c41ea400-843d-4a01-a7a7-9d48ba20ca81">


## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [ ] Tested changes and included test evidence in the PR, if appropriate
- [x] Included all required tags and other properties for any new resources in the SAM template
- [x] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [x] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [x] Ensured that no log lines include PII or other sensitive data
- [ ] Implemented unit testing for any new logic implemented, if appropriate
- [x] Ensured that all commits in this PR are signed
- [ ] Ensured appropriate code coverage is maintained by unit tests


[ATB-1243]: https://govukverify.atlassian.net/browse/ATB-1243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ