### PR TITLE
ATB-1173 | Lambda Memory Allocations

### DIFF
--- a/src/infra/main/template.yaml
+++ b/src/infra/main/template.yaml
@@ -167,7 +167,7 @@ Resources:
       CodeUri: ../../../dist/interventions-processor-handler
       Timeout: 5
       Handler: interventions-processor-handler.handler
-      MemorySize: 128
+      MemorySize: 512
       Role: !GetAtt InterventionsProcessorFunctionRole.Arn
       CodeSigningConfigArn: !If [ UseCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue ]
       KmsKeyArn: !GetAtt LambdaEnvironmentVariableEncryptionKey.Arn
@@ -1019,7 +1019,7 @@ Resources:
       CodeSigningConfigArn: !If [ UseCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue ]
       CodeUri: ../../../dist/handlers/invoke-private-api
       Timeout: 10
-      MemorySize: 128
+      MemorySize: 256
       KmsKeyArn: !GetAtt LambdaEnvironmentVariableEncryptionKey.Arn
       Role: !GetAtt InvokePrivateAPIGatewayFunctionRole.Arn
       Environment:


### PR DESCRIPTION
## Proposed changes
This PR merges changes to allocate appropriate memory to our StatusRetriever, InterventionProcessor, and InvokePrivateapigateway lambdas. This values were identified using lambda power tuning https://docs.aws.amazon.com/lambda/latest/operatorguide/profile-functions.html 
Linked ticket contains details on the results

### What changed
Updated `MemorySize` for relevant lambdas

### Why did it change
Increase execution speed while keeping cost controlled 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- List any related PRs -->
- [ATB-1173](https://govukverify.atlassian.net/browse/ATB-1173)

## Testing
Changes deployed to AWS

## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [ ] Tested changes and included test evidence in the PR, if appropriate
- [ ] Included all required tags and other properties for any new resources in the SAM template
- [ ] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [ ] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [ ] Ensured that no log lines include PII or other sensitive data
- [ ] Implemented unit testing for any new logic implemented, if appropriate
- [ ] Ensured that all commits in this PR are signed
- [ ] Ensured appropriate code coverage is maintained by unit tests
- [ ] Checked SonarCube and ensured no code smells were added
