### PR TITLE
ATB-1270 | Integrate TxMAEgress queue

### DIFF
--- a/src/infra/main/template.yaml
+++ b/src/infra/main/template.yaml
@@ -764,6 +764,13 @@ Resources:
             Condition:
               ArnEquals:
                 aws:SourceArn: !Ref AccountDeletionProcessorSNSTopic
+          - Effect: Allow
+            Principal:
+              AWS: !FindInMap [ EnvConfig, !Ref Environment, TxMAAccountARN ]
+            Action:
+              - "kms:Decrypt"
+              - "kms:GenerateDataKey"
+            Resource: "*"
       Tags:
         - Key: Product
           Value: !Ref ProductTagValue


### PR DESCRIPTION
## Proposed changes
This ticket merges changes necessary to ensure that TxMA can ready messages from our egress queue

### What changed
Added permission for TxMA account to use the key that encrypts messages in the queue

### Why did it change
Allow integration with TxMA for outgoing messages

### Issue tracking
- [ATB-1270](https://govukverify.atlassian.net/browse/ATB-1270)

## Testing
Successfully deployed changes to AWS account

## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [x] Tested changes and included test evidence in the PR, if appropriate
- [x] Included all required tags and other properties for any new resources in the SAM template
- [x] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [x] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [x] Ensured that no log lines include PII or other sensitive data
- [x] Implemented unit testing for any new logic implemented, if appropriate
- [x] Ensured that all commits in this PR are signed
- [x] Ensured appropriate code coverage is maintained by unit tests


[ATB-1270]: https://govukverify.atlassian.net/browse/ATB-1270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ