### PR TITLE
ATB-1384: added iac lint to linting phase

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "test": "yarn test:unit",
     "test:unit": "jest --group=unit --coverage --runInBand",
-    "lint": "yarn lint:code && yarn lint:spec",
+    "lint": "yarn lint:code && yarn lint:spec && yarn lint:iac",
     "lint:code": "eslint --ext .ts .",
     "lint:code:fix": "yarn lint:code --fix",
     "lint:iac": "for f in src/infra/**/template.yaml; do (sam validate --lint -t $f) || exit 1; done",


### PR DESCRIPTION
## Proposed changes
Added iac lint to linting phase

### What changed
Linting phase now includes linting of template.yaml's

### Why did it change
Was not being linted

### Issue tracking
- [ATB-1384](https://govukverify.atlassian.net/browse/ATB-1384)

## Testing
Tested locally

## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [x] Tested changes and included test evidence in the PR, if appropriate
- [ ] Included all required tags and other properties for any new resources in the SAM template
- [ ] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [ ] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [ ] Ensured that no log lines include PII or other sensitive data
- [ ] Implemented unit testing for any new logic implemented, if appropriate
- [x] Ensured that all commits in this PR are signed
- [ ] Ensured appropriate code coverage is maintained by unit tests


[ATB-1384]: https://govukverify.atlassian.net/browse/ATB-1384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ