### PR TITLE
ATB-1425 | Create metric to measure the time to resolve a suspension

### DIFF
--- a/src/commons/build-partial-update-state-command.ts
+++ b/src/commons/build-partial-update-state-command.ts
@@ -1,6 +1,6 @@
 import { StateDetails, TxMAIngressEvent } from '../data-types/interfaces';
 import { UpdateItemCommandInput } from '@aws-sdk/client-dynamodb';
-import { AISInterventionTypes, EventsEnum, MetricNames } from '../data-types/constants';
+import { AISInterventionTypes, EventsEnum, MetricNames, noMetadata } from '../data-types/constants';
 import { logAndPublishMetric } from './metrics';
 import { HistoryStringBuilder } from './history-string-builder';
 
@@ -11,12 +11,14 @@ import { HistoryStringBuilder } from './history-string-builder';
  * @param currentTimestamp - timestamp of now in ms
  * @param interventionName - optional intervention name if the event was a fraud intervention
  * @param interventionEvent - intervention type
+ * @param previousAppliedAt - timestamp of previous intervention
  */
 export const buildPartialUpdateAccountStateCommand = (
   finalState: StateDetails,
   eventName: EventsEnum,
   currentTimestamp: number,
   interventionEvent: TxMAIngressEvent,
+  previousAppliedAt: number,
   interventionName?: AISInterventionTypes,
 ): Partial<UpdateItemCommandInput> => {
   const eventTimestamp = interventionEvent.event_timestamp_ms ?? interventionEvent.timestamp * 1000;
@@ -42,6 +44,9 @@ export const buildPartialUpdateAccountStateCommand = (
     baseUpdateItemCommandInput['ExpressionAttributeNames']['#RIdA'] = 'reprovedIdentityAt';
     baseUpdateItemCommandInput['ExpressionAttributeValues'][':rida'] = { N: `${eventTimestamp}` };
     baseUpdateItemCommandInput['UpdateExpression'] += ', #RIdA = :rida';
+    logAndPublishMetric(MetricNames.TIME_TO_RESOLVE, noMetadata, 1, {
+      reproveIdentity: (Math.floor(currentTimestamp / 1000) - previousAppliedAt).toString(),
+    });
   } else if (
     eventName === EventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL ||
     eventName === EventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL_FOR_TEST_CLIENT
@@ -49,10 +54,18 @@ export const buildPartialUpdateAccountStateCommand = (
     baseUpdateItemCommandInput['ExpressionAttributeNames']['#RPswdA'] = 'resetPasswordAt';
     baseUpdateItemCommandInput['ExpressionAttributeValues'][':rpswda'] = { N: `${eventTimestamp}` };
     baseUpdateItemCommandInput['UpdateExpression'] += ', #RPswdA = :rpswda';
+    logAndPublishMetric(MetricNames.TIME_TO_RESOLVE, noMetadata, 1, {
+      passwordReset: (Math.floor(currentTimestamp / 1000) - previousAppliedAt).toString(),
+    });
   } else {
     if (!interventionName) {
       logAndPublishMetric(MetricNames.INTERVENTION_DID_NOT_HAVE_NAME_IN_CURRENT_CONFIG);
       throw new Error('The intervention received did not have an interventionName field.');
+    }
+    if (eventName === EventsEnum.FRAUD_UNSUSPEND_ACCOUNT) {
+      logAndPublishMetric(MetricNames.TIME_TO_RESOLVE, noMetadata, 1, {
+        suspension: (Math.floor(currentTimestamp / 1000) - previousAppliedAt).toString(),
+      });
     }
     baseUpdateItemCommandInput['ExpressionAttributeNames']['#INT'] = 'intervention';
     baseUpdateItemCommandInput['ExpressionAttributeValues'][':int'] = { S: interventionName };

--- a/src/data-types/constants.ts
+++ b/src/data-types/constants.ts
@@ -31,6 +31,7 @@ export enum MetricNames {
   EVENT_DELIVERY_LATENCY = 'EVENT_DELIVERY_LATENCY',
   ACCOUNTS_BLOCKED = 'ACCOUNTS_BLOCKED',
   ACCOUNTS_SUSPENDED = 'ACCOUNTS_SUSPENDED',
+  TIME_TO_RESOLVE = 'TIME_TO_RESOLVE',
 }
 
 export const noMetadata: { key: string; value: string }[] = [];

--- a/src/handlers/interventions-processor-handler.ts
+++ b/src/handlers/interventions-processor-handler.ts
@@ -97,11 +97,14 @@ async function processSQSRecord(record: SQSRecord) {
   }
 
   const statusResult = accountStateEngine.applyEventTransition(eventName, currentAccountState);
+  const previousInterventionAppliedAt = Math.floor(itemFromDB?.appliedAt ? itemFromDB.appliedAt / 1000 : 0);
+
   const partialCommandInput = buildPartialUpdateAccountStateCommand(
     statusResult.stateResult,
     eventName,
     currentTimestamp.milliseconds,
     recordBody,
+    previousInterventionAppliedAt,
     statusResult.interventionName,
   );
   logger.debug('processed requested event, sending update request to dynamo db');


### PR DESCRIPTION
## Proposed changes
<!-- Include the Jira ticket number in square brackets as prefix, eg `ATB-XXXX: Description of Change` -->

### What changed
Added to metric which calculates time difference in seconds from when an account was suspended to when it got unsuspended

### Why did it change
To measure the time taken (seconds) for a suspended account to become unsuspended, either through user action or explicitly with an unsuspend intervention.

### Issue tracking

- [ATB-1425](https://govukverify.atlassian.net/browse/ATB-1425)

## Testing
1. Sent an unsuspend intervention
<img width="466" alt="image" src="https://github.com/govuk-one-login/account-interventions-service/assets/124037159/5832b70d-98e5-4179-ab77-b5db83bead98">

<img width="1117" alt="image" src="https://github.com/govuk-one-login/account-interventions-service/assets/124037159/44681a33-e124-49a4-ba9a-45be4de0fdf6">

2. Sent IPV_IDENTITY_ISSUED
<img width="415" alt="image" src="https://github.com/govuk-one-login/account-interventions-service/assets/124037159/543b612a-4da9-4699-b6bd-808ed3a439b3">

<img width="1146" alt="image" src="https://github.com/govuk-one-login/account-interventions-service/assets/124037159/d8e9df35-df80-4545-8d77-7cf675928712">

3. Sent AUTH_PASSWORD_RESET_SUCCESSFUL
<img width="472" alt="image" src="https://github.com/govuk-one-login/account-interventions-service/assets/124037159/117181ce-0b83-4676-b39d-58a9b36c9290">

<img width="1375" alt="image" src="https://github.com/govuk-one-login/account-interventions-service/assets/124037159/43fa6028-4b44-425f-b91f-c90589200e89">


## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [x] Tested changes and included test evidence in the PR, if appropriate
- [x] Included all required tags and other properties for any new resources in the SAM template
- [x] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [x] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [x] Ensured that no log lines include PII or other sensitive data
- [x] Implemented unit testing for any new logic implemented, if appropriate
- [x] Ensured that all commits in this PR are signed
- [x] Ensured appropriate code coverage is maintained by unit tests
- [ ] Checked SonarCube and ensured no code smells were added


[ATB-1425]: https://govukverify.atlassian.net/browse/ATB-1425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ