### PR TITLE
ATB 1414 reset reprovedIdentityAt and resetPasswordAt 

### DIFF
--- a/src/commons/build-partial-update-state-command.ts
+++ b/src/commons/build-partial-update-state-command.ts
@@ -66,11 +66,11 @@ export const buildPartialUpdateAccountStateCommand = (
     baseUpdateItemCommandInput['UpdateExpression'] +=
       ', #INT = :int, #SA = :sa, #AA = :aa, #H = list_append(if_not_exists(#H, :empty_list), :h)';
     if (finalState.resetPassword && finalState.reproveIdentity) {
-      baseUpdateItemCommandInput['UpdateExpression'] += ' REMOVE #RPswdA, #RIdA';
+      baseUpdateItemCommandInput['UpdateExpression'] += ' REMOVE resetPasswordAt, reprovedIdentityAt';
     } else if (finalState.resetPassword && !finalState.reproveIdentity) {
-      baseUpdateItemCommandInput['UpdateExpression'] += ' REMOVE #RPswdA';
+      baseUpdateItemCommandInput['UpdateExpression'] += ' REMOVE resetPasswordAt';
     } else if (!finalState.resetPassword && finalState.reproveIdentity) {
-      baseUpdateItemCommandInput['UpdateExpression'] += ' REMOVE #RIdA';
+      baseUpdateItemCommandInput['UpdateExpression'] += ' REMOVE reprovedIdentityAt';
     }
   }
   return baseUpdateItemCommandInput;

--- a/src/commons/build-partial-update-state-command.ts
+++ b/src/commons/build-partial-update-state-command.ts
@@ -65,6 +65,13 @@ export const buildPartialUpdateAccountStateCommand = (
     };
     baseUpdateItemCommandInput['UpdateExpression'] +=
       ', #INT = :int, #SA = :sa, #AA = :aa, #H = list_append(if_not_exists(#H, :empty_list), :h)';
+    if (finalState.resetPassword && finalState.reproveIdentity) {
+      baseUpdateItemCommandInput['UpdateExpression'] += ' REMOVE #RPswdA, #RIdA';
+    } else if (finalState.resetPassword && !finalState.reproveIdentity) {
+      baseUpdateItemCommandInput['UpdateExpression'] += ' REMOVE #RPswdA';
+    } else if (!finalState.resetPassword && finalState.reproveIdentity) {
+      baseUpdateItemCommandInput['UpdateExpression'] += ' REMOVE #RIdA';
+    }
   }
   return baseUpdateItemCommandInput;
 };

--- a/src/commons/test/build-partial-update-state-command.test.ts
+++ b/src/commons/test/build-partial-update-state-command.test.ts
@@ -146,7 +146,7 @@ describe('build-partial-update-state-command', () => {
         ':int': { S: 'AIS_FORCED_USER_PASSWORD_RESET' },
       },
       UpdateExpression:
-        'SET #B = :b, #S = :s, #RP = :rp, #RI = :ri, #UA = :ua, #INT = :int, #SA = :sa, #AA = :aa, #H = list_append(if_not_exists(#H, :empty_list), :h) REMOVE #RPswdA',
+        'SET #B = :b, #S = :s, #RP = :rp, #RI = :ri, #UA = :ua, #INT = :int, #SA = :sa, #AA = :aa, #H = list_append(if_not_exists(#H, :empty_list), :h) REMOVE resetPasswordAt',
     };
     const command = buildPartialUpdateAccountStateCommand(
       state,
@@ -190,7 +190,7 @@ describe('build-partial-update-state-command', () => {
         ':int': { S: 'AIS_FORCED_USER_IDENTITY_VERIFY' },
       },
       UpdateExpression:
-        'SET #B = :b, #S = :s, #RP = :rp, #RI = :ri, #UA = :ua, #INT = :int, #SA = :sa, #AA = :aa, #H = list_append(if_not_exists(#H, :empty_list), :h) REMOVE #RIdA',
+        'SET #B = :b, #S = :s, #RP = :rp, #RI = :ri, #UA = :ua, #INT = :int, #SA = :sa, #AA = :aa, #H = list_append(if_not_exists(#H, :empty_list), :h) REMOVE reprovedIdentityAt',
     };
     const command = buildPartialUpdateAccountStateCommand(
       state,
@@ -234,7 +234,7 @@ describe('build-partial-update-state-command', () => {
         ':int': { S: 'AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY' },
       },
       UpdateExpression:
-        'SET #B = :b, #S = :s, #RP = :rp, #RI = :ri, #UA = :ua, #INT = :int, #SA = :sa, #AA = :aa, #H = list_append(if_not_exists(#H, :empty_list), :h) REMOVE #RPswdA, #RIdA',
+        'SET #B = :b, #S = :s, #RP = :rp, #RI = :ri, #UA = :ua, #INT = :int, #SA = :sa, #AA = :aa, #H = list_append(if_not_exists(#H, :empty_list), :h) REMOVE resetPasswordAt, reprovedIdentityAt',
     };
     const interventionEventBodyNoMsTimestamp = {
       ...interventionEventBody,


### PR DESCRIPTION
… requires new user action

## Proposed changes

### What changed
Deleted reprovedIdentityAt and resetPasswordAt when new user actions are needed.

### Why did it change
When a new user action is needed on the account,  reprovedIdentityAt and resetPasswordAt are not expected to be present anymore.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- List any related PRs -->
- [ATB-1414](https://govukverify.atlassian.net/browse/ATB-1414)

## Testing
DynamoDB entry before applying Intervention with code 04 (requires password update)
<img width="1273" alt="image" src="https://github.com/govuk-one-login/account-interventions-service/assets/124037159/a7deda77-d15c-48dd-96f7-b8b7a9b4eac1">

After applying intervention (no resetPasswordAt):
<img width="1279" alt="image" src="https://github.com/govuk-one-login/account-interventions-service/assets/124037159/b738e910-1faf-462c-8f59-813800470a60">


## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [x] Tested changes and included test evidence in the PR, if appropriate
- [x] Included all required tags and other properties for any new resources in the SAM template
- [x] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [x] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [x] Ensured that no log lines include PII or other sensitive data
- [x] Implemented unit testing for any new logic implemented, if appropriate
- [x] Ensured that all commits in this PR are signed
- [x] Ensured appropriate code coverage is maintained by unit tests
- [x] Checked SonarCube and ensured no code smells were added


[ATB-1414]: https://govukverify.atlassian.net/browse/ATB-1414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ