### PR TITLE
ATB-1387: Added tags to enable backup and deletion protection

### DIFF
--- a/src/infra/core/template.yaml
+++ b/src/infra/core/template.yaml
@@ -2,7 +2,7 @@ AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 
 Description: >-
-  Data layer template for the account interventions service solution
+  The Data layer for the Account Interventions Service (AIS) solution
 
 Parameters:
   Environment:
@@ -30,7 +30,10 @@ Parameters:
   SourceTagValue:
     Description: Value for the Source Tag
     Type: String
-    Default: govuk-one-login/account-interventions-service/src/infra/main/template.yaml
+    Default: govuk-one-login/account-interventions-service/src/infra/core/template.yaml
+
+Conditions:
+  IsDevEnvironment: !Equals [!Ref Environment, 'dev']
 
 Resources:
   AccountStatusTable:
@@ -48,6 +51,9 @@ Resources:
         KMSMasterKeyId: !Ref AccountStatusTableEncryptionKey
         SSEEnabled: true
         SSEType: KMS
+      DeletionProtectionEnabled: !If [ IsDevEnvironment, false, true ]
+      ContributorInsightsSpecification:
+        Enabled: true
       PointInTimeRecoverySpecification:
         PointInTimeRecoveryEnabled: true
       TimeToLiveSpecification:
@@ -64,6 +70,8 @@ Resources:
           Value: !Ref OwnerTagValue
         - Key: Source
           Value: !Ref SourceTagValue
+        - Key: BackupFrequency
+          Value: Bihourly
 
   AccountStatusTableEncryptionKey:
     Type: AWS::KMS::Key

--- a/src/infra/core/template.yaml
+++ b/src/infra/core/template.yaml
@@ -53,7 +53,7 @@ Resources:
         SSEType: KMS
       DeletionProtectionEnabled: !If [ IsDevEnvironment, false, true ]
       ContributorInsightsSpecification:
-        Enabled: true
+        Enabled: false
       PointInTimeRecoverySpecification:
         PointInTimeRecoveryEnabled: true
       TimeToLiveSpecification:


### PR DESCRIPTION
## Proposed changes
Added tags to enable backup and deletion protection

### What changed
DynamoDB config

### Why did it change
Enable backups via AWS Backup

### Issue tracking
- [ATB-1387](https://govukverify.atlassian.net/browse/ATB-1387)

## Testing
Only testable once tag applied.

## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [ ] Tested changes and included test evidence in the PR, if appropriate
- [x] Included all required tags and other properties for any new resources in the SAM template
- [ ] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [ ] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [ ] Ensured that no log lines include PII or other sensitive data
- [ ] Implemented unit testing for any new logic implemented, if appropriate
- [x] Ensured that all commits in this PR are signed
- [ ] Ensured appropriate code coverage is maintained by unit tests


[ATB-1387]: https://govukverify.atlassian.net/browse/ATB-1387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ