### PR TITLE
ATB-1433 | Add VPC Endpoint IDs for Auth/Orch

### DIFF
--- a/src/infra/main/template.yaml
+++ b/src/infra/main/template.yaml
@@ -1164,6 +1164,11 @@ Resources:
       TracingEnabled: true
       EndpointConfiguration:
         Type: PRIVATE
+        VpcEndpointIds:
+          - vpce-0339d04aeb67de9da # Authentication Staging VPC Endpoint ID
+          - vpce-068df58b11adba0c7 # Authentication & Orchestration Intergration VPC Endpoint ID
+          - vpce-0e7b281bd24fbd378 # Authentication & Orchestration Production VPC Endpoint ID
+          - vpce-040f33c3489ff777b # Orchestration Sandbox VPC endpoint ID
       Tags:
         CheckovRulesToSkip: CKV_AWS_120
         Product: !Ref ProductTagValue

--- a/src/infra/main/template.yaml
+++ b/src/infra/main/template.yaml
@@ -72,7 +72,9 @@ Mappings:
       TxMAIngressQueueARN: "Uses Internal TxMAIngressQueue"
       TxMAIngressQueueKmsKeyARN: "Uses the SQSEncryptionKey with Internal TxMAIngressQueue"
       OrchestrationVPCID: vpc-093ac0375aa3f291d # ID Reuse Core Dev VPC ID
+      OrchestrationVPCEndpointID: none
       AuthenticationVPCID: vpc-093ac0375aa3f291d # ID Reuse Core Dev VPC ID
+      AuthenticationVPCEndpointID: none
       OneLoginHomeVPCID: vpc-093ac0375aa3f291d # ID Reuse Core Dev VPC ID
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables # pragma: allowlist secret
     build:
@@ -82,7 +84,9 @@ Mappings:
       TxMAIngressQueueARN: "Uses Internal TxMAIngressQueue"
       TxMAIngressQueueKmsKeyARN: "Uses the SQSEncryptionKey with Internal TxMAIngressQueue"
       OrchestrationVPCID: vpc-0ae068c236590b989 # ID Reuse Core Build VPC ID
+      OrchestrationVPCEndpointID: none
       AuthenticationVPCID: vpc-0ae068c236590b989 # ID Reuse Core Build VPC ID
+      AuthenticationVPCEndpointID: none
       OneLoginHomeVPCID: vpc-0ae068c236590b989 # ID Reuse Core Build VPC ID
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables # pragma: allowlist secret
     staging:
@@ -92,7 +96,9 @@ Mappings:
       TxMAIngressQueueARN: arn:aws:sqs:eu-west-2:178023842775:self-staging-EC-SQS-Output-Queue-accountsIntervention
       TxMAIngressQueueKmsKeyARN: arn:aws:kms:eu-west-2:178023842775:key/e388cb30-2d78-431f-b1a6-847549a815aa
       OrchestrationVPCID: vpc-0ca40c7d13490419d # Auth & Orchestration Staging VPC ID
+      OrchestrationVPCEndpointID: vpce-040f33c3489ff777b # Orchestration Sandbox VPC endpoint ID
       AuthenticationVPCID: vpc-0b6f4a5d72f84ed0c # Authentication Sandbox VPC ID
+      AuthenticationVPCEndpointID: vpce-0339d04aeb67de9da # Authentication Staging VPC Endpoint ID
       OneLoginHomeVPCID: vpc-02e4eb3b0cffc08b0 # Performance testing VPC ID
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables # pragma: allowlist secret
     integration:
@@ -102,7 +108,9 @@ Mappings:
       TxMAIngressQueueARN: arn:aws:sqs:eu-west-2:729485541398:self-integration-EC-SQS-Output-Queue-accountsIntervention
       TxMAIngressQueueKmsKeyARN: arn:aws:kms:eu-west-2:729485541398:key/c360ee61-da3b-48de-998e-68cb91743414
       OrchestrationVPCID: vpc-04444d1dc96d8822c # Orchestration Integration VPC ID
+      OrchestrationVPCEndpointID: vpce-068df58b11adba0c7 # Authentication & Orchestration Intergration VPC Endpoint ID
       AuthenticationVPCID: vpc-04444d1dc96d8822c # Authentication Integration VPC ID
+      AuthenticationVPCEndpointID: vpce-068df58b11adba0c7 # Authentication & Orchestration Intergration VPC Endpoint ID
       OneLoginHomeVPCID: vpc-048c9133a5998efe7 # One Login Home Integration VPC ID
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables # pragma: allowlist secret
     production:
@@ -112,7 +120,9 @@ Mappings:
       TxMAIngressQueueARN: arn:aws:sqs:eu-west-2:451773080033:self-production-EC-SQS-Output-Queue-accountsIntervention
       TxMAIngressQueueKmsKeyARN: arn:aws:kms:eu-west-2:451773080033:key/5bbb4188-6774-4fe8-a78a-968f5e435295
       OrchestrationVPCID: vpc-00012e96e1cd0bf95 # Orchestration Production VPC ID
+      OrchestrationVPCEndpointID: vpce-0e7b281bd24fbd378 # Authentication & Orchestration Production VPC Endpoint ID
       AuthenticationVPCID: vpc-00012e96e1cd0bf95 # Authentication Production VPC ID
+      AuthenticationVPCEndpointID: vpce-0e7b281bd24fbd378 # Authentication & Orchestration Production VPC Endpoint ID
       OneLoginHomeVPCID: vpc-0c94e753d20410154 # One Login Home Production VPC ID
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables # pragma: allowlist secret
 
@@ -1164,11 +1174,11 @@ Resources:
       TracingEnabled: true
       EndpointConfiguration:
         Type: PRIVATE
-        VpcEndpointIds:
-          - vpce-0339d04aeb67de9da # Authentication Staging VPC Endpoint ID
-          - vpce-068df58b11adba0c7 # Authentication & Orchestration Intergration VPC Endpoint ID
-          - vpce-0e7b281bd24fbd378 # Authentication & Orchestration Production VPC Endpoint ID
-          - vpce-040f33c3489ff777b # Orchestration Sandbox VPC endpoint ID
+        Condition: !If
+          - IsNotInternal
+          - VpcEndpointIds:
+            - !FindInMap [ EnvConfig, !Ref Environment, AuthenticationVPCEndpointID ]
+            - !FindInMap [ EnvConfig, !Ref Environment, OrchestrationVPCEndpointID ]
       Tags:
         CheckovRulesToSkip: CKV_AWS_120
         Product: !Ref ProductTagValue


### PR DESCRIPTION
## Proposed changes
[ATB-1433](https://govukverify.atlassian.net/browse/ATB-1433)

### What changed
In order for Auth and Orch to call our Private API from within their VPC, they have create an execute-api VPC Endpoint to enable calls to AIS API via AWS networks

### Why did it change
Otherwise will not be able to discover and connect to the AIS API

## Testing
Tested locally, passes linting:
<img width="1224" alt="Screenshot 2024-01-18 at 16 06 21" src="https://github.com/govuk-one-login/account-interventions-service/assets/130994595/cb966bff-4ea1-4c8f-85fb-a0a64f504cab">

Stack successfully deploys:
<img width="452" alt="Screenshot 2024-01-18 at 16 06 03" src="https://github.com/govuk-one-login/account-interventions-service/assets/130994595/c3eb8cff-3228-445a-b93d-54b00860b432">

## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [x] Tested changes and included test evidence in the PR, if appropriate
- [ ] Included all required tags and other properties for any new resources in the SAM template
- [x] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [ ] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [ ] Ensured that no log lines include PII or other sensitive data
- [ ] Implemented unit testing for any new logic implemented, if appropriate
- [ ] Ensured that all commits in this PR are signed
- [ ] Ensured appropriate code coverage is maintained by unit tests
- [ ] Checked SonarCube and ensured no code smells were added


[ATB-1433]: https://govukverify.atlassian.net/browse/ATB-1433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ