### PR TITLE
ATB-1429: Reduce egress messages noise

### DIFF
--- a/src/commons/test/build-partial-update-state-command.test.ts
+++ b/src/commons/test/build-partial-update-state-command.test.ts
@@ -230,7 +230,9 @@ describe('build-partial-update-state-command', () => {
         ':sa': { N: '1000000' },
         ':aa': { N: '2222' },
         ':empty_list': { L: [] },
-        ':h': { L: [{ S: '1000000|TICF_CRI|01|reason|originating_component_id|originator_reference_id|requester_id' }] },
+        ':h': {
+          L: [{ S: '1000000|TICF_CRI|01|reason|originating_component_id|originator_reference_id|requester_id' }],
+        },
         ':int': { S: 'AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY' },
       },
       UpdateExpression:
@@ -244,8 +246,7 @@ describe('build-partial-update-state-command', () => {
       state,
       intervention,
       2222,
-      // @ts-ignore
-      interventionEventBodyNoMsTimestamp,
+      interventionEventBodyNoMsTimestamp as unknown as TxMAIngressEvent,
       AISInterventionTypes.AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY,
     );
     expect(command).toEqual(expectedOutput);

--- a/src/contract-testing/amf-ais-consumer.pact.test.ts
+++ b/src/contract-testing/amf-ais-consumer.pact.test.ts
@@ -1,12 +1,8 @@
-import {
-  MessageConsumerPact,
-  synchronousBodyHandler,
-  LogLevel,
-} from '@pact-foundation/pact';
-import { COMPONENT_ID } from "../data-types/constants";
-import { string } from "@pact-foundation/pact/src/v3/matchers";
+import { MessageConsumerPact, synchronousBodyHandler, LogLevel } from '@pact-foundation/pact';
+import { COMPONENT_ID } from '../data-types/constants';
+import { string } from '@pact-foundation/pact/src/v3/matchers';
 
-const path = require('path');
+const path = require('node:path');
 const LOG_LEVEL = process.env['LOG_LEVEL'] || 'ERROR';
 
 describe('AMF & AIS - Contract Testing - Consumer', () => {
@@ -20,22 +16,20 @@ describe('AMF & AIS - Contract Testing - Consumer', () => {
 
   describe('Incoming delete account event from Account Management Frontend', () => {
     it('accepts a valid account deletion event', () => {
-      return (
-        messagePact
-          .given('AIS is healthy')
-          .expectsToReceive('a valid intervention event')
-          .withContent({
-              user_id: string('urn:fdc:gov.uk:2022:USER_ONE')
-          })
-          .verify(synchronousBodyHandler(syncMessageHandler))
-      )
+      return messagePact
+        .given('AIS is healthy')
+        .expectsToReceive('a valid intervention event')
+        .withContent({
+          user_id: string('urn:fdc:gov.uk:2022:USER_ONE'),
+        })
+        .verify(synchronousBodyHandler(syncMessageHandler));
     });
   });
 });
 
-function syncMessageHandler(event: any){
+function syncMessageHandler(event: any) {
   const userId = event['user_id'];
-  if( !userId || typeof userId !== 'string' || userId.trim() === ""){
+  if (!userId || typeof userId !== 'string' || userId.trim() === '') {
     throw new Error('Invalid Message');
   }
   return;

--- a/src/contract-testing/txma-ais-consumer.pact.test.ts
+++ b/src/contract-testing/txma-ais-consumer.pact.test.ts
@@ -1,16 +1,12 @@
-import {
-  Matchers,
-  MessageConsumerPact,
-  synchronousBodyHandler,
-  LogLevel,
-} from '@pact-foundation/pact';
-import {COMPONENT_ID} from "../data-types/constants";
-import { term } from "@pact-foundation/pact/src/dsl/matchers";
-import { boolean, number, string } from "@pact-foundation/pact/src/v3/matchers";
-import { validateEventAgainstSchema } from "../services/validate-event";
+import { Matchers, MessageConsumerPact, synchronousBodyHandler, LogLevel } from '@pact-foundation/pact';
+import { COMPONENT_ID } from '../data-types/constants';
+import { term } from '@pact-foundation/pact/src/dsl/matchers';
+import { boolean, number, string } from '@pact-foundation/pact/src/v3/matchers';
+import { validateEventAgainstSchema } from '../services/validate-event';
+
 const { like } = Matchers;
 
-const path = require('path');
+const path = require('node:path');
 const LOG_LEVEL = process.env['LOG_LEVEL'] || 'ERROR';
 
 describe('TxMA & AIS - Contract Testing - Consumer', () => {
@@ -24,66 +20,59 @@ describe('TxMA & AIS - Contract Testing - Consumer', () => {
 
   describe('Incoming event is received from TxMA', () => {
     it('accepts a valid intervention event from TxMA', () => {
-      return (
-        messagePact
-          .given('AIS is healthy')
-          .expectsToReceive('a valid intervention event')
-          .withContent({
-            timestamp: like(1705318190),
-            event_name: 'TICF_ACCOUNT_INTERVENTION',
-            user: {
-              user_id: string('urn:fdc:gov.uk:2022:USER_ONE')
+      return messagePact
+        .given('AIS is healthy')
+        .expectsToReceive('a valid intervention event')
+        .withContent({
+          timestamp: like(1_705_318_190),
+          event_name: 'TICF_ACCOUNT_INTERVENTION',
+          user: {
+            user_id: string('urn:fdc:gov.uk:2022:USER_ONE'),
+          },
+          extensions: {
+            intervention: {
+              intervention_code: term({ generate: '01', matcher: '^(01|02|03|04|05|06|07)$' }),
+              intervention_reason: string('a reason for the intervention'),
             },
-            extensions: {
-              intervention : {
-                intervention_code: term({ generate: '01', matcher: '^(01|02|03|04|05|06|07)$'}),
-                intervention_reason: string('a reason for the intervention'),
-              }
-            }
-          })
-          .verify(synchronousBodyHandler(syncMessageHandler))
-      )
+          },
+        })
+        .verify(synchronousBodyHandler(syncMessageHandler));
     });
     it('accepts a valid user action (reset password) event from TxMA', () => {
-      return (
-        messagePact
-          .given('AIS is healthy')
-          .expectsToReceive('a valid user action event - reset password')
-          .withContent({
-            timestamp: number(1705318190),
-            event_name: like('AUTH_PASSWORD_RESET_SUCCESSFUL'),
-            user: {
-              user_id: string('urn:fdc:gov.uk:2022:USER_ONE')
-            }
-          })
-          .verify(synchronousBodyHandler(syncMessageHandler))
-      )
+      return messagePact
+        .given('AIS is healthy')
+        .expectsToReceive('a valid user action event - reset password')
+        .withContent({
+          timestamp: number(1_705_318_190),
+          event_name: like('AUTH_PASSWORD_RESET_SUCCESSFUL'),
+          user: {
+            user_id: string('urn:fdc:gov.uk:2022:USER_ONE'),
+          },
+        })
+        .verify(synchronousBodyHandler(syncMessageHandler));
     });
     it('accepts a valid user action (reset identity) event from TxMA', () => {
-      return (
-        messagePact
-          .given('AIS is healthy')
-          .expectsToReceive('a valid user action event - reset password')
-          .withContent({
-            timestamp: number(1705318190),
-            event_name: like('IPV_IDENTITY_ISSUED'),
-            user: {
-              user_id: string('urn:fdc:gov.uk:2022:USER_ONE')
-            },
-            extensions: {
-              levelOfConfidence: like('P2'),
-              ciFail: boolean(false),
-              hasMitigations: boolean(false)
-            }
-          })
-          .verify(synchronousBodyHandler(syncMessageHandler))
-      )
+      return messagePact
+        .given('AIS is healthy')
+        .expectsToReceive('a valid user action event - reset password')
+        .withContent({
+          timestamp: number(1_705_318_190),
+          event_name: like('IPV_IDENTITY_ISSUED'),
+          user: {
+            user_id: string('urn:fdc:gov.uk:2022:USER_ONE'),
+          },
+          extensions: {
+            levelOfConfidence: like('P2'),
+            ciFail: boolean(false),
+            hasMitigations: boolean(false),
+          },
+        })
+        .verify(synchronousBodyHandler(syncMessageHandler));
     });
-
   });
 });
 
-function syncMessageHandler(event: any){
+function syncMessageHandler(event: any) {
   validateEventAgainstSchema(event);
   return;
 }

--- a/src/data-types/interfaces.ts
+++ b/src/data-types/interfaces.ts
@@ -30,7 +30,7 @@ export interface FullAccountInformation {
   auditLevel?: string;
 }
 export interface AccountStateEngineOutput {
-  finalState: StateDetails;
+  stateResult: StateDetails;
   interventionName?: AISInterventionTypes;
   nextAllowableInterventions: string[];
 }

--- a/src/handlers/tests/interventions-processor-lambda.test.ts
+++ b/src/handlers/tests/interventions-processor-lambda.test.ts
@@ -147,7 +147,7 @@ describe('intervention processor handler', () => {
       accountStateEngine.applyEventTransition = jest.fn().mockImplementationOnce(() => {
         throw new StateTransitionError('State transition Error', EventsEnum.FRAUD_FORCED_USER_PASSWORD_RESET, {
           nextAllowableInterventions: [],
-          finalState: {
+          stateResult: {
             blocked: false,
             suspended: false,
             resetPassword: false,

--- a/src/handlers/tests/interventions-processor-lambda.test.ts
+++ b/src/handlers/tests/interventions-processor-lambda.test.ts
@@ -167,7 +167,7 @@ describe('intervention processor handler', () => {
         EventsEnum.FRAUD_FORCED_USER_PASSWORD_RESET,
         interventionEventBody,
         {
-          finalState: {
+          stateResult: {
             blocked: false,
             reproveIdentity: false,
             resetPassword: false,
@@ -181,7 +181,7 @@ describe('intervention processor handler', () => {
 
     it('should succeed when a valid intervention event is received', async () => {
       accountStateEngine.applyEventTransition = jest.fn().mockReturnValueOnce({
-        finalState: {
+        stateResult: {
           blocked: false,
           suspended: true,
           resetPassword: false,
@@ -198,7 +198,7 @@ describe('intervention processor handler', () => {
         EventsEnum.FRAUD_BLOCK_ACCOUNT,
         interventionEventBody,
         {
-          finalState: {
+          stateResult: {
             blocked: false,
             reproveIdentity: false,
             resetPassword: false,
@@ -217,7 +217,7 @@ describe('intervention processor handler', () => {
     it('should succeed when an intervention event is received for a non existing user', async () => {
       mockRetrieveRecords.mockReturnValue(undefined);
       accountStateEngine.applyEventTransition = jest.fn().mockReturnValueOnce({
-        finalState: {
+        stateResult: {
           blocked: false,
           suspended: true,
           resetPassword: false,
@@ -234,7 +234,7 @@ describe('intervention processor handler', () => {
         EventsEnum.FRAUD_BLOCK_ACCOUNT,
         interventionEventBody,
         {
-          finalState: {
+          stateResult: {
             blocked: false,
             reproveIdentity: false,
             resetPassword: false,
@@ -252,7 +252,7 @@ describe('intervention processor handler', () => {
 
     it('should succeed when a valid user action event is received', async () => {
       accountStateEngine.applyEventTransition = jest.fn().mockReturnValueOnce({
-        finalState: {
+        stateResult: {
           blocked: false,
           suspended: false,
           resetPassword: false,
@@ -271,7 +271,7 @@ describe('intervention processor handler', () => {
         EventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL,
         resetPasswordEventBody,
         {
-          finalState: {
+          stateResult: {
             blocked: false,
             reproveIdentity: false,
             resetPassword: false,
@@ -310,7 +310,7 @@ describe('intervention processor handler', () => {
         EventsEnum.FRAUD_BLOCK_ACCOUNT,
         interventionEventBody,
         {
-          finalState: {
+          stateResult: {
             blocked: false,
             reproveIdentity: false,
             resetPassword: false,
@@ -380,7 +380,7 @@ describe('intervention processor handler', () => {
         EventsEnum.FRAUD_BLOCK_ACCOUNT,
         interventionEventBody,
         {
-          finalState: {
+          stateResult: {
             blocked: false,
             reproveIdentity: false,
             resetPassword: false,

--- a/src/handlers/tests/interventions-processor-lambda.test.ts
+++ b/src/handlers/tests/interventions-processor-lambda.test.ts
@@ -224,7 +224,7 @@ describe('intervention processor handler', () => {
           reproveIdentity: false,
         },
         interventionName: EventsEnum.FRAUD_BLOCK_ACCOUNT,
-        nextAllowableInterventions: []
+        nextAllowableInterventions: [],
       });
       expect(await handler(mockEvent, mockContext)).toEqual({
         batchItemFailures: [],
@@ -241,7 +241,7 @@ describe('intervention processor handler', () => {
             suspended: true,
           },
           interventionName: 'FRAUD_BLOCK_ACCOUNT',
-          nextAllowableInterventions: []
+          nextAllowableInterventions: [],
         },
       );
       expect(logAndPublishMetric).toHaveBeenCalledWith(MetricNames.EVENT_DELIVERY_LATENCY, [], 5000);
@@ -259,7 +259,7 @@ describe('intervention processor handler', () => {
           reproveIdentity: false,
         },
         interventionName: AISInterventionTypes.AIS_FORCED_USER_PASSWORD_RESET,
-        nextAllowableInterventions: []
+        nextAllowableInterventions: [],
       });
       mockRecord.body = JSON.stringify(resetPasswordEventBody);
       mockEvent.Records = [mockRecord];
@@ -278,7 +278,7 @@ describe('intervention processor handler', () => {
             suspended: false,
           },
           interventionName: AISInterventionTypes.AIS_FORCED_USER_PASSWORD_RESET,
-          nextAllowableInterventions: []
+          nextAllowableInterventions: [],
         },
       );
 

--- a/src/handlers/tests/status-retriever-handler.test.ts
+++ b/src/handlers/tests/status-retriever-handler.test.ts
@@ -100,7 +100,7 @@ describe('status-retriever-handler', () => {
         sentAt: 123456789,
         description: suspendedRecord.intervention,
         reprovedIdentityAt: 849473,
-        resetPasswordAt: 5847392
+        resetPasswordAt: 5847392,
       },
       state: {
         blocked: false,
@@ -126,7 +126,7 @@ describe('status-retriever-handler', () => {
         updatedAt: 1685404800000,
         appliedAt: 1685404800000,
         sentAt: 1685404800000,
-        description: 'AIS_NO_INTERVENTION'
+        description: 'AIS_NO_INTERVENTION',
       },
       state: {
         blocked: false,
@@ -173,7 +173,7 @@ describe('status-retriever-handler', () => {
         description: accountFoundNotSuspendedRecord.intervention,
         reprovedIdentityAt: 849473,
         resetPasswordAt: 5847392,
-        accountDeletedAt: 12345685809
+        accountDeletedAt: 12345685809,
       },
       state: {
         blocked: false,
@@ -231,7 +231,7 @@ describe('status-retriever-handler', () => {
         sentAt: 123456789,
         description: suspendedRecord.intervention,
         reprovedIdentityAt: 849473,
-        resetPasswordAt: 5847392
+        resetPasswordAt: 5847392,
       },
       state: {
         blocked: false,
@@ -257,7 +257,7 @@ describe('status-retriever-handler', () => {
         updatedAt: 1685404800000,
         appliedAt: 1685404800000,
         sentAt: 1685404800000,
-        description: 'AIS_NO_INTERVENTION'
+        description: 'AIS_NO_INTERVENTION',
       },
       state: {
         blocked: false,
@@ -316,7 +316,7 @@ describe('status-retriever-handler', () => {
         sentAt: 123456789,
         description: nullUpdatedAt.intervention,
         reprovedIdentityAt: 849473,
-        resetPasswordAt: 5847392
+        resetPasswordAt: 5847392,
       },
       state: {
         blocked: false,
@@ -342,7 +342,7 @@ describe('status-retriever-handler', () => {
         updatedAt: 1685404800000,
         appliedAt: 1685404800000,
         sentAt: 1685404800000,
-        description: 'AIS_NO_INTERVENTION'
+        description: 'AIS_NO_INTERVENTION',
       },
       state: {
         blocked: false,
@@ -388,7 +388,7 @@ describe('status-retriever-handler', () => {
         sentAt: 123456789,
         description: accountFoundNotSuspendedRecord.intervention,
         reprovedIdentityAt: 849473,
-        resetPasswordAt: 5847392
+        resetPasswordAt: 5847392,
       },
       state: {
         blocked: false,
@@ -436,7 +436,7 @@ describe('status-retriever-handler', () => {
         sentAt: 123456789,
         description: accountFoundNotSuspendedRecord.intervention,
         reprovedIdentityAt: 849473,
-        resetPasswordAt: 5847392
+        resetPasswordAt: 5847392,
       },
       state: {
         blocked: false,
@@ -500,7 +500,7 @@ describe('status-retriever-handler', () => {
         sentAt: 123456789,
         description: accountFoundNotSuspendedRecord.intervention,
         reprovedIdentityAt: 849473,
-        resetPasswordAt: 5847392
+        resetPasswordAt: 5847392,
       },
       state: {
         blocked: false,

--- a/src/infra/main/samconfig.toml
+++ b/src/infra/main/samconfig.toml
@@ -1,10 +1,10 @@
 version = 0.1
 [default.deploy.parameters]
-stack_name = "ais-main"
+stack_name = "ais-main-ch"
 resolve_s3 = true
-s3_prefix = "ais-main"
+s3_prefix = "ais-main-ch"
 region = "eu-west-2"
 confirm_changeset = true
 capabilities = "CAPABILITY_NAMED_IAM"
-parameter_overrides = "Environment=\"dev\" VpcStackName=\"vpc\" PermissionsBoundary=\"none\" CoreStackName=\"ais-core\""
+parameter_overrides = "Environment=\"dev\" ApiStageName=\"v1\" VpcStackName=\"vpc\" PermissionsBoundary=\"none\" CSLSSubscriptionEndpointArn=\"arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2\" CodeSigningConfigArn=\"none\" CoreStackName=\"ais-core\" ProductTagValue=\"GOV.UK One Login\" SystemTagValue=\"Account Interventions Service\" OwnerTagValue=\"PLACEHOLDER\" SourceTagValue=\"govuk-one-login/account-interventions-service/src/infra/main/template.yaml\""
 image_repositories = []

--- a/src/infra/main/samconfig.toml
+++ b/src/infra/main/samconfig.toml
@@ -1,10 +1,10 @@
 version = 0.1
 [default.deploy.parameters]
-stack_name = "ais-main-ch"
+stack_name = "ais-main"
 resolve_s3 = true
-s3_prefix = "ais-main-ch"
+s3_prefix = "ais-main"
 region = "eu-west-2"
 confirm_changeset = true
 capabilities = "CAPABILITY_NAMED_IAM"
-parameter_overrides = "Environment=\"dev\" ApiStageName=\"v1\" VpcStackName=\"vpc\" PermissionsBoundary=\"none\" CSLSSubscriptionEndpointArn=\"arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2\" CodeSigningConfigArn=\"none\" CoreStackName=\"ais-core\" ProductTagValue=\"GOV.UK One Login\" SystemTagValue=\"Account Interventions Service\" OwnerTagValue=\"PLACEHOLDER\" SourceTagValue=\"govuk-one-login/account-interventions-service/src/infra/main/template.yaml\""
+parameter_overrides = "Environment=\"dev\" VpcStackName=\"vpc\" PermissionsBoundary=\"none\" CoreStackName=\"ais-core\""
 image_repositories = []

--- a/src/infra/main/template.yaml
+++ b/src/infra/main/template.yaml
@@ -912,7 +912,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${AWS::StackName}-StatusRetrieverFunction'
       Description: "Retrieves the account's intervention status."
-      CodeUri: ../../../dist/handlers/status-retriever-handler
+      CodeUri: ../../../dist/status-retriever-handler
       MemorySize: 512
       CodeSigningConfigArn: !If [ UseCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue ]
       KmsKeyArn: !GetAtt LambdaEnvironmentVariableEncryptionKey.Arn
@@ -1017,7 +1017,7 @@ Resources:
       FunctionName: !Sub '${AWS::StackName}-InvokePrivateAPIGatewayFunction'
       Description: 'Utility function to invoke the Private REST API (Non-Prod Only)'
       CodeSigningConfigArn: !If [ UseCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue ]
-      CodeUri: ../../../dist/handlers/invoke-private-api
+      CodeUri: ../../../dist/invoke-private-api
       Timeout: 10
       MemorySize: 256
       KmsKeyArn: !GetAtt LambdaEnvironmentVariableEncryptionKey.Arn

--- a/src/services/account-states/account-state-engine.ts
+++ b/src/services/account-states/account-state-engine.ts
@@ -75,7 +75,7 @@ export class AccountStateEngine {
         initialState,
       );
     return {
-      finalState: newStateObject,
+      stateResult: newStateObject,
       interventionName: AccountStateEngine.configuration.edges[transition]?.interventionName as AISInterventionTypes,
       nextAllowableInterventions: this.findPossibleTransitions(this.findAccountStateName(newStateObject)),
     };
@@ -172,7 +172,7 @@ function buildStateTransitionError(
   logAndPublishMetric(metricName);
   logger.error({ message: errorMessage });
   return new StateTransitionError(errorMessage, transition, {
-    finalState: initialState,
+    stateResult: initialState,
     nextAllowableInterventions: AccountStateEngine.getInstance().determineNextAllowableInterventions(initialState),
     interventionName: AISInterventionTypes.AIS_NO_INTERVENTION,
   });

--- a/src/services/send-audit-events.ts
+++ b/src/services/send-audit-events.ts
@@ -172,6 +172,12 @@ function buildAdditionalAttributes(
   };
 }
 
+/**
+ * Function to check if an event should be sent to TxMA
+ * @param egressEventName - Name of the event to be published to TxMA
+ * @param ingressEventEnum - Name of the original event
+ * @param accountStateEngineOutput - optional parameter containing the output from the State Engine
+ */
 function eventShouldBeIgnored(
   egressEventName: TxMAEgressEventName,
   ingressEventEnum: EventsEnum,

--- a/src/services/test/account-state-engine.test.ts
+++ b/src/services/test/account-state-engine.test.ts
@@ -42,7 +42,7 @@ const accountIsBlocked = {
   reproveIdentity: false,
 };
 const blockAccountUpdate = {
-  finalState: {
+  stateResult: {
     blocked: true,
     suspended: false,
     resetPassword: false,
@@ -52,7 +52,7 @@ const blockAccountUpdate = {
   nextAllowableInterventions: ['07'],
 };
 const suspendAccountUpdate = {
-  finalState: {
+  stateResult: {
     blocked: false,
     suspended: true,
     resetPassword: false,
@@ -62,7 +62,7 @@ const suspendAccountUpdate = {
   nextAllowableInterventions: ['02', '03', '04', '05', '06'],
 };
 const passwordResetRequiredUpdate = {
-  finalState: {
+  stateResult: {
     blocked: false,
     suspended: true,
     resetPassword: true,
@@ -72,7 +72,7 @@ const passwordResetRequiredUpdate = {
   nextAllowableInterventions: ['01', '02', '03', '05', '06', '90', '94'],
 };
 const idResetRequiredUpdate = {
-  finalState: {
+  stateResult: {
     blocked: false,
     suspended: true,
     resetPassword: false,
@@ -82,7 +82,7 @@ const idResetRequiredUpdate = {
   nextAllowableInterventions: ['01', '02', '03', '04', '06', '91'],
 };
 const pswAndIdResetRequiredUpdate = {
-  finalState: {
+  stateResult: {
     blocked: false,
     suspended: true,
     resetPassword: true,
@@ -92,7 +92,7 @@ const pswAndIdResetRequiredUpdate = {
   nextAllowableInterventions: ['01', '02', '03', '04', '05', '92', '93', '95'],
 };
 const unsuspendAccountUpdate = {
-  finalState: {
+  stateResult: {
     blocked: false,
     suspended: false,
     resetPassword: false,
@@ -102,7 +102,7 @@ const unsuspendAccountUpdate = {
   nextAllowableInterventions: ['01', '03', '04', '05', '06'],
 };
 const unblockAccountUpdate = {
-  finalState: {
+  stateResult: {
     blocked: false,
     suspended: false,
     resetPassword: false,
@@ -112,7 +112,7 @@ const unblockAccountUpdate = {
   nextAllowableInterventions: ['01', '03', '04', '05', '06'],
 };
 const pswResetSuccessfulUpdateUnsuspended = {
-  finalState: {
+  stateResult: {
     blocked: false,
     suspended: false,
     resetPassword: false,
@@ -121,7 +121,7 @@ const pswResetSuccessfulUpdateUnsuspended = {
   nextAllowableInterventions: ['01', '03', '04', '05', '06']
 };
 const pswResetSuccessfulUpdateSuspended = {
-  finalState: {
+  stateResult: {
     blocked: false,
     suspended: true,
     resetPassword: false,
@@ -130,7 +130,7 @@ const pswResetSuccessfulUpdateSuspended = {
   nextAllowableInterventions: ['01', '02', '03', '04', '06', '91']
 };
 const idResetSuccessfulUpdateUnsuspended = {
-  finalState: {
+  stateResult: {
     blocked: false,
     suspended: false,
     resetPassword: false,
@@ -139,7 +139,7 @@ const idResetSuccessfulUpdateUnsuspended = {
   nextAllowableInterventions: ['01', '03', '04', '05', '06']
 };
 const idResetSuccessfulUpdateSuspended = {
-  finalState: {
+  stateResult: {
     blocked: false,
     suspended: true,
     resetPassword: true,

--- a/src/services/test/account-state-engine.test.ts
+++ b/src/services/test/account-state-engine.test.ts
@@ -118,7 +118,7 @@ const pswResetSuccessfulUpdateUnsuspended = {
     resetPassword: false,
     reproveIdentity: false,
   },
-  nextAllowableInterventions: ['01', '03', '04', '05', '06']
+  nextAllowableInterventions: ['01', '03', '04', '05', '06'],
 };
 const pswResetSuccessfulUpdateSuspended = {
   stateResult: {
@@ -127,7 +127,7 @@ const pswResetSuccessfulUpdateSuspended = {
     resetPassword: false,
     reproveIdentity: true,
   },
-  nextAllowableInterventions: ['01', '02', '03', '04', '06', '91']
+  nextAllowableInterventions: ['01', '02', '03', '04', '06', '91'],
 };
 const idResetSuccessfulUpdateUnsuspended = {
   stateResult: {
@@ -136,7 +136,7 @@ const idResetSuccessfulUpdateUnsuspended = {
     resetPassword: false,
     reproveIdentity: false,
   },
-  nextAllowableInterventions: ['01', '03', '04', '05', '06']
+  nextAllowableInterventions: ['01', '03', '04', '05', '06'],
 };
 const idResetSuccessfulUpdateSuspended = {
   stateResult: {
@@ -145,7 +145,7 @@ const idResetSuccessfulUpdateSuspended = {
     resetPassword: true,
     reproveIdentity: false,
   },
-  nextAllowableInterventions: ['01', '02', '03', '05', '06', '90', '94']
+  nextAllowableInterventions: ['01', '02', '03', '05', '06', '90', '94'],
 };
 
 jest.mock('@aws-lambda-powertools/logger');
@@ -219,7 +219,11 @@ describe('account-state-service', () => {
         [EventsEnum.FRAUD_UNSUSPEND_ACCOUNT, accountNeedsPswReset, unsuspendAccountUpdate],
         [EventsEnum.FRAUD_SUSPEND_ACCOUNT, accountNeedsPswReset, suspendAccountUpdate],
         [EventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL, accountNeedsPswReset, pswResetSuccessfulUpdateUnsuspended],
-        [EventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL_FOR_TEST_CLIENT, accountNeedsPswReset, pswResetSuccessfulUpdateUnsuspended],
+        [
+          EventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL_FOR_TEST_CLIENT,
+          accountNeedsPswReset,
+          pswResetSuccessfulUpdateUnsuspended,
+        ],
         [EventsEnum.FRAUD_FORCED_USER_IDENTITY_REVERIFICATION, accountNeedsPswReset, idResetRequiredUpdate],
         [
           EventsEnum.FRAUD_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_REVERIFICATION,
@@ -255,7 +259,11 @@ describe('account-state-service', () => {
         [EventsEnum.FRAUD_BLOCK_ACCOUNT, accountNeedsIDResetAdnPswReset, blockAccountUpdate],
         [EventsEnum.FRAUD_FORCED_USER_IDENTITY_REVERIFICATION, accountNeedsIDResetAdnPswReset, idResetRequiredUpdate],
         [EventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL, accountNeedsIDResetAdnPswReset, pswResetSuccessfulUpdateSuspended],
-        [EventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL_FOR_TEST_CLIENT, accountNeedsIDResetAdnPswReset, pswResetSuccessfulUpdateSuspended],
+        [
+          EventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL_FOR_TEST_CLIENT,
+          accountNeedsIDResetAdnPswReset,
+          pswResetSuccessfulUpdateSuspended,
+        ],
         [EventsEnum.FRAUD_FORCED_USER_PASSWORD_RESET, accountNeedsIDResetAdnPswReset, passwordResetRequiredUpdate],
         [EventsEnum.IPV_IDENTITY_ISSUED, accountNeedsIDResetAdnPswReset, idResetSuccessfulUpdateSuspended],
         [EventsEnum.FRAUD_UNSUSPEND_ACCOUNT, accountNeedsIDResetAdnPswReset, unsuspendAccountUpdate],
@@ -321,12 +329,11 @@ describe('account-state-service', () => {
         [EventsEnum.FRAUD_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_REVERIFICATION, accountIsBlocked],
       ])('%p applied on account state: %p', (intervention, retrievedAccountState) => {
         expect(() => accountStateEngine.applyEventTransition(intervention, retrievedAccountState)).toThrow(
-          new StateTransitionError(`${intervention} is not allowed from current state`, intervention,
-            {
-              nextAllowableInterventions: [],
-              stateResult: retrievedAccountState,
-              interventionName: AISInterventionTypes.AIS_NO_INTERVENTION,
-            }),
+          new StateTransitionError(`${intervention} is not allowed from current state`, intervention, {
+            nextAllowableInterventions: [],
+            stateResult: retrievedAccountState,
+            interventionName: AISInterventionTypes.AIS_NO_INTERVENTION,
+          }),
         );
       });
     });
@@ -393,7 +400,7 @@ describe('account-state-service', () => {
             nextAllowableInterventions: [],
             interventionName: AISInterventionTypes.AIS_NO_INTERVENTION,
             stateResult: accountIsOkay,
-          }
+          },
         ),
       );
       expect(logAndPublishMetric).toHaveBeenLastCalledWith(MetricNames.TRANSITION_SAME_AS_CURRENT_STATE);

--- a/src/services/test/account-state-engine.test.ts
+++ b/src/services/test/account-state-engine.test.ts
@@ -319,7 +319,7 @@ describe('account-state-service', () => {
           new StateTransitionError(`${intervention} is not allowed from current state`, intervention,
             {
               nextAllowableInterventions: [],
-              finalState: retrievedAccountState,
+              stateResult: retrievedAccountState,
               interventionName: AISInterventionTypes.AIS_NO_INTERVENTION,
             }),
         );
@@ -387,7 +387,7 @@ describe('account-state-service', () => {
           {
             nextAllowableInterventions: [],
             interventionName: AISInterventionTypes.AIS_NO_INTERVENTION,
-            finalState: accountIsOkay,
+            stateResult: accountIsOkay,
           }
         ),
       );

--- a/src/services/test/dynamo-database-service.test.ts
+++ b/src/services/test/dynamo-database-service.test.ts
@@ -179,7 +179,7 @@ describe('Dynamo DB Service', () => {
         ':isAccountDeleted': { BOOL: true },
         ':ttl': { N: '1685417145' },
         ':false': { BOOL: false },
-        ':deletedAt': { N: '1685404800000' }
+        ':deletedAt': { N: '1685404800000' },
       },
       ReturnValues: 'ALL_NEW',
       ConditionExpression:

--- a/src/services/test/send-audit-events.test.ts
+++ b/src/services/test/send-audit-events.test.ts
@@ -239,7 +239,7 @@ describe('send-audit-events', () => {
       {
         nextAllowableInterventions: [],
         interventionName: AISInterventionTypes.AIS_FORCED_USER_PASSWORD_RESET,
-        finalState: { blocked: false, suspended: true, reproveIdentity: false, resetPassword: true },
+        stateResult: { blocked: false, suspended: true, reproveIdentity: false, resetPassword: true },
       },
     );
     expect(response).toEqual({ $metadata: { httpStatusCode: 200 } });
@@ -258,7 +258,7 @@ describe('send-audit-events', () => {
       {
         nextAllowableInterventions: [],
         interventionName: AISInterventionTypes.AIS_ACCOUNT_SUSPENDED,
-        finalState: { blocked: true, suspended: true, reproveIdentity: false, resetPassword: true },
+        stateResult: { blocked: true, suspended: true, reproveIdentity: false, resetPassword: true },
       },
     );
     expect(response).toEqual({ $metadata: { httpStatusCode: 200 } });
@@ -277,7 +277,7 @@ describe('send-audit-events', () => {
       {
         nextAllowableInterventions: [],
         interventionName: AISInterventionTypes.AIS_ACCOUNT_SUSPENDED,
-        finalState: { blocked: false, suspended: true, reproveIdentity: false, resetPassword: false },
+        stateResult: { blocked: false, suspended: true, reproveIdentity: false, resetPassword: false },
       },
     );
     expect(response).toBeUndefined();
@@ -298,7 +298,7 @@ describe('send-audit-events', () => {
       {
         nextAllowableInterventions: [],
         interventionName: AISInterventionTypes.AIS_ACCOUNT_SUSPENDED,
-        finalState: { blocked: true, suspended: true, reproveIdentity: false, resetPassword: false },
+        stateResult: { blocked: true, suspended: true, reproveIdentity: false, resetPassword: false },
       },
     );
     expect(response).toEqual({ $metadata: { httpStatusCode: 200 } });
@@ -317,7 +317,7 @@ describe('send-audit-events', () => {
       {
         nextAllowableInterventions: ['01', '91'],
         interventionName: AISInterventionTypes.AIS_ACCOUNT_SUSPENDED,
-        finalState: { blocked: false, suspended: true, reproveIdentity: false, resetPassword: false },
+        stateResult: { blocked: false, suspended: true, reproveIdentity: false, resetPassword: false },
       },
     );
     expect(response).toEqual({ $metadata: { httpStatusCode: 200 } });
@@ -336,7 +336,7 @@ describe('send-audit-events', () => {
       {
         nextAllowableInterventions: [],
         interventionName: AISInterventionTypes.AIS_FORCED_USER_IDENTITY_VERIFY,
-        finalState: { blocked: false, suspended: true, reproveIdentity: true, resetPassword: false },
+        stateResult: { blocked: false, suspended: true, reproveIdentity: true, resetPassword: false },
       },
     );
     expect(response).toEqual({ $metadata: { httpStatusCode: 200 } });
@@ -355,7 +355,7 @@ describe('send-audit-events', () => {
       {
         nextAllowableInterventions: [],
         interventionName: AISInterventionTypes.AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY,
-        finalState: { blocked: false, suspended: true, reproveIdentity: true, resetPassword: true },
+        stateResult: { blocked: false, suspended: true, reproveIdentity: true, resetPassword: true },
       },
     );
     expect(response).toEqual({ $metadata: { httpStatusCode: 200 } });
@@ -374,7 +374,7 @@ describe('send-audit-events', () => {
       {
         nextAllowableInterventions: ["01"],
         interventionName: AISInterventionTypes.AIS_ACCOUNT_UNSUSPENDED,
-        finalState: { blocked: false, suspended: false, reproveIdentity: false, resetPassword: false },
+        stateResult: { blocked: false, suspended: false, reproveIdentity: false, resetPassword: false },
       },
     );
     expect(response).toEqual({ $metadata: { httpStatusCode: 200 } });

--- a/src/services/test/send-audit-events.test.ts
+++ b/src/services/test/send-audit-events.test.ts
@@ -1,20 +1,20 @@
-import {SendMessageCommand, SQSClient} from '@aws-sdk/client-sqs';
-import {mockClient} from 'aws-sdk-client-mock';
-import {sendAuditEvent} from '../send-audit-events';
+import { SendMessageCommand, SQSClient } from '@aws-sdk/client-sqs';
+import { mockClient } from 'aws-sdk-client-mock';
+import { sendAuditEvent } from '../send-audit-events';
 import {
   ActiveStateActions,
   AISInterventionTypes,
   COMPONENT_ID,
   EventsEnum,
   State,
-  TriggerEventsEnum
+  TriggerEventsEnum,
 } from '../../data-types/constants';
-import {logAndPublishMetric} from '../../commons/metrics';
+import { logAndPublishMetric } from '../../commons/metrics';
 import logger from '../../commons/logger';
-import {AppConfigService} from '../app-config-service';
-import {getCurrentTimestamp} from '../../commons/get-current-timestamp';
+import { AppConfigService } from '../app-config-service';
+import { getCurrentTimestamp } from '../../commons/get-current-timestamp';
 import 'aws-sdk-client-mock-jest';
-import {TxMAIngressEvent} from '../../data-types/interfaces';
+import { TxMAIngressEvent } from '../../data-types/interfaces';
 
 jest.mock('@aws-lambda-powertools/logger');
 jest.mock('../../commons/metrics');
@@ -81,7 +81,7 @@ const sqsCommandInputForUserAction = {
       description: 'AIS_FORCED_USER_PASSWORD_RESET',
       allowable_interventions: [],
       state: State.ACTIVE,
-      action: ActiveStateActions.RESET_PASSWORD
+      action: ActiveStateActions.RESET_PASSWORD,
     },
   }),
 };
@@ -106,7 +106,6 @@ const sqsCommandInputForBlockIntervention = {
   }),
 };
 
-
 const sqsCommandInputForDeletedAccount = {
   QueueUrl: AppConfigService.getInstance().txmaEgressQueueUrl,
   MessageBody: JSON.stringify({
@@ -122,7 +121,7 @@ const sqsCommandInputForDeletedAccount = {
       intervention_code: '01',
       description: AISInterventionTypes.AIS_ACCOUNT_SUSPENDED,
       allowable_interventions: [],
-      state: State.DELETED
+      state: State.DELETED,
     },
   }),
 };
@@ -142,7 +141,7 @@ const sqsCommandInputForSuspendIntervention = {
       intervention_code: '01',
       description: AISInterventionTypes.AIS_ACCOUNT_SUSPENDED,
       allowable_interventions: ['01'],
-      state: State.SUSPENDED
+      state: State.SUSPENDED,
     },
   }),
 };
@@ -162,7 +161,7 @@ const sqsCommandInputForUnsuspendIntervention = {
       intervention_code: '01',
       description: AISInterventionTypes.AIS_ACCOUNT_UNSUSPENDED,
       allowable_interventions: ['01'],
-      state: State.ACTIVE
+      state: State.ACTIVE,
     },
   }),
 };
@@ -200,7 +199,7 @@ const sqsCommandInputForSuspendUserAction = {
       description: 'AIS_FORCED_USER_IDENTITY_VERIFY',
       allowable_interventions: [],
       state: State.ACTIVE,
-      action: ActiveStateActions.REPROVE_IDENTITY
+      action: ActiveStateActions.REPROVE_IDENTITY,
     },
   }),
 };
@@ -221,7 +220,7 @@ const sqsCommandInputForSuspendUserActionReproveIdentityAndResetPass = {
       description: 'AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY',
       allowable_interventions: [],
       state: State.ACTIVE,
-      action: ActiveStateActions.RESET_PASSWORD_AND_REPROVE_IDENTITY
+      action: ActiveStateActions.RESET_PASSWORD_AND_REPROVE_IDENTITY,
     },
   }),
 };
@@ -258,7 +257,7 @@ describe('send-audit-events', () => {
       EventsEnum.FRAUD_SUSPEND_ACCOUNT,
       ingressInterventionEvent,
       {
-        nextAllowableInterventions: ["01"],
+        nextAllowableInterventions: ['01'],
         interventionName: AISInterventionTypes.AIS_ACCOUNT_SUSPENDED,
         stateResult: { blocked: false, suspended: true, reproveIdentity: false, resetPassword: false },
       },
@@ -383,7 +382,10 @@ describe('send-audit-events', () => {
     expect(logAndPublishMetric).toHaveBeenCalledWith('PUBLISHED_EVENT_TO_TXMA');
     expect(logger.debug).toHaveBeenCalledTimes(2);
     expect(getCurrentTimestamp).toHaveBeenCalledTimes(1);
-    expect(sqsMock).toHaveReceivedCommandWith(SendMessageCommand, sqsCommandInputForSuspendUserActionReproveIdentityAndResetPass);
+    expect(sqsMock).toHaveReceivedCommandWith(
+      SendMessageCommand,
+      sqsCommandInputForSuspendUserActionReproveIdentityAndResetPass,
+    );
   });
 
   it('should successfully send the audit event and return a response when an the account is unsuspended', async () => {
@@ -393,7 +395,7 @@ describe('send-audit-events', () => {
       EventsEnum.FRAUD_UNSUSPEND_ACCOUNT,
       ingressInterventionEvent,
       {
-        nextAllowableInterventions: ["01"],
+        nextAllowableInterventions: ['01'],
         interventionName: AISInterventionTypes.AIS_ACCOUNT_UNSUSPENDED,
         stateResult: { blocked: false, suspended: false, reproveIdentity: false, resetPassword: false },
       },
@@ -411,7 +413,6 @@ describe('send-audit-events', () => {
       'AIS_EVENT_IGNORED_IN_FUTURE',
       EventsEnum.FRAUD_SUSPEND_ACCOUNT,
       ingressInterventionEvent,
-      undefined
     );
     expect(response).toEqual({ $metadata: { httpStatusCode: 200 } });
     expect(logAndPublishMetric).toHaveBeenCalledWith('PUBLISHED_EVENT_TO_TXMA');
@@ -431,10 +432,10 @@ describe('send-audit-events', () => {
           blocked: false,
           suspended: false,
           resetPassword: false,
-          reproveIdentity: false
+          reproveIdentity: false,
         },
-        nextAllowableInterventions: []
-      }
+        nextAllowableInterventions: [],
+      },
     );
     expect(response).toBeUndefined();
     expect(logAndPublishMetric).not.toHaveBeenCalled();

--- a/src/services/test/validate-event.test.ts
+++ b/src/services/test/validate-event.test.ts
@@ -185,7 +185,7 @@ describe('event-validation', () => {
     ).rejects.toThrow(new ValidationError('Event received predates last applied event for this user.'));
     expect(logAndPublishMetric).toHaveBeenCalledWith(MetricNames.INTERVENTION_EVENT_STALE);
     expect(sendAuditEvent).toHaveBeenCalledWith('AIS_EVENT_IGNORED_STALE', 'FRAUD_SUSPEND_ACCOUNT', staleEvent, {
-      finalState: { blocked: false, reproveIdentity: false, resetPassword: false, suspended: false },
+      stateResult: { blocked: false, reproveIdentity: false, resetPassword: false, suspended: false },
       interventionName: 'AIS_NO_INTERVENTION',
       nextAllowableInterventions: ['01', '03', '04', '05', '06'],
     });

--- a/src/services/validate-event.ts
+++ b/src/services/validate-event.ts
@@ -89,7 +89,7 @@ export async function validateEventIsNotStale(
     logger.warn('Event received predates last applied event for this user.');
     logAndPublishMetric(MetricNames.INTERVENTION_EVENT_STALE);
     await sendAuditEvent('AIS_EVENT_IGNORED_STALE', intervention, event, {
-      finalState: initialState,
+      stateResult: initialState,
       interventionName: AISInterventionTypes.AIS_NO_INTERVENTION,
       nextAllowableInterventions: AccountStateEngine.getInstance().determineNextAllowableInterventions(initialState),
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3109,6 +3109,13 @@ aws-xray-sdk-core@^3.5.3:
     cls-hooked "^4.2.2"
     semver "^7.5.3"
 
+axios@^0.21.1:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+  dependencies:
+    follow-redirects "^1.14.0"
+
 axios@^1.6.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.2.tgz#de67d42c755b571d3e698df1b6504cde9b0ee9f2"
@@ -4541,7 +4548,7 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
   integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
 
-follow-redirects@^1.0.0, follow-redirects@^1.15.4:
+follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.15.4:
   version "1.15.5"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.5.tgz#54d4d6d062c0fa7d9d17feb008461550e3ba8020"
   integrity sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==


### PR DESCRIPTION
## Proposed changes
This PR merges changes not to publish egress messages to TxMA when an user action event is received (reset password/id successful) for a user who does not have an active intervention on their account.

### What changed
- added check to the send audit event flow to see if the event should be ignored
- updated unit tests to assert that call to sqs mock doesn't happen when event is excluded
- linted tests

### Why did it change
reduce noise 

### Issue tracking

- [ATB-1429](https://govukverify.atlassian.net/browse/ATB-1429)

## Testing
Coverage maintained
![Screenshot 2024-01-17 at 14 27 03](https://github.com/govuk-one-login/account-interventions-service/assets/110468890/0f43b2f5-976e-4cb0-9261-5ae75681a08c)

Changes deployed to AWS.
- sent a password reset successful event for a non-existing user
![Screenshot 2024-01-17 at 14 39 23](https://github.com/govuk-one-login/account-interventions-service/assets/110468890/d0bb32ad-1515-4b39-9107-be58d256ac5f)
- sent an id reset event for a non-existing user
![image](https://github.com/govuk-one-login/account-interventions-service/assets/110468890/473b445c-7a70-4e54-92a1-772ed67c5a4a)
- sent a psw reset successful event for a user that exists in the DB but has no active intervention
![Screenshot 2024-01-17 at 14 51 41](https://github.com/govuk-one-login/account-interventions-service/assets/110468890/bf83fb86-c45f-4499-9025-1b1e5a9a4316)

- sent an id reset event for a user that exists in the DB but has no active intervention
- ![image](https://github.com/govuk-one-login/account-interventions-service/assets/110468890/87210bd7-2e58-4675-ba2f-ce542823d4f0)
- sent a suspend event for a new user, sent a psw reset event for that user
![Screenshot 2024-01-17 at 14 42 26](https://github.com/govuk-one-login/account-interventions-service/assets/110468890/e047c554-f15b-46e2-a564-8387ce86620a)

## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [x] Tested changes and included test evidence in the PR, if appropriate
- [ ] Included all required tags and other properties for any new resources in the SAM template
- [ ] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [ ] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [ ] Ensured that no log lines include PII or other sensitive data
- [x] Implemented unit testing for any new logic implemented, if appropriate
- [x] Ensured that all commits in this PR are signed
- [x] Ensured appropriate code coverage is maintained by unit tests
- [x] Checked SonarCube and ensured no code smells were added


[ATB-1429]: https://govukverify.atlassian.net/browse/ATB-1429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ