### PR TITLE
ATB-1367 | TxMA Egress Queue and DLQ Alarms

### DIFF
--- a/src/infra/alarm/template.yaml
+++ b/src/infra/alarm/template.yaml
@@ -17,43 +17,133 @@ Parameters:
     Description: "The ARN of the Alerting SNS High Alert Notification topic"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/ais-infra-alerting/SNS/HighAlertNotificationTopic/ARN" #pragma: allowlist secret
+  TxMAEgressQueueName:
+    Description: "The name of the TxMA Egress queue"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/ais-main/SQS/TxMAEgressQueue/Name" #pragma: allowlist secret
+  TxMAEgressDLQName:
+    Description: "The name of the TxMA Egress DLQ"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/ais-main/SQS/TxMAEgressDLQ/Name" #pragma: allowlist secret
 
 Resources:
 #
 # CloudWatch Alarms for SQS Queues
 #
-  TxMAIngressQueueProcessingSlowly:
+
+  TxMAEgressQueueProcessingSlowly:
     Type: AWS::CloudWatch::Alarm
     Properties:
       ActionsEnabled: true
       AlarmActions:
         - !Ref AlertingSNSLowAlertNotificationTopicARN
-      AlarmDescription: "The TxMA Ingress Queue is processing slowly."
-      Namespace: AWS/SQS
-      MetricName: TXMA_INGRESS_QUEUE_PROCESSING_SLOWLY
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      Statistic: SampleCount
+      AlarmDescription: "TxMA Egress queue processing slowly"
+      ComparisonOperator: GreaterThanThreshold
       Threshold: 60
       EvaluationPeriods: 1
-      Period: 60
       TreatMissingData: notBreaching
+      Dimensions:
+        - Name: QueueName
+          Value: !Ref TxMAEgressQueueName
+      MetricName: ApproximateAgeOfOldestMessage
+      Namespace: AWS/SQS
+      Period: 60
+      Statistic: Maximum
 
-  TxMAIngressQueueProcessingTooSlowly:
+  TxMAQueueProcessingTooSlow:
     Type: AWS::CloudWatch::Alarm
     Properties:
       ActionsEnabled: true
       AlarmActions:
         - !Ref AlertingSNSHighAlertNotificationTopicARN
-      AlarmDescription: "The TxMA Ingress Queue is processing slowly."
-      Namespace: AWS/SQS
-      MetricName: TXMA_INGRESS_QUEUE_PROCESSING_TOO_SLOWLY
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      Statistic: SampleCount
+      AlarmDescription: "TxMA Egress queue processing too slow"
+      ComparisonOperator: GreaterThanThreshold
       Threshold: 600
       EvaluationPeriods: 1
-      Period: 60
       TreatMissingData: notBreaching
+      Dimensions:
+        - Name: QueueName
+          Value: !Ref TxMAEgressQueueName
+      MetricName: ApproximateAgeOfOldestMessage
+      Namespace: AWS/SQS
+      Period: 60
+      Statistic: Maximum
 
+  TxMAQueueHasBacklog:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref AlertingSNSLowAlertNotificationTopicARN
+      AlarmDescription: "TxMA Egress queue has backlog"
+      ComparisonOperator: GreaterThanThreshold
+      Threshold: 10
+      EvaluationPeriods: 1
+      TreatMissingData: notBreaching
+      Dimensions:
+        - Name: QueueName
+          Value: !Ref TxMAEgressQueueName
+      MetricName: ApproximateNumberOfMessagesVisible
+      Namespace: AWS/SQS
+      Period: 60
+      Statistic: Maximum
+
+  TxMAQueueTooManyMessages:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref AlertingSNSHighAlertNotificationTopicARN
+      AlarmDescription: "TxMA Egress queue has too many messages"
+      ComparisonOperator: GreaterThanThreshold
+      Threshold: 50
+      EvaluationPeriods: 1
+      TreatMissingData: notBreaching
+      Dimensions:
+        - Name: QueueName
+          Value: !Ref TxMAEgressQueueName
+      MetricName: ApproximateNumberOfMessagesVisible
+      Namespace: AWS/SQS
+      Period: 60
+      Statistic: Maximum
+
+  TxMADLQHasMessages:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref AlertingSNSLowAlertNotificationTopicARN
+      AlarmDescription: "TxMA Egress DLQ has messages"
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Threshold: 1
+      EvaluationPeriods: 1
+      TreatMissingData: notBreaching
+      Dimensions:
+        - Name: QueueName
+          Value: !Ref TxMAEgressDLQName
+      MetricName: ApproximateNumberOfMessagesVisible
+      Namespace: AWS/SQS
+      Period: 60
+      Statistic: Maximum
+
+  TxMADLQTooManyMessages:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref AlertingSNSHighAlertNotificationTopicARN
+      AlarmDescription: "TxMA Egress DLQ has too many messages"
+      ComparisonOperator: GreaterThanThreshold
+      Threshold: 10
+      EvaluationPeriods: 1
+      TreatMissingData: notBreaching
+      Dimensions:
+        - Name: QueueName
+          Value: !Ref TxMAEgressDLQName
+      MetricName: ApproximateNumberOfMessagesVisible
+      Namespace: AWS/SQS
+      Period: 60
+      Statistic: Maximum
 #
 # CloudWatch Alarms for Updating Deletion Status
 #

--- a/src/infra/alarm/template.yaml
+++ b/src/infra/alarm/template.yaml
@@ -50,7 +50,7 @@ Resources:
       Period: 60
       Statistic: Maximum
 
-  TxMAQueueProcessingTooSlow:
+  TxMAEgressQueueProcessingTooSlow:
     Type: AWS::CloudWatch::Alarm
     Properties:
       ActionsEnabled: true
@@ -69,7 +69,7 @@ Resources:
       Period: 60
       Statistic: Maximum
 
-  TxMAQueueHasBacklog:
+  TxMAEgressQueueHasBacklog:
     Type: AWS::CloudWatch::Alarm
     Properties:
       ActionsEnabled: true
@@ -88,7 +88,7 @@ Resources:
       Period: 60
       Statistic: Maximum
 
-  TxMAQueueTooManyMessages:
+  TxMAEgressQueueTooManyMessages:
     Type: AWS::CloudWatch::Alarm
     Properties:
       ActionsEnabled: true
@@ -107,7 +107,7 @@ Resources:
       Period: 60
       Statistic: Maximum
 
-  TxMADLQHasMessages:
+  TxMAEgressDLQHasMessages:
     Type: AWS::CloudWatch::Alarm
     Properties:
       ActionsEnabled: true
@@ -126,7 +126,7 @@ Resources:
       Period: 60
       Statistic: Maximum
 
-  TxMADLQTooManyMessages:
+  TxMAEgressDLQTooManyMessages:
     Type: AWS::CloudWatch::Alarm
     Properties:
       ActionsEnabled: true

--- a/src/infra/main/template.yaml
+++ b/src/infra/main/template.yaml
@@ -691,6 +691,20 @@ Resources:
                 aws:SourceArn:
                   - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:${AWS::StackName}-InterventionsProcessorFunction"
 
+  TxMAEgressQueueNameSSM:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: The Name of the TxMA Egress Queue
+      Name: !Sub "/${AWS::StackName}/SQS/TxMAEgressQueue/Name"
+      Type: String
+      Value: !GetAtt TxMAEgressQueue.QueueName
+      Tags:
+        Environment: !Ref Environment
+        Product: !Ref ProductTagValue
+        System: !Ref SystemTagValue
+        Owner: !Ref OwnerTagValue
+        Source: !Ref SourceTagValue
+
   TxMAEgressDLQ:
     Type: AWS::SQS::Queue
     Properties:
@@ -713,6 +727,20 @@ Resources:
           Value: !Ref OwnerTagValue
         - Key: Source
           Value: !Ref SourceTagValue
+
+  TxMAEgressDLQNameSSM:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: The Name of the TxMA Egress DLQ
+      Name: !Sub "/${AWS::StackName}/SQS/TxMAEgressDLQ/Name"
+      Type: String
+      Value: !GetAtt TxMAEgressDLQ.QueueName
+      Tags:
+        Environment: !Ref Environment
+        Product: !Ref ProductTagValue
+        System: !Ref SystemTagValue
+        Owner: !Ref OwnerTagValue
+        Source: !Ref SourceTagValue
 
 ### Encryption Key SQS & SNS ###
 


### PR DESCRIPTION
## Proposed changes
This PR merges changes as per tickets:
- https://govukverify.atlassian.net/browse/ATB-1367
- https://govukverify.atlassian.net/browse/ATB-1369

### What changed
This PR changes:
- main template: added SSM parameter resources to store the name of the TxMA Egress SQS queue and its DLQ, to be read in by the alarm template
- alarm template: added Cloudwatch alarm resources to track:
         - TxMAEgressDLQHasMessages - threshold 1, period 60sec, eval period 1, Low Severity Alert
         - TxMAEgressDLQTooManyMessages - threshold 10, period 60sec, eval period 1, High Severity Alert
         - TxMAEgressQueueTooManyMessages - threshold 50, period 60sec, eval period 1, High Severity Alert
         - TxMAEgressQueueHasBacklog - threshold 10, period 60sec, eval period 1, Low Severity Alert
         - TxMAEgressQueueProcessingSlowly - threshold 60, period 60sec, eval period 1
         - TxMAEgressQueueProcessingTooSlow - threshold 600, period 60sec, eval period 1, High Severity Alert
        
### Why did it change
Enhance observability of the solution

### Issue tracking
- [ATB-1367](https://govukverify.atlassian.net/browse/ATB-1367)
- [ATB-1369](https://govukverify.atlassian.net/browse/ATB-1369)

## Testing
deployed changes to AWS account and triggered condition for each alarm
![image](https://github.com/govuk-one-login/account-interventions-service/assets/110468890/b51bbafd-9915-44ae-b549-827557ced0ed)
![image](https://github.com/govuk-one-login/account-interventions-service/assets/110468890/103805f0-f8cd-48ad-951f-07a200148ca8)
![image](https://github.com/govuk-one-login/account-interventions-service/assets/110468890/7434de51-d25c-436f-8193-ee4963da5a2a)
![image](https://github.com/govuk-one-login/account-interventions-service/assets/110468890/bcdef727-ee0a-4514-9baa-740e90fa7c2a)
![image](https://github.com/govuk-one-login/account-interventions-service/assets/110468890/6e2154ba-d561-4ac7-b80b-84f61f34f5e3)
![image](https://github.com/govuk-one-login/account-interventions-service/assets/110468890/23f91b32-32d4-4e45-afab-510e3eee24ff)

## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [x] Tested changes and included test evidence in the PR, if appropriate
- [x] Included all required tags and other properties for any new resources in the SAM template
- [x] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [x] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [x] Ensured that no log lines include PII or other sensitive data
- [x] Implemented unit testing for any new logic implemented, if appropriate
- [x] Ensured that all commits in this PR are signed
- [x] Ensured appropriate code coverage is maintained by unit tests


[ATB-1367]: https://govukverify.atlassian.net/browse/ATB-1367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ