### PR TITLE
ATB-1466: Fix Code Smell

### DIFF
--- a/src/handlers/interventions-processor-handler.ts
+++ b/src/handlers/interventions-processor-handler.ts
@@ -109,7 +109,7 @@ async function processSQSRecord(record: SQSRecord) {
   publishTimeToResolveMetrics(
     currentAccountState,
     statusResult.stateResult,
-    itemFromDB?.appliedAt || currentTimestamp.milliseconds,
+    itemFromDB?.appliedAt ?? currentTimestamp.milliseconds,
     currentTimestamp.milliseconds,
     eventName,
   );

--- a/src/handlers/interventions-processor-handler.ts
+++ b/src/handlers/interventions-processor-handler.ts
@@ -74,7 +74,7 @@ async function processSQSRecord(record: SQSRecord) {
   const recordBody: TxMAIngressEvent = JSON.parse(record.body);
   validateEventAgainstSchema(recordBody);
   const eventName = getEventName(recordBody);
-  logger.debug(`${LOGS_PREFIX_SENSITIVE_INFO} Intervention received.`, { intervention: eventName });
+  logger.debug('Intervention received.', { intervention: eventName });
   validateLevelOfConfidence(eventName, recordBody);
   await validateEventIsNotInFuture(eventName, recordBody);
 
@@ -104,7 +104,7 @@ async function processSQSRecord(record: SQSRecord) {
     recordBody,
     statusResult.interventionName,
   );
-  logger.debug('Updating user status', { userId, partialCommandInput });
+  logger.debug(`${LOGS_PREFIX_SENSITIVE_INFO} Updating user status`, { userId, partialCommandInput });
   await service.updateUserStatus(userId, partialCommandInput);
   publishTimeToResolveMetrics(
     currentAccountState,


### PR DESCRIPTION
## Proposed changes
This PR merges a small change to fix a code smell reported by sonar cloud

### What changed
- turned `||` into `??` in intervention processor handler file
- added sensitive info pre-fix to debug line containing user id, removed sensitive info prefix to debug line containing intervention name 

### Why did it change
fix code smell

### Issue tracking

- [ATB-1466](https://govukverify.atlassian.net/browse/ATB-1466)

## Testing
Deployed changes to AWS account and run feature tests suites
Manually check that metric is still being logged as expected
![Screenshot 2024-01-22 at 14 27 52](https://github.com/govuk-one-login/account-interventions-service/assets/110468890/7dc8ce6b-a925-4bf9-81aa-e1f9e78f40f2)

no code smell reported: https://sonarcloud.io/summary/new_code?id=govuk-one-login_account-interventions-service&pullRequest=180 

## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [x] Tested changes and included test evidence in the PR, if appropriate
- [ ] Included all required tags and other properties for any new resources in the SAM template
- [ ] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [ ] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [x] Ensured that no log lines include PII or other sensitive data
- [ ] Implemented unit testing for any new logic implemented, if appropriate
- [x] Ensured that all commits in this PR are signed
- [x] Ensured appropriate code coverage is maintained by unit tests
- [x] Checked SonarCube and ensured no code smells were added
