### PR TITLE
ATB 1449 | Add new fields to ais-event.ts file for TxMA egress message for Fraud team

### DIFF
--- a/feature-tests/utils/ais-events.ts
+++ b/feature-tests/utils/ais-events.ts
@@ -5,6 +5,7 @@ interface Event {
   timestamp: number;
   event_timestamp_ms: number;
   event_name: string;
+  event_id: string;
   component_id: string;
   client_id?: string;
   user: {
@@ -26,6 +27,7 @@ export const aisEvents: {
     timestamp: seconds,
     event_timestamp_ms: ms,
     event_name: 'TICF_ACCOUNT_INTERVENTION',
+    event_id: '123',
     component_id: 'TICF_CRI',
     user: { user_id: 'urn:fdc:gov.uk:2022:USER_ONE' },
     extensions: {
@@ -43,6 +45,7 @@ export const aisEvents: {
     timestamp: seconds,
     event_timestamp_ms: ms,
     event_name: 'TICF_ACCOUNT_INTERVENTION',
+    event_id: '123',
     component_id: 'TICF_CRI',
     user: { user_id: 'urn:fdc:gov.uk:2022:USER_ONE' },
     extensions: {
@@ -60,6 +63,7 @@ export const aisEvents: {
     timestamp: seconds,
     event_timestamp_ms: ms,
     event_name: 'TICF_ACCOUNT_INTERVENTION',
+    event_id: '123',
     component_id: 'TICF_CRI',
     user: { user_id: 'urn:fdc:gov.uk:2022:USER_ONE' },
     extensions: {
@@ -77,6 +81,7 @@ export const aisEvents: {
     timestamp: seconds,
     event_timestamp_ms: ms,
     event_name: 'TICF_ACCOUNT_INTERVENTION',
+    event_id: '123',
     component_id: 'TICF_CRI',
     user: { user_id: 'urn:fdc:gov.uk:2022:USER_ONE' },
     extensions: {
@@ -94,6 +99,7 @@ export const aisEvents: {
     timestamp: seconds,
     event_timestamp_ms: ms,
     event_name: 'TICF_ACCOUNT_INTERVENTION',
+    event_id: '123',
     component_id: 'TICF_CRI',
     user: { user_id: 'urn:fdc:gov.uk:2022:USER_ONE' },
     extensions: {
@@ -111,6 +117,7 @@ export const aisEvents: {
     timestamp: seconds,
     event_timestamp_ms: ms,
     event_name: 'TICF_ACCOUNT_INTERVENTION',
+    event_id: '123',
     component_id: 'TICF_CRI',
     user: { user_id: 'urn:fdc:gov.uk:2022:USER_ONE' },
     extensions: {
@@ -128,6 +135,7 @@ export const aisEvents: {
     timestamp: seconds,
     event_timestamp_ms: ms,
     event_name: 'TICF_ACCOUNT_INTERVENTION',
+    event_id: '123',
     component_id: 'TICF_CRI',
     user: { user_id: 'urn:fdc:gov.uk:2022:USER_ONE' },
     extensions: {
@@ -143,6 +151,7 @@ export const aisEvents: {
 
   userActionIdResetSuccess: {
     event_name: 'IPV_IDENTITY_ISSUED',
+    event_id: '123',
     timestamp: seconds,
     event_timestamp_ms: ms,
     client_id: 'UNKNOWN',
@@ -165,6 +174,7 @@ export const aisEvents: {
 
   userActionPswResetSuccess: {
     event_name: 'AUTH_PASSWORD_RESET_SUCCESSFUL',
+    event_id: '123',
     timestamp: seconds,
     event_timestamp_ms: ms,
     client_id: 'UNKNOWN',

--- a/feature-tests/utils/ais-events.ts
+++ b/feature-tests/utils/ais-events.ts
@@ -32,6 +32,9 @@ export const aisEvents: {
       intervention: {
         intervention_code: '01',
         intervention_reason: 'suspend - 01',
+        originating_component_id: 'CMS',
+        originator_reference_id: '1234567',
+        requester_id: '1234567',
       },
     },
   },
@@ -46,6 +49,9 @@ export const aisEvents: {
       intervention: {
         intervention_code: '02',
         intervention_reason: 'unsuspend - 02',
+        originating_component_id: 'CMS',
+        originator_reference_id: '1234567',
+        requester_id: '1234567',
       },
     },
   },
@@ -60,6 +66,9 @@ export const aisEvents: {
       intervention: {
         intervention_code: '03',
         intervention_reason: 'block - 03',
+        originating_component_id: 'CMS',
+        originator_reference_id: '1234567',
+        requester_id: '1234567',
       },
     },
   },
@@ -74,6 +83,9 @@ export const aisEvents: {
       intervention: {
         intervention_code: '04',
         intervention_reason: 'password reset - 04',
+        originating_component_id: 'CMS',
+        originator_reference_id: '1234567',
+        requester_id: '1234567',
       },
     },
   },
@@ -88,6 +100,9 @@ export const aisEvents: {
       intervention: {
         intervention_code: '05',
         intervention_reason: 'id reset - 05',
+        originating_component_id: 'CMS',
+        originator_reference_id: '1234567',
+        requester_id: '1234567',
       },
     },
   },
@@ -102,6 +117,9 @@ export const aisEvents: {
       intervention: {
         intervention_code: '06',
         intervention_reason: 'password and id reset - 06',
+        originating_component_id: 'CMS',
+        originator_reference_id: '1234567',
+        requester_id: '1234567',
       },
     },
   },
@@ -116,6 +134,9 @@ export const aisEvents: {
       intervention: {
         intervention_code: '07',
         intervention_reason: 'unblock - 07',
+        originating_component_id: 'CMS',
+        originator_reference_id: '1234567',
+        requester_id: '1234567',
       },
     },
   },


### PR DESCRIPTION
## Proposed changes
[ATB-1449](https://govukverify.atlassian.net/browse/ATB-1449)

### What changed
As per ATB-1365, the following fields will need to be added to and validated against:

- originating_component_id
- originator_reference_id
- requester_id
- event_id

### Why did it change
To mirror events passed in so they can be correctly validated, mirrored against the JSON files passed in:
<img width="1134" alt="Screenshot 2024-01-25 at 15 20 38" src="https://github.com/govuk-one-login/account-interventions-service/assets/130994595/bc83e8c9-225a-4597-849d-dc30981c82e0">


## Testing
Passes tests locally:
<img width="317" alt="Screenshot 2024-01-25 at 14 37 07" src="https://github.com/govuk-one-login/account-interventions-service/assets/130994595/12121729-5efb-4317-b8e5-e4e7c1bb7732">

## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [x] Tested changes and included test evidence in the PR, if appropriate
- [ ] Included all required tags and other properties for any new resources in the SAM template
- [ ] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [ ] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [ ] Ensured that no log lines include PII or other sensitive data
- [ ] Implemented unit testing for any new logic implemented, if appropriate
- [x] Ensured that all commits in this PR are signed
- [ ] Ensured appropriate code coverage is maintained by unit tests
- [ ] Checked SonarCube and ensured no code smells were added


[ATB-1449]: https://govukverify.atlassian.net/browse/ATB-1449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ