### PR TITLE
ATB-1423 | 'Add AuditLevel' field from Intervention response as a example and validated field in feature-tests

### DIFF
--- a/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-HappyPath.feature
+++ b/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-HappyPath.feature
@@ -3,115 +3,115 @@ Feature: Invoke-APIGateway-HappyPath.feature
     Scenario Outline: Happy Path - Get Request to /ais/userId - Returns Expected Data for <aisEventType>
         Given I send an <aisEventType> intervention message to the TxMA ingress SQS queue
         When I invoke the API to retrieve the intervention status of the user's account. With history <historyValue>
-        Then I expect the intervention to be <interventionType>, with the following state settings <blockedState>, <suspendedState>, <resetPassword> and <reproveIdentity> with the <auditLevel> returned
+        Then I expect the intervention to be <interventionType>, with the following state settings <blockedState>, <suspendedState>, <resetPassword> and <reproveIdentity>
         Examples:
-            | aisEventType              | historyValue | interventionType                                   | blockedState | suspendedState | resetPassword | reproveIdentity | auditLevel |
-            | pswResetRequired          | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | true           | true          | false           | standard   |
-            | suspendNoAction           | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           | standard   |
-            | block                     | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           | standard   |
-            | idResetRequired           | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | true           | false         | true            | standard   |
-            | pswAndIdResetRequired     | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | true          | true            | standard   |
-            | unblock                   | false        | AIS_NO_INTERVENTION                                | false        | false          | false         | false           | standard   |
-            | userActionIdResetSuccess  | false        | AIS_NO_INTERVENTION                                | false        | false          | false         | false           | standard   |
-            | userActionPswResetSuccess | false        | AIS_NO_INTERVENTION                                | false        | false          | false         | false           | standard   |
-            | unSuspendAction           | false        | AIS_NO_INTERVENTION                                | false        | false          | false         | false           | standard   |
+            | aisEventType              | historyValue | interventionType                                   | blockedState | suspendedState | resetPassword | reproveIdentity |
+            | pswResetRequired          | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | true           | true          | false           |
+            | suspendNoAction           | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           |
+            | block                     | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           |
+            | idResetRequired           | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | true           | false         | true            |
+            | pswAndIdResetRequired     | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | true          | true            |
+            | unblock                   | false        | AIS_NO_INTERVENTION                                | false        | false          | false         | false           |
+            | userActionIdResetSuccess  | false        | AIS_NO_INTERVENTION                                | false        | false          | false         | false           |
+            | userActionPswResetSuccess | false        | AIS_NO_INTERVENTION                                | false        | false          | false         | false           |
+            | unSuspendAction           | false        | AIS_NO_INTERVENTION                                | false        | false          | false         | false           |
 
     Scenario Outline: Happy Path - <originalAisEventType> account - Get Request to /ais/userId - Returns Expected Data for <aisEventType>
         Given I send an <aisEventType> intervention message to the TxMA ingress SQS queue for a Account in <originalAisEventType> state
         When I invoke the API to retrieve the intervention status of the user's account. With history <historyValue>
-        Then I expect the intervention to be <interventionType>, with the following state settings <blockedState>, <suspendedState>, <resetPassword> and <reproveIdentity> with the <auditLevel> returned
+        Then I expect the intervention to be <interventionType>, with the following state settings <blockedState>, <suspendedState>, <resetPassword> and <reproveIdentity>
         Examples:
-            | originalAisEventType  | aisEventType              | historyValue | interventionType                                   | blockedState | suspendedState | resetPassword | reproveIdentity | auditLevel |
+            | originalAisEventType  | aisEventType              | historyValue | interventionType                                   | blockedState | suspendedState | resetPassword | reproveIdentity |
             # passsword reset account status to new intervention type
-            | pswResetRequired      | pswResetRequired          | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | true           | true          | false           | standard   |
-            | pswResetRequired      | suspendNoAction           | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           | standard   |
-            | pswResetRequired      | block                     | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           | standard   |
-            | pswResetRequired      | idResetRequired           | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | true           | false         | true            | standard   |
-            | pswResetRequired      | pswAndIdResetRequired     | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | true          | true            | standard   |
-            | pswResetRequired      | unblock                   | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | true           | true          | false           | standard   |
-            | pswResetRequired      | userActionIdResetSuccess  | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | true           | true          | false           | standard   |
-            | pswResetRequired      | userActionPswResetSuccess | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | false          | false         | false           | standard   |
-            | pswResetRequired      | unSuspendAction           | false        | AIS_ACCOUNT_UNSUSPENDED                            | false        | false          | false         | false           | standard   |
+            | pswResetRequired      | pswResetRequired          | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | true           | true          | false           |
+            | pswResetRequired      | suspendNoAction           | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           |
+            | pswResetRequired      | block                     | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           |
+            | pswResetRequired      | idResetRequired           | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | true           | false         | true            |
+            | pswResetRequired      | pswAndIdResetRequired     | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | true          | true            |
+            | pswResetRequired      | unblock                   | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | true           | true          | false           |
+            | pswResetRequired      | userActionIdResetSuccess  | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | true           | true          | false           |
+            | pswResetRequired      | userActionPswResetSuccess | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | false          | false         | false           |
+            | pswResetRequired      | unSuspendAction           | false        | AIS_ACCOUNT_UNSUSPENDED                            | false        | false          | false         | false           |
             # suspend no action account status to new intervention type
-            | suspendNoAction       | pswResetRequired          | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | true           | true          | false           | standard   |
-            | suspendNoAction       | suspendNoAction           | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           | standard   |
-            | suspendNoAction       | block                     | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           | standard   |
-            | suspendNoAction       | idResetRequired           | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | true           | false         | true            | standard   |
-            | suspendNoAction       | pswAndIdResetRequired     | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | true          | true            | standard   |
-            | suspendNoAction       | unblock                   | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           | standard   |
-            | suspendNoAction       | userActionIdResetSuccess  | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           | standard   |
-            | suspendNoAction       | userActionPswResetSuccess | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           | standard   |
-            | suspendNoAction       | unSuspendAction           | false        | AIS_ACCOUNT_UNSUSPENDED                            | false        | false          | false         | false           | standard   |
+            | suspendNoAction       | pswResetRequired          | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | true           | true          | false           |
+            | suspendNoAction       | suspendNoAction           | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           |
+            | suspendNoAction       | block                     | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           |
+            | suspendNoAction       | idResetRequired           | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | true           | false         | true            |
+            | suspendNoAction       | pswAndIdResetRequired     | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | true          | true            |
+            | suspendNoAction       | unblock                   | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           |
+            | suspendNoAction       | userActionIdResetSuccess  | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           |
+            | suspendNoAction       | userActionPswResetSuccess | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           |
+            | suspendNoAction       | unSuspendAction           | false        | AIS_ACCOUNT_UNSUSPENDED                            | false        | false          | false         | false           |
             # blocked account status to new intervention type
-            | block                 | pswResetRequired          | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           | standard   |
-            | block                 | suspendNoAction           | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           | standard   |
-            | block                 | block                     | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           | standard   |
-            | block                 | idResetRequired           | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           | standard   |
-            | block                 | pswAndIdResetRequired     | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           | standard   |
-            | block                 | unblock                   | false        | AIS_ACCOUNT_UNBLOCKED                              | false        | false          | false         | false           | standard   |
-            | block                 | userActionIdResetSuccess  | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           | standard   |
-            | block                 | userActionPswResetSuccess | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           | standard   |
-            | block                 | unSuspendAction           | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           | standard   |
+            | block                 | pswResetRequired          | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           |
+            | block                 | suspendNoAction           | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           |
+            | block                 | block                     | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           |
+            | block                 | idResetRequired           | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           |
+            | block                 | pswAndIdResetRequired     | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           |
+            | block                 | unblock                   | false        | AIS_ACCOUNT_UNBLOCKED                              | false        | false          | false         | false           |
+            | block                 | userActionIdResetSuccess  | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           |
+            | block                 | userActionPswResetSuccess | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           |
+            | block                 | unSuspendAction           | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           |
             # Id reset account status to new intervention type
-            | idResetRequired       | pswResetRequired          | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | true           | true          | false           | standard   |
-            | idResetRequired       | suspendNoAction           | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           | standard   |
-            | idResetRequired       | block                     | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           | standard   |
-            | idResetRequired       | idResetRequired           | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | true           | false         | true            | standard   |
-            | idResetRequired       | pswAndIdResetRequired     | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | true          | true            | standard   |
-            | idResetRequired       | unblock                   | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | true           | false         | true            | standard   |
-            | idResetRequired       | userActionIdResetSuccess  | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | false          | false         | false           | standard   |
-            | idResetRequired       | userActionPswResetSuccess | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | true           | false         | true            | standard   |
-            | idResetRequired       | unSuspendAction           | false        | AIS_ACCOUNT_UNSUSPENDED                            | false        | false          | false         | false           | standard   |
+            | idResetRequired       | pswResetRequired          | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | true           | true          | false           |
+            | idResetRequired       | suspendNoAction           | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           |
+            | idResetRequired       | block                     | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           |
+            | idResetRequired       | idResetRequired           | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | true           | false         | true            |
+            | idResetRequired       | pswAndIdResetRequired     | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | true          | true            |
+            | idResetRequired       | unblock                   | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | true           | false         | true            |
+            | idResetRequired       | userActionIdResetSuccess  | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | false          | false         | false           |
+            | idResetRequired       | userActionPswResetSuccess | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | true           | false         | true            |
+            | idResetRequired       | unSuspendAction           | false        | AIS_ACCOUNT_UNSUSPENDED                            | false        | false          | false         | false           |
             # password reset required account status to new intervention type
-            | pswAndIdResetRequired | pswResetRequired          | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | true           | true          | false           | standard   |
-            | pswAndIdResetRequired | suspendNoAction           | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           | standard   |
-            | pswAndIdResetRequired | block                     | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           | standard   |
-            | pswAndIdResetRequired | idResetRequired           | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | true           | false         | true            | standard   |
-            | pswAndIdResetRequired | pswAndIdResetRequired     | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | true          | true            | standard   |
-            | pswAndIdResetRequired | unblock                   | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | true          | true            | standard   |
-            | pswAndIdResetRequired | userActionIdResetSuccess  | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | true          | false           | standard   |
-            | pswAndIdResetRequired | userActionPswResetSuccess | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | false         | true            | standard   |
-            | pswAndIdResetRequired | unSuspendAction           | false        | AIS_ACCOUNT_UNSUSPENDED                            | false        | false          | false         | false           | standard   |
+            | pswAndIdResetRequired | pswResetRequired          | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | true           | true          | false           |
+            | pswAndIdResetRequired | suspendNoAction           | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           |
+            | pswAndIdResetRequired | block                     | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           |
+            | pswAndIdResetRequired | idResetRequired           | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | true           | false         | true            |
+            | pswAndIdResetRequired | pswAndIdResetRequired     | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | true          | true            |
+            | pswAndIdResetRequired | unblock                   | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | true          | true            |
+            | pswAndIdResetRequired | userActionIdResetSuccess  | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | true          | false           |
+            | pswAndIdResetRequired | userActionPswResetSuccess | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | false         | true            |
+            | pswAndIdResetRequired | unSuspendAction           | false        | AIS_ACCOUNT_UNSUSPENDED                            | false        | false          | false         | false           |
 
 
     Scenario Outline: Happy Path - <originalAisEventType> account - Get Request to /ais/userId - Returns Expected Data for <aisEventType> with History values
         Given I send an updated request to the SQS queue with intervention data of the type <aisEventType> from <originalAisEventType>
         When I invoke the API to retrieve the intervention status of the user's account with <historyValue>
-        Then I expect the intervention to be <interventionType>, with the following history values with <componentHistory>, <interventionCodeHistory>, <interventionHistory>, <reason> with the <auditLevel> returned
+        Then I expect the intervention to be <interventionType>, with the following history values with <componentHistory>, <interventionCodeHistory>, <interventionHistory>, <reason>
         Examples:
-            | originalAisEventType  | aisEventType          | historyValue | interventionType                                   | componentHistory | interventionCodeHistory | interventionHistory                                          | reason                     | auditLevel |
+            | originalAisEventType  | aisEventType          | historyValue | interventionType                                   | componentHistory | interventionCodeHistory | interventionHistory                                          | reason                     |
             # passsword reset account status to new intervention type
-            | pswResetRequired      | suspendNoAction       | true         | AIS_ACCOUNT_SUSPENDED                              | TICF_CRI         | 01                      | FRAUD_SUSPEND_ACCOUNT                                        | suspend - 01               | standard   |
-            | pswResetRequired      | block                 | true         | AIS_ACCOUNT_BLOCKED                                | TICF_CRI         | 03                      | FRAUD_BLOCK_ACCOUNT                                          | block - 03                 | standard   |
-            | pswResetRequired      | idResetRequired       | true         | AIS_FORCED_USER_IDENTITY_VERIFY                    | TICF_CRI         | 05                      | FRAUD_FORCED_USER_IDENTITY_REVERIFICATION                    | id reset - 05              | standard   |
-            | pswResetRequired      | pswAndIdResetRequired | true         | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | TICF_CRI         | 06                      | FRAUD_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_REVERIFICATION | password and id reset - 06 | standard   |
-            | pswResetRequired      | unSuspendAction       | true         | AIS_ACCOUNT_UNSUSPENDED                            | TICF_CRI         | 02                      | FRAUD_UNSUSPEND_ACCOUNT                                      | unsuspend - 02             | standard   |
+            | pswResetRequired      | suspendNoAction       | true         | AIS_ACCOUNT_SUSPENDED                              | TICF_CRI         | 01                      | FRAUD_SUSPEND_ACCOUNT                                        | suspend - 01               |
+            | pswResetRequired      | block                 | true         | AIS_ACCOUNT_BLOCKED                                | TICF_CRI         | 03                      | FRAUD_BLOCK_ACCOUNT                                          | block - 03                 |
+            | pswResetRequired      | idResetRequired       | true         | AIS_FORCED_USER_IDENTITY_VERIFY                    | TICF_CRI         | 05                      | FRAUD_FORCED_USER_IDENTITY_REVERIFICATION                    | id reset - 05              |
+            | pswResetRequired      | pswAndIdResetRequired | true         | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | TICF_CRI         | 06                      | FRAUD_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_REVERIFICATION | password and id reset - 06 |
+            | pswResetRequired      | unSuspendAction       | true         | AIS_ACCOUNT_UNSUSPENDED                            | TICF_CRI         | 02                      | FRAUD_UNSUSPEND_ACCOUNT                                      | unsuspend - 02             |
             # suspend no action account status to new intervention type
-            | suspendNoAction       | pswResetRequired      | true         | AIS_FORCED_USER_PASSWORD_RESET                     | TICF_CRI         | 04                      | FRAUD_FORCED_USER_PASSWORD_RESET                             | password reset - 04        | standard   |
-            | suspendNoAction       | block                 | true         | AIS_ACCOUNT_BLOCKED                                | TICF_CRI         | 03                      | FRAUD_BLOCK_ACCOUNT                                          | block - 03                 | standard   |
-            | suspendNoAction       | idResetRequired       | true         | AIS_FORCED_USER_IDENTITY_VERIFY                    | TICF_CRI         | 05                      | FRAUD_FORCED_USER_IDENTITY_REVERIFICATION                    | id reset - 05              | standard   |
-            | suspendNoAction       | pswAndIdResetRequired | true         | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | TICF_CRI         | 06                      | FRAUD_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_REVERIFICATION | password and id reset - 06 | standard   |
-            | suspendNoAction       | unSuspendAction       | true         | AIS_ACCOUNT_UNSUSPENDED                            | TICF_CRI         | 02                      | FRAUD_UNSUSPEND_ACCOUNT                                      | unsuspend - 02             | standard   |
+            | suspendNoAction       | pswResetRequired      | true         | AIS_FORCED_USER_PASSWORD_RESET                     | TICF_CRI         | 04                      | FRAUD_FORCED_USER_PASSWORD_RESET                             | password reset - 04        |
+            | suspendNoAction       | block                 | true         | AIS_ACCOUNT_BLOCKED                                | TICF_CRI         | 03                      | FRAUD_BLOCK_ACCOUNT                                          | block - 03                 |
+            | suspendNoAction       | idResetRequired       | true         | AIS_FORCED_USER_IDENTITY_VERIFY                    | TICF_CRI         | 05                      | FRAUD_FORCED_USER_IDENTITY_REVERIFICATION                    | id reset - 05              |
+            | suspendNoAction       | pswAndIdResetRequired | true         | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | TICF_CRI         | 06                      | FRAUD_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_REVERIFICATION | password and id reset - 06 |
+            | suspendNoAction       | unSuspendAction       | true         | AIS_ACCOUNT_UNSUSPENDED                            | TICF_CRI         | 02                      | FRAUD_UNSUSPEND_ACCOUNT                                      | unsuspend - 02             |
             # blocked account status to new intervention type
-            | block                 | unblock               | true         | AIS_ACCOUNT_UNBLOCKED                              | TICF_CRI         | 07                      | FRAUD_UNBLOCK_ACCOUNT                                        | unblock - 07               | standard   |
+            | block                 | unblock               | true         | AIS_ACCOUNT_UNBLOCKED                              | TICF_CRI         | 07                      | FRAUD_UNBLOCK_ACCOUNT                                        | unblock - 07               |
             # Id reset account status to new intervention type
-            | idResetRequired       | pswResetRequired      | true         | AIS_FORCED_USER_PASSWORD_RESET                     | TICF_CRI         | 04                      | FRAUD_FORCED_USER_PASSWORD_RESET                             | password reset - 04        | standard   |
-            | idResetRequired       | suspendNoAction       | true         | AIS_ACCOUNT_SUSPENDED                              | TICF_CRI         | 01                      | FRAUD_SUSPEND_ACCOUNT                                        | suspend - 01               | standard   |
-            | idResetRequired       | block                 | true         | AIS_ACCOUNT_BLOCKED                                | TICF_CRI         | 03                      | FRAUD_BLOCK_ACCOUNT                                          | block - 03                 | standard   |
-            | idResetRequired       | pswAndIdResetRequired | true         | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | TICF_CRI         | 06                      | FRAUD_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_REVERIFICATION | password and id reset - 06 | standard   |
-            | idResetRequired       | unSuspendAction       | true         | AIS_ACCOUNT_UNSUSPENDED                            | TICF_CRI         | 02                      | FRAUD_UNSUSPEND_ACCOUNT                                      | unsuspend - 02             | standard   |
+            | idResetRequired       | pswResetRequired      | true         | AIS_FORCED_USER_PASSWORD_RESET                     | TICF_CRI         | 04                      | FRAUD_FORCED_USER_PASSWORD_RESET                             | password reset - 04        |
+            | idResetRequired       | suspendNoAction       | true         | AIS_ACCOUNT_SUSPENDED                              | TICF_CRI         | 01                      | FRAUD_SUSPEND_ACCOUNT                                        | suspend - 01               |
+            | idResetRequired       | block                 | true         | AIS_ACCOUNT_BLOCKED                                | TICF_CRI         | 03                      | FRAUD_BLOCK_ACCOUNT                                          | block - 03                 |
+            | idResetRequired       | pswAndIdResetRequired | true         | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | TICF_CRI         | 06                      | FRAUD_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_REVERIFICATION | password and id reset - 06 |
+            | idResetRequired       | unSuspendAction       | true         | AIS_ACCOUNT_UNSUSPENDED                            | TICF_CRI         | 02                      | FRAUD_UNSUSPEND_ACCOUNT                                      | unsuspend - 02             |
             # password reset required account status to new intervention type
-            | pswAndIdResetRequired | pswResetRequired      | true         | AIS_FORCED_USER_PASSWORD_RESET                     | TICF_CRI         | 04                      | FRAUD_FORCED_USER_PASSWORD_RESET                             | password reset - 04        | standard   |
-            | pswAndIdResetRequired | suspendNoAction       | true         | AIS_ACCOUNT_SUSPENDED                              | TICF_CRI         | 01                      | FRAUD_SUSPEND_ACCOUNT                                        | suspend - 01               | standard   |
-            | pswAndIdResetRequired | block                 | true         | AIS_ACCOUNT_BLOCKED                                | TICF_CRI         | 03                      | FRAUD_BLOCK_ACCOUNT                                          | block - 03                 | standard   |
-            | pswAndIdResetRequired | idResetRequired       | true         | AIS_FORCED_USER_IDENTITY_VERIFY                    | TICF_CRI         | 05                      | FRAUD_FORCED_USER_IDENTITY_REVERIFICATION                    | id reset - 05              | standard   |
-            | pswAndIdResetRequired | unSuspendAction       | true         | AIS_ACCOUNT_UNSUSPENDED                            | TICF_CRI         | 02                      | FRAUD_UNSUSPEND_ACCOUNT                                      | unsuspend - 02             | standard   |
+            | pswAndIdResetRequired | pswResetRequired      | true         | AIS_FORCED_USER_PASSWORD_RESET                     | TICF_CRI         | 04                      | FRAUD_FORCED_USER_PASSWORD_RESET                             | password reset - 04        |
+            | pswAndIdResetRequired | suspendNoAction       | true         | AIS_ACCOUNT_SUSPENDED                              | TICF_CRI         | 01                      | FRAUD_SUSPEND_ACCOUNT                                        | suspend - 01               |
+            | pswAndIdResetRequired | block                 | true         | AIS_ACCOUNT_BLOCKED                                | TICF_CRI         | 03                      | FRAUD_BLOCK_ACCOUNT                                          | block - 03                 |
+            | pswAndIdResetRequired | idResetRequired       | true         | AIS_FORCED_USER_IDENTITY_VERIFY                    | TICF_CRI         | 05                      | FRAUD_FORCED_USER_IDENTITY_REVERIFICATION                    | id reset - 05              |
+            | pswAndIdResetRequired | unSuspendAction       | true         | AIS_ACCOUNT_UNSUSPENDED                            | TICF_CRI         | 02                      | FRAUD_UNSUSPEND_ACCOUNT                                      | unsuspend - 02             |
 
 
     Scenario Outline: Happy Path - Field Validation - Get Request to /ais/userId - Returns Expected Data for <aisEventType> with specific field validation
         Given I send a invalid request to sqs queue with no userId and <aisEventType>, <testUserId> data
         When I invoke apiGateway to retreive the status of the invalid userId with <historyValue>
-        Then I should receive the appropriate <interventionType> for the ais endpoint with the <auditLevel> returned
+        Then I should receive the appropriate <interventionType> for the ais endpoint
         Examples:
-            | aisEventType    | historyValue | interventionType    | testUserId | auditLevel |
-            | suspendNoAction | false        | AIS_NO_INTERVENTION |            | standard   |
+            | aisEventType    | historyValue | interventionType    | testUserId |
+            | suspendNoAction | false        | AIS_NO_INTERVENTION |            |

--- a/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-HappyPath.feature
+++ b/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-HappyPath.feature
@@ -3,115 +3,115 @@ Feature: Invoke-APIGateway-HappyPath.feature
     Scenario Outline: Happy Path - Get Request to /ais/userId - Returns Expected Data for <aisEventType>
         Given I send an <aisEventType> intervention message to the TxMA ingress SQS queue
         When I invoke the API to retrieve the intervention status of the user's account. With history <historyValue>
-        Then I expect the intervention to be <interventionType>, with the following state settings <blockedState>, <suspendedState>, <resetPassword> and <reproveIdentity>
+        Then I expect the intervention to be <interventionType>, with the following state settings <blockedState>, <suspendedState>, <resetPassword> and <reproveIdentity> with the <auditLevel> returned
         Examples:
-            | aisEventType              | historyValue | interventionType                                   | blockedState | suspendedState | resetPassword | reproveIdentity |
-            | pswResetRequired          | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | true           | true          | false           |
-            | suspendNoAction           | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           |
-            | block                     | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           |
-            | idResetRequired           | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | true           | false         | true            |
-            | pswAndIdResetRequired     | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | true          | true            |
-            | unblock                   | false        | AIS_NO_INTERVENTION                                | false        | false          | false         | false           |
-            | userActionIdResetSuccess  | false        | AIS_NO_INTERVENTION                                | false        | false          | false         | false           |
-            | userActionPswResetSuccess | false        | AIS_NO_INTERVENTION                                | false        | false          | false         | false           |
-            | unSuspendAction           | false        | AIS_NO_INTERVENTION                                | false        | false          | false         | false           |
+            | aisEventType              | historyValue | interventionType                                   | blockedState | suspendedState | resetPassword | reproveIdentity | auditLevel |
+            | pswResetRequired          | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | true           | true          | false           | standard   |
+            | suspendNoAction           | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           | standard   |
+            | block                     | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           | standard   |
+            | idResetRequired           | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | true           | false         | true            | standard   |
+            | pswAndIdResetRequired     | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | true          | true            | standard   |
+            | unblock                   | false        | AIS_NO_INTERVENTION                                | false        | false          | false         | false           | standard   |
+            | userActionIdResetSuccess  | false        | AIS_NO_INTERVENTION                                | false        | false          | false         | false           | standard   |
+            | userActionPswResetSuccess | false        | AIS_NO_INTERVENTION                                | false        | false          | false         | false           | standard   |
+            | unSuspendAction           | false        | AIS_NO_INTERVENTION                                | false        | false          | false         | false           | standard   |
 
     Scenario Outline: Happy Path - <originalAisEventType> account - Get Request to /ais/userId - Returns Expected Data for <aisEventType>
         Given I send an <aisEventType> intervention message to the TxMA ingress SQS queue for a Account in <originalAisEventType> state
         When I invoke the API to retrieve the intervention status of the user's account. With history <historyValue>
-        Then I expect the intervention to be <interventionType>, with the following state settings <blockedState>, <suspendedState>, <resetPassword> and <reproveIdentity>
+        Then I expect the intervention to be <interventionType>, with the following state settings <blockedState>, <suspendedState>, <resetPassword> and <reproveIdentity> with the <auditLevel> returned
         Examples:
-            | originalAisEventType  | aisEventType              | historyValue | interventionType                                   | blockedState | suspendedState | resetPassword | reproveIdentity |
+            | originalAisEventType  | aisEventType              | historyValue | interventionType                                   | blockedState | suspendedState | resetPassword | reproveIdentity | auditLevel |
             # passsword reset account status to new intervention type
-            | pswResetRequired      | pswResetRequired          | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | true           | true          | false           |
-            | pswResetRequired      | suspendNoAction           | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           |
-            | pswResetRequired      | block                     | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           |
-            | pswResetRequired      | idResetRequired           | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | true           | false         | true            |
-            | pswResetRequired      | pswAndIdResetRequired     | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | true          | true            |
-            | pswResetRequired      | unblock                   | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | true           | true          | false           |
-            | pswResetRequired      | userActionIdResetSuccess  | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | true           | true          | false           |
-            | pswResetRequired      | userActionPswResetSuccess | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | false          | false         | false           |
-            | pswResetRequired      | unSuspendAction           | false        | AIS_ACCOUNT_UNSUSPENDED                            | false        | false          | false         | false           |
+            | pswResetRequired      | pswResetRequired          | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | true           | true          | false           | standard   |
+            | pswResetRequired      | suspendNoAction           | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           | standard   |
+            | pswResetRequired      | block                     | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           | standard   |
+            | pswResetRequired      | idResetRequired           | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | true           | false         | true            | standard   |
+            | pswResetRequired      | pswAndIdResetRequired     | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | true          | true            | standard   |
+            | pswResetRequired      | unblock                   | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | true           | true          | false           | standard   |
+            | pswResetRequired      | userActionIdResetSuccess  | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | true           | true          | false           | standard   |
+            | pswResetRequired      | userActionPswResetSuccess | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | false          | false         | false           | standard   |
+            | pswResetRequired      | unSuspendAction           | false        | AIS_ACCOUNT_UNSUSPENDED                            | false        | false          | false         | false           | standard   |
             # suspend no action account status to new intervention type
-            | suspendNoAction       | pswResetRequired          | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | true           | true          | false           |
-            | suspendNoAction       | suspendNoAction           | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           |
-            | suspendNoAction       | block                     | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           |
-            | suspendNoAction       | idResetRequired           | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | true           | false         | true            |
-            | suspendNoAction       | pswAndIdResetRequired     | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | true          | true            |
-            | suspendNoAction       | unblock                   | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           |
-            | suspendNoAction       | userActionIdResetSuccess  | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           |
-            | suspendNoAction       | userActionPswResetSuccess | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           |
-            | suspendNoAction       | unSuspendAction           | false        | AIS_ACCOUNT_UNSUSPENDED                            | false        | false          | false         | false           |
+            | suspendNoAction       | pswResetRequired          | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | true           | true          | false           | standard   |
+            | suspendNoAction       | suspendNoAction           | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           | standard   |
+            | suspendNoAction       | block                     | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           | standard   |
+            | suspendNoAction       | idResetRequired           | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | true           | false         | true            | standard   |
+            | suspendNoAction       | pswAndIdResetRequired     | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | true          | true            | standard   |
+            | suspendNoAction       | unblock                   | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           | standard   |
+            | suspendNoAction       | userActionIdResetSuccess  | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           | standard   |
+            | suspendNoAction       | userActionPswResetSuccess | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           | standard   |
+            | suspendNoAction       | unSuspendAction           | false        | AIS_ACCOUNT_UNSUSPENDED                            | false        | false          | false         | false           | standard   |
             # blocked account status to new intervention type
-            | block                 | pswResetRequired          | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           |
-            | block                 | suspendNoAction           | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           |
-            | block                 | block                     | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           |
-            | block                 | idResetRequired           | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           |
-            | block                 | pswAndIdResetRequired     | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           |
-            | block                 | unblock                   | false        | AIS_ACCOUNT_UNBLOCKED                              | false        | false          | false         | false           |
-            | block                 | userActionIdResetSuccess  | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           |
-            | block                 | userActionPswResetSuccess | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           |
-            | block                 | unSuspendAction           | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           |
+            | block                 | pswResetRequired          | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           | standard   |
+            | block                 | suspendNoAction           | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           | standard   |
+            | block                 | block                     | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           | standard   |
+            | block                 | idResetRequired           | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           | standard   |
+            | block                 | pswAndIdResetRequired     | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           | standard   |
+            | block                 | unblock                   | false        | AIS_ACCOUNT_UNBLOCKED                              | false        | false          | false         | false           | standard   |
+            | block                 | userActionIdResetSuccess  | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           | standard   |
+            | block                 | userActionPswResetSuccess | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           | standard   |
+            | block                 | unSuspendAction           | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           | standard   |
             # Id reset account status to new intervention type
-            | idResetRequired       | pswResetRequired          | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | true           | true          | false           |
-            | idResetRequired       | suspendNoAction           | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           |
-            | idResetRequired       | block                     | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           |
-            | idResetRequired       | idResetRequired           | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | true           | false         | true            |
-            | idResetRequired       | pswAndIdResetRequired     | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | true          | true            |
-            | idResetRequired       | unblock                   | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | true           | false         | true            |
-            | idResetRequired       | userActionIdResetSuccess  | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | false          | false         | false           |
-            | idResetRequired       | userActionPswResetSuccess | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | true           | false         | true            |
-            | idResetRequired       | unSuspendAction           | false        | AIS_ACCOUNT_UNSUSPENDED                            | false        | false          | false         | false           |
+            | idResetRequired       | pswResetRequired          | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | true           | true          | false           | standard   |
+            | idResetRequired       | suspendNoAction           | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           | standard   |
+            | idResetRequired       | block                     | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           | standard   |
+            | idResetRequired       | idResetRequired           | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | true           | false         | true            | standard   |
+            | idResetRequired       | pswAndIdResetRequired     | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | true          | true            | standard   |
+            | idResetRequired       | unblock                   | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | true           | false         | true            | standard   |
+            | idResetRequired       | userActionIdResetSuccess  | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | false          | false         | false           | standard   |
+            | idResetRequired       | userActionPswResetSuccess | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | true           | false         | true            | standard   |
+            | idResetRequired       | unSuspendAction           | false        | AIS_ACCOUNT_UNSUSPENDED                            | false        | false          | false         | false           | standard   |
             # password reset required account status to new intervention type
-            | pswAndIdResetRequired | pswResetRequired          | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | true           | true          | false           |
-            | pswAndIdResetRequired | suspendNoAction           | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           |
-            | pswAndIdResetRequired | block                     | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           |
-            | pswAndIdResetRequired | idResetRequired           | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | true           | false         | true            |
-            | pswAndIdResetRequired | pswAndIdResetRequired     | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | true          | true            |
-            | pswAndIdResetRequired | unblock                   | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | true          | true            |
-            | pswAndIdResetRequired | userActionIdResetSuccess  | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | true          | false           |
-            | pswAndIdResetRequired | userActionPswResetSuccess | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | false         | true            |
-            | pswAndIdResetRequired | unSuspendAction           | false        | AIS_ACCOUNT_UNSUSPENDED                            | false        | false          | false         | false           |
+            | pswAndIdResetRequired | pswResetRequired          | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false        | true           | true          | false           | standard   |
+            | pswAndIdResetRequired | suspendNoAction           | false        | AIS_ACCOUNT_SUSPENDED                              | false        | true           | false         | false           | standard   |
+            | pswAndIdResetRequired | block                     | false        | AIS_ACCOUNT_BLOCKED                                | true         | false          | false         | false           | standard   |
+            | pswAndIdResetRequired | idResetRequired           | false        | AIS_FORCED_USER_IDENTITY_VERIFY                    | false        | true           | false         | true            | standard   |
+            | pswAndIdResetRequired | pswAndIdResetRequired     | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | true          | true            | standard   |
+            | pswAndIdResetRequired | unblock                   | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | true          | true            | standard   |
+            | pswAndIdResetRequired | userActionIdResetSuccess  | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | true          | false           | standard   |
+            | pswAndIdResetRequired | userActionPswResetSuccess | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false        | true           | false         | true            | standard   |
+            | pswAndIdResetRequired | unSuspendAction           | false        | AIS_ACCOUNT_UNSUSPENDED                            | false        | false          | false         | false           | standard   |
 
 
     Scenario Outline: Happy Path - <originalAisEventType> account - Get Request to /ais/userId - Returns Expected Data for <aisEventType> with History values
         Given I send an updated request to the SQS queue with intervention data of the type <aisEventType> from <originalAisEventType>
         When I invoke the API to retrieve the intervention status of the user's account with <historyValue>
-        Then I expect the intervention to be <interventionType>, with the following history values with <componentHistory>, <interventionCodeHistory>, <interventionHistory>, <reason>
+        Then I expect the intervention to be <interventionType>, with the following history values with <componentHistory>, <interventionCodeHistory>, <interventionHistory>, <reason> with the <auditLevel> returned
         Examples:
-            | originalAisEventType  | aisEventType          | historyValue | interventionType                                   | componentHistory | interventionCodeHistory | interventionHistory                                          | reason                     |
+            | originalAisEventType  | aisEventType          | historyValue | interventionType                                   | componentHistory | interventionCodeHistory | interventionHistory                                          | reason                     | auditLevel |
             # passsword reset account status to new intervention type
-            | pswResetRequired      | suspendNoAction       | true         | AIS_ACCOUNT_SUSPENDED                              | TICF_CRI         | 01                      | FRAUD_SUSPEND_ACCOUNT                                        | suspend - 01               |
-            | pswResetRequired      | block                 | true         | AIS_ACCOUNT_BLOCKED                                | TICF_CRI         | 03                      | FRAUD_BLOCK_ACCOUNT                                          | block - 03                 |
-            | pswResetRequired      | idResetRequired       | true         | AIS_FORCED_USER_IDENTITY_VERIFY                    | TICF_CRI         | 05                      | FRAUD_FORCED_USER_IDENTITY_REVERIFICATION                    | id reset - 05              |
-            | pswResetRequired      | pswAndIdResetRequired | true         | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | TICF_CRI         | 06                      | FRAUD_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_REVERIFICATION | password and id reset - 06 |
-            | pswResetRequired      | unSuspendAction       | true         | AIS_ACCOUNT_UNSUSPENDED                            | TICF_CRI         | 02                      | FRAUD_UNSUSPEND_ACCOUNT                                      | unsuspend - 02             |
+            | pswResetRequired      | suspendNoAction       | true         | AIS_ACCOUNT_SUSPENDED                              | TICF_CRI         | 01                      | FRAUD_SUSPEND_ACCOUNT                                        | suspend - 01               | standard   |
+            | pswResetRequired      | block                 | true         | AIS_ACCOUNT_BLOCKED                                | TICF_CRI         | 03                      | FRAUD_BLOCK_ACCOUNT                                          | block - 03                 | standard   |
+            | pswResetRequired      | idResetRequired       | true         | AIS_FORCED_USER_IDENTITY_VERIFY                    | TICF_CRI         | 05                      | FRAUD_FORCED_USER_IDENTITY_REVERIFICATION                    | id reset - 05              | standard   |
+            | pswResetRequired      | pswAndIdResetRequired | true         | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | TICF_CRI         | 06                      | FRAUD_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_REVERIFICATION | password and id reset - 06 | standard   |
+            | pswResetRequired      | unSuspendAction       | true         | AIS_ACCOUNT_UNSUSPENDED                            | TICF_CRI         | 02                      | FRAUD_UNSUSPEND_ACCOUNT                                      | unsuspend - 02             | standard   |
             # suspend no action account status to new intervention type
-            | suspendNoAction       | pswResetRequired      | true         | AIS_FORCED_USER_PASSWORD_RESET                     | TICF_CRI         | 04                      | FRAUD_FORCED_USER_PASSWORD_RESET                             | password reset - 04        |
-            | suspendNoAction       | block                 | true         | AIS_ACCOUNT_BLOCKED                                | TICF_CRI         | 03                      | FRAUD_BLOCK_ACCOUNT                                          | block - 03                 |
-            | suspendNoAction       | idResetRequired       | true         | AIS_FORCED_USER_IDENTITY_VERIFY                    | TICF_CRI         | 05                      | FRAUD_FORCED_USER_IDENTITY_REVERIFICATION                    | id reset - 05              |
-            | suspendNoAction       | pswAndIdResetRequired | true         | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | TICF_CRI         | 06                      | FRAUD_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_REVERIFICATION | password and id reset - 06 |
-            | suspendNoAction       | unSuspendAction       | true         | AIS_ACCOUNT_UNSUSPENDED                            | TICF_CRI         | 02                      | FRAUD_UNSUSPEND_ACCOUNT                                      | unsuspend - 02             |
+            | suspendNoAction       | pswResetRequired      | true         | AIS_FORCED_USER_PASSWORD_RESET                     | TICF_CRI         | 04                      | FRAUD_FORCED_USER_PASSWORD_RESET                             | password reset - 04        | standard   |
+            | suspendNoAction       | block                 | true         | AIS_ACCOUNT_BLOCKED                                | TICF_CRI         | 03                      | FRAUD_BLOCK_ACCOUNT                                          | block - 03                 | standard   |
+            | suspendNoAction       | idResetRequired       | true         | AIS_FORCED_USER_IDENTITY_VERIFY                    | TICF_CRI         | 05                      | FRAUD_FORCED_USER_IDENTITY_REVERIFICATION                    | id reset - 05              | standard   |
+            | suspendNoAction       | pswAndIdResetRequired | true         | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | TICF_CRI         | 06                      | FRAUD_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_REVERIFICATION | password and id reset - 06 | standard   |
+            | suspendNoAction       | unSuspendAction       | true         | AIS_ACCOUNT_UNSUSPENDED                            | TICF_CRI         | 02                      | FRAUD_UNSUSPEND_ACCOUNT                                      | unsuspend - 02             | standard   |
             # blocked account status to new intervention type
-            | block                 | unblock               | true         | AIS_ACCOUNT_UNBLOCKED                              | TICF_CRI         | 07                      | FRAUD_UNBLOCK_ACCOUNT                                        | unblock - 07               |
+            | block                 | unblock               | true         | AIS_ACCOUNT_UNBLOCKED                              | TICF_CRI         | 07                      | FRAUD_UNBLOCK_ACCOUNT                                        | unblock - 07               | standard   |
             # Id reset account status to new intervention type
-            | idResetRequired       | pswResetRequired      | true         | AIS_FORCED_USER_PASSWORD_RESET                     | TICF_CRI         | 04                      | FRAUD_FORCED_USER_PASSWORD_RESET                             | password reset - 04        |
-            | idResetRequired       | suspendNoAction       | true         | AIS_ACCOUNT_SUSPENDED                              | TICF_CRI         | 01                      | FRAUD_SUSPEND_ACCOUNT                                        | suspend - 01               |
-            | idResetRequired       | block                 | true         | AIS_ACCOUNT_BLOCKED                                | TICF_CRI         | 03                      | FRAUD_BLOCK_ACCOUNT                                          | block - 03                 |
-            | idResetRequired       | pswAndIdResetRequired | true         | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | TICF_CRI         | 06                      | FRAUD_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_REVERIFICATION | password and id reset - 06 |
-            | idResetRequired       | unSuspendAction       | true         | AIS_ACCOUNT_UNSUSPENDED                            | TICF_CRI         | 02                      | FRAUD_UNSUSPEND_ACCOUNT                                      | unsuspend - 02             |
+            | idResetRequired       | pswResetRequired      | true         | AIS_FORCED_USER_PASSWORD_RESET                     | TICF_CRI         | 04                      | FRAUD_FORCED_USER_PASSWORD_RESET                             | password reset - 04        | standard   |
+            | idResetRequired       | suspendNoAction       | true         | AIS_ACCOUNT_SUSPENDED                              | TICF_CRI         | 01                      | FRAUD_SUSPEND_ACCOUNT                                        | suspend - 01               | standard   |
+            | idResetRequired       | block                 | true         | AIS_ACCOUNT_BLOCKED                                | TICF_CRI         | 03                      | FRAUD_BLOCK_ACCOUNT                                          | block - 03                 | standard   |
+            | idResetRequired       | pswAndIdResetRequired | true         | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | TICF_CRI         | 06                      | FRAUD_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_REVERIFICATION | password and id reset - 06 | standard   |
+            | idResetRequired       | unSuspendAction       | true         | AIS_ACCOUNT_UNSUSPENDED                            | TICF_CRI         | 02                      | FRAUD_UNSUSPEND_ACCOUNT                                      | unsuspend - 02             | standard   |
             # password reset required account status to new intervention type
-            | pswAndIdResetRequired | pswResetRequired      | true         | AIS_FORCED_USER_PASSWORD_RESET                     | TICF_CRI         | 04                      | FRAUD_FORCED_USER_PASSWORD_RESET                             | password reset - 04        |
-            | pswAndIdResetRequired | suspendNoAction       | true         | AIS_ACCOUNT_SUSPENDED                              | TICF_CRI         | 01                      | FRAUD_SUSPEND_ACCOUNT                                        | suspend - 01               |
-            | pswAndIdResetRequired | block                 | true         | AIS_ACCOUNT_BLOCKED                                | TICF_CRI         | 03                      | FRAUD_BLOCK_ACCOUNT                                          | block - 03                 |
-            | pswAndIdResetRequired | idResetRequired       | true         | AIS_FORCED_USER_IDENTITY_VERIFY                    | TICF_CRI         | 05                      | FRAUD_FORCED_USER_IDENTITY_REVERIFICATION                    | id reset - 05              |
-            | pswAndIdResetRequired | unSuspendAction       | true         | AIS_ACCOUNT_UNSUSPENDED                            | TICF_CRI         | 02                      | FRAUD_UNSUSPEND_ACCOUNT                                      | unsuspend - 02             |
+            | pswAndIdResetRequired | pswResetRequired      | true         | AIS_FORCED_USER_PASSWORD_RESET                     | TICF_CRI         | 04                      | FRAUD_FORCED_USER_PASSWORD_RESET                             | password reset - 04        | standard   |
+            | pswAndIdResetRequired | suspendNoAction       | true         | AIS_ACCOUNT_SUSPENDED                              | TICF_CRI         | 01                      | FRAUD_SUSPEND_ACCOUNT                                        | suspend - 01               | standard   |
+            | pswAndIdResetRequired | block                 | true         | AIS_ACCOUNT_BLOCKED                                | TICF_CRI         | 03                      | FRAUD_BLOCK_ACCOUNT                                          | block - 03                 | standard   |
+            | pswAndIdResetRequired | idResetRequired       | true         | AIS_FORCED_USER_IDENTITY_VERIFY                    | TICF_CRI         | 05                      | FRAUD_FORCED_USER_IDENTITY_REVERIFICATION                    | id reset - 05              | standard   |
+            | pswAndIdResetRequired | unSuspendAction       | true         | AIS_ACCOUNT_UNSUSPENDED                            | TICF_CRI         | 02                      | FRAUD_UNSUSPEND_ACCOUNT                                      | unsuspend - 02             | standard   |
 
 
     Scenario Outline: Happy Path - Field Validation - Get Request to /ais/userId - Returns Expected Data for <aisEventType> with specific field validation
         Given I send a invalid request to sqs queue with no userId and <aisEventType>, <testUserId> data
         When I invoke apiGateway to retreive the status of the invalid userId with <historyValue>
-        Then I should receive the appropriate <interventionType> for the ais endpoint
+        Then I should receive the appropriate <interventionType> for the ais endpoint with the <auditLevel> returned
         Examples:
-            | aisEventType    | historyValue | interventionType    | testUserId |
-            | suspendNoAction | false        | AIS_NO_INTERVENTION |            |
+            | aisEventType    | historyValue | interventionType    | testUserId | auditLevel |
+            | suspendNoAction | false        | AIS_NO_INTERVENTION |            | standard   |

--- a/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
@@ -34,14 +34,13 @@ defineFeature(feature, (test) => {
     );
 
     then(
-      /^I expect the intervention to be (.*), with the following state settings (.*), (.*), (.*) and (.*) with the (.*) returned$/,
+      /^I expect the intervention to be (.*), with the following state settings (.*), (.*), (.*) and (.*)$/,
       async (
         interventionType: string,
         blockedState: string,
         suspendedState: string,
         resetPassword: string,
         reproveIdentity: string,
-        auditLevel: string,
       ) => {
         console.log(`Received`, { response });
         expect(response.intervention.description).toBe(interventionType);
@@ -49,7 +48,7 @@ defineFeature(feature, (test) => {
         expect(response.state.suspended).toBe(JSON.parse(suspendedState));
         expect(response.state.resetPassword).toBe(JSON.parse(resetPassword));
         expect(response.state.reproveIdentity).toBe(JSON.parse(reproveIdentity));
-        expect(response.auditLevel).toBe(auditLevel);
+        expect(response.auditLevel).toBe('standard');
       },
     );
   });
@@ -79,14 +78,13 @@ defineFeature(feature, (test) => {
     );
 
     then(
-      /^I expect the intervention to be (.*), with the following state settings (.*), (.*), (.*) and (.*) with the (.*) returned$/,
+      /^I expect the intervention to be (.*), with the following state settings (.*), (.*), (.*) and (.*)$/,
       async (
         interventionType: string,
         blockedState: string,
         suspendedState: string,
         resetPassword: string,
         reproveIdentity: string,
-        auditLevel: string,
       ) => {
         console.log(`Received`, { response });
         expect(response.intervention.description).toBe(interventionType);
@@ -94,7 +92,7 @@ defineFeature(feature, (test) => {
         expect(response.state.suspended).toBe(JSON.parse(suspendedState));
         expect(response.state.resetPassword).toBe(JSON.parse(resetPassword));
         expect(response.state.reproveIdentity).toBe(JSON.parse(reproveIdentity));
-        expect(response.auditLevel).toBe(auditLevel);
+        expect(response.auditLevel).toBe('standard');
       },
     );
   });
@@ -124,18 +122,17 @@ defineFeature(feature, (test) => {
     );
 
     then(
-      /^I expect the intervention to be (.*), with the following history values with (.*), (.*), (.*), (.*) with the (.*) returned$/,
+      /^I expect the intervention to be (.*), with the following history values with (.*), (.*), (.*), (.*)$/,
       async (
         interventionType: string,
         componentHistory: string,
         interventionCodeHistory: string,
         interventionHistory: string,
         reason: string,
-        auditLevel: string,
       ) => {
         console.log(`Received History`, response.intervention.history);
         expect(response.intervention.description).toBe(interventionType);
-        expect(response.auditLevel).toBe(auditLevel);
+        expect(response.auditLevel).toBe('standard');
         expect(response.history.at(-1).component).toBe(componentHistory);
         expect(response.history.at(-1).code).toBe(interventionCodeHistory);
         expect(response.history.at(-1).intervention).toBe(interventionHistory);
@@ -161,13 +158,10 @@ defineFeature(feature, (test) => {
       response = await invokeGetAccountState(testUserId, historyValue);
     });
 
-    then(
-      /^I should receive the appropriate (.*) for the ais endpoint with the (.*) returned$/,
-      async (interventionType, auditLevel) => {
-        console.log(`Received`, { response });
-        expect(response.intervention.description).toBe(interventionType);
-        expect(response.auditLevel).toBe(auditLevel);
-      },
-    );
+    then(/^I should receive the appropriate (.*) for the ais endpoint$/, async (interventionType) => {
+      console.log(`Received`, { response });
+      expect(response.intervention.description).toBe(interventionType);
+      expect(response.auditLevel).toBe('standard');
+    });
   });
 });

--- a/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
@@ -34,13 +34,14 @@ defineFeature(feature, (test) => {
     );
 
     then(
-      /^I expect the intervention to be (.*), with the following state settings (.*), (.*), (.*) and (.*)$/,
+      /^I expect the intervention to be (.*), with the following state settings (.*), (.*), (.*) and (.*) with the (.*) returned$/,
       async (
         interventionType: string,
         blockedState: string,
         suspendedState: string,
         resetPassword: string,
         reproveIdentity: string,
+        auditLevel: string,
       ) => {
         console.log(`Received`, { response });
         expect(response.intervention.description).toBe(interventionType);
@@ -48,6 +49,7 @@ defineFeature(feature, (test) => {
         expect(response.state.suspended).toBe(JSON.parse(suspendedState));
         expect(response.state.resetPassword).toBe(JSON.parse(resetPassword));
         expect(response.state.reproveIdentity).toBe(JSON.parse(reproveIdentity));
+        expect(response.auditLevel).toBe(auditLevel);
       },
     );
   });
@@ -77,13 +79,14 @@ defineFeature(feature, (test) => {
     );
 
     then(
-      /^I expect the intervention to be (.*), with the following state settings (.*), (.*), (.*) and (.*)$/,
+      /^I expect the intervention to be (.*), with the following state settings (.*), (.*), (.*) and (.*) with the (.*) returned$/,
       async (
         interventionType: string,
         blockedState: string,
         suspendedState: string,
         resetPassword: string,
         reproveIdentity: string,
+        auditLevel: string,
       ) => {
         console.log(`Received`, { response });
         expect(response.intervention.description).toBe(interventionType);
@@ -91,6 +94,7 @@ defineFeature(feature, (test) => {
         expect(response.state.suspended).toBe(JSON.parse(suspendedState));
         expect(response.state.resetPassword).toBe(JSON.parse(resetPassword));
         expect(response.state.reproveIdentity).toBe(JSON.parse(reproveIdentity));
+        expect(response.auditLevel).toBe(auditLevel);
       },
     );
   });
@@ -120,16 +124,18 @@ defineFeature(feature, (test) => {
     );
 
     then(
-      /^I expect the intervention to be (.*), with the following history values with (.*), (.*), (.*), (.*)$/,
+      /^I expect the intervention to be (.*), with the following history values with (.*), (.*), (.*), (.*) with the (.*) returned$/,
       async (
         interventionType: string,
         componentHistory: string,
         interventionCodeHistory: string,
         interventionHistory: string,
         reason: string,
+        auditLevel: string,
       ) => {
         console.log(`Received History`, response.intervention.history);
         expect(response.intervention.description).toBe(interventionType);
+        expect(response.auditLevel).toBe(auditLevel);
         expect(response.history.at(-1).component).toBe(componentHistory);
         expect(response.history.at(-1).code).toBe(interventionCodeHistory);
         expect(response.history.at(-1).intervention).toBe(interventionHistory);
@@ -155,9 +161,13 @@ defineFeature(feature, (test) => {
       response = await invokeGetAccountState(testUserId, historyValue);
     });
 
-    then(/^I should receive the appropriate (.*) for the ais endpoint$/, async (interventionType) => {
-      console.log(`Received`, { response });
-      expect(response.intervention.description).toBe(interventionType);
-    });
+    then(
+      /^I should receive the appropriate (.*) for the ais endpoint with the (.*) returned$/,
+      async (interventionType, auditLevel) => {
+        console.log(`Received`, { response });
+        expect(response.intervention.description).toBe(interventionType);
+        expect(response.auditLevel).toBe(auditLevel);
+      },
+    );
   });
 });


### PR DESCRIPTION
## Proposed changes
[ATB 1423](https://govukverify.atlassian.net/browse/ATB-1423)

### What changed
Added auditLevel field from intervention response as an example

### Why did it change
To validate the field in feature tests

## Testing
Passes all feature tests:

<img width="297" alt="Screenshot 2024-01-22 at 17 08 55" src="https://github.com/govuk-one-login/account-interventions-service/assets/130994595/cefdba19-e56d-474b-8178-206641faf262">

## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [x] Tested changes and included test evidence in the PR, if appropriate
- [ ] Included all required tags and other properties for any new resources in the SAM template
- [ ] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [ ] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [ ] Ensured that no log lines include PII or other sensitive data
- [ ] Implemented unit testing for any new logic implemented, if appropriate
- [x] Ensured that all commits in this PR are signed
- [ ] Ensured appropriate code coverage is maintained by unit tests
- [ ] Checked SonarCube and ensured no code smells were added
