### PR TITLE
ATB-1447 Remove history item if its age exceeds 2 years

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'unicorn/filename-case': ['error', { case: 'kebabCase' }],
     'unicorn/prevent-abbreviations': ['warn'],
     'unicorn/error-message': ['warn'],
+    'unicorn/no-array-reduce': ['off'],
     'unicorn/prefer-logical-operator-over-ternary': ['warn'],
     'unicorn/prefer-spread': ['warn'],
     'tsdoc/syntax': ['warn'],

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,3 +13,4 @@ process.env['TABLE_NAME'] = 'table_name';
 process.env['AWS_REGION'] = 'aws_region';
 process.env['DELETED_ACCOUNT_RETENTION_SECONDS'] = '12345';
 process.env['TXMA_QUEUE_URL'] = 'https://sqs.eu-west-2.amazonaws.com/111122223333/TxMAQueue';
+process.env['HISTORY_RETENTION_SECONDS'] = '63072000';

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "engines": {
     "node": ">=18"
   },
+  "type": "commonjs",
   "packageManager": "yarn@1.22.21",
   "scripts": {
     "test": "yarn test:unit",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "engines": {
     "node": ">=18"
   },
-  "type": "commonjs",
   "packageManager": "yarn@1.22.21",
   "scripts": {
     "test": "yarn test:unit",

--- a/src/commons/build-partial-update-state-command.ts
+++ b/src/commons/build-partial-update-state-command.ts
@@ -48,7 +48,7 @@ export const buildPartialUpdateAccountStateCommand = (
     baseUpdateItemCommandInput['UpdateExpression'] += ', #RIdA = :rida';
     baseUpdateItemCommandInput['ExpressionAttributeNames']['#H'] = 'history';
     baseUpdateItemCommandInput['ExpressionAttributeValues'][':h'] = {
-      L: extractValidHistoryItemIndices(historyList),
+      L: extractValidHistoryItems(historyList),
     };
     return baseUpdateItemCommandInput;
   }
@@ -61,7 +61,7 @@ export const buildPartialUpdateAccountStateCommand = (
     baseUpdateItemCommandInput['UpdateExpression'] += ', #RPswdA = :rpswda';
     baseUpdateItemCommandInput['ExpressionAttributeNames']['#H'] = 'history';
     baseUpdateItemCommandInput['ExpressionAttributeValues'][':h'] = {
-      L: extractValidHistoryItemIndices(historyList),
+      L: extractValidHistoryItems(historyList),
     };
     return baseUpdateItemCommandInput;
   }
@@ -79,7 +79,7 @@ export const buildPartialUpdateAccountStateCommand = (
   baseUpdateItemCommandInput['ExpressionAttributeNames']['#H'] = 'history';
   baseUpdateItemCommandInput['ExpressionAttributeValues'][':h'] = {
     L: [
-      ...extractValidHistoryItemIndices(historyList),
+      ...extractValidHistoryItems(historyList),
       { S: stringBuilder.getHistoryString(interventionEvent, eventTimestamp) },
     ],
   };
@@ -110,7 +110,7 @@ function buildRemoveExpression(finalState: StateDetails) {
   return ' REMOVE ' + itemsToRemove.join(', ');
 }
 
-function extractValidHistoryItemIndices(historyList: string[]) {
+function extractValidHistoryItems(historyList: string[]) {
   const historyStringBuilder = new HistoryStringBuilder();
   const listOfHistoryStringsToKeep: Array<{ S: string }> = [];
 

--- a/src/commons/build-partial-update-state-command.ts
+++ b/src/commons/build-partial-update-state-command.ts
@@ -110,19 +110,20 @@ function buildRemoveExpression(finalState: StateDetails) {
   return ' REMOVE ' + itemsToRemove.join(', ');
 }
 
+/**
+ * Helper function to determine which history items have not exceeded the retention period.
+ * @param historyList - list of history items
+ */
 function extractValidHistoryItems(historyList: string[]) {
   const historyStringBuilder = new HistoryStringBuilder();
-  const listOfHistoryStringsToKeep: Array<{ S: string }> = [];
+  const retentionPeriod = AppConfigService.getInstance().historyRetentionSeconds;
+  const currentTimeSeconds = getCurrentTimestamp().seconds;
 
-  for (const historyItem of historyList) {
+  return historyList.map((historyItem) => {
     const historyObject = historyStringBuilder.getHistoryObject(historyItem);
     const sendAtSeconds = Math.floor(new Date(historyObject.sentAt).getTime() / 1000);
-    const retentionPeriod = AppConfigService.getInstance().historyRetentionSeconds;
-    const currentTimeSeconds = getCurrentTimestamp().seconds;
     if (sendAtSeconds + retentionPeriod >= currentTimeSeconds) {
-      listOfHistoryStringsToKeep.push({ S: historyItem });
+      return { S: historyItem };
     }
-  }
-
-  return listOfHistoryStringsToKeep;
+  });
 }

--- a/src/commons/build-partial-update-state-command.ts
+++ b/src/commons/build-partial-update-state-command.ts
@@ -117,8 +117,7 @@ function buildRemoveExpression(finalState: StateDetails) {
 function extractValidHistoryItems(historyList: string[], currentTimestampMs: number) {
   const historyStringBuilder = new HistoryStringBuilder();
 
-  // eslint-disable-next-line unicorn/no-array-reduce
-  return historyList.reduce<Array<{ S: string }>>((validHistoryItems, historyItem) => {
+  return historyList.reduce((validHistoryItems: { S: string }[], historyItem: string) => {
     const historyObject = historyStringBuilder.getHistoryObject(historyItem);
     const sendAtMs = new Date(historyObject.sentAt).getTime();
     if (sendAtMs + AppConfigService.getInstance().historyRetentionSeconds * 1000 >= currentTimestampMs) {

--- a/src/commons/history-string-builder.ts
+++ b/src/commons/history-string-builder.ts
@@ -54,8 +54,8 @@ export class HistoryStringBuilder {
 
   /**
    * Method to get the history object and validates if it contains the correct amount of components.
-   * @param historyString - string passed in with seperators ('|') included. This will be
-   * recieved from DynamoDB.
+   * @param historyString - string passed in with separators ('|') included. This will be
+   * received from DynamoDB.
    * @returns - The history string transformed into an object.
    */
   public getHistoryObject(historyString: string): HistoryObject {
@@ -67,7 +67,7 @@ export class HistoryStringBuilder {
 
   /**
    * Method to take the history string and transform it into an object.
-   * @param array - Array of strings recieved from DynamoDB.
+   * @param array - Array of strings received from DynamoDB.
    * @returns - The string transformed into an object with the relevant parts.
    * Optional parts are left as an empty string ('')
    */

--- a/src/commons/test/build-partial-update-state-command.test.ts
+++ b/src/commons/test/build-partial-update-state-command.test.ts
@@ -8,9 +8,9 @@ jest.mock('../../commons/metrics');
 jest.mock('../../commons/get-current-timestamp', () => ({
   getCurrentTimestamp: jest.fn().mockImplementation(() => {
     return {
-      milliseconds: 1706544555234,
+      milliseconds: 1_706_544_555_234,
       isoString: 'today',
-      seconds: 1706544555,
+      seconds: 1_706_544_555,
     };
   }),
 }));
@@ -63,6 +63,7 @@ describe('build-partial-update-state-command', () => {
     const expectedOutput = {
       ExpressionAttributeNames: {
         '#B': 'blocked',
+        '#H': 'history',
         '#S': 'suspended',
         '#RP': 'resetPassword',
         '#RI': 'reproveIdentity',
@@ -71,6 +72,7 @@ describe('build-partial-update-state-command', () => {
       },
       ExpressionAttributeValues: {
         ':b': { BOOL: false },
+        ':h': { L: [] },
         ':s': { BOOL: false },
         ':rp': { BOOL: true },
         ':ri': { BOOL: true },
@@ -94,6 +96,7 @@ describe('build-partial-update-state-command', () => {
     const expectedOutput = {
       ExpressionAttributeNames: {
         '#B': 'blocked',
+        '#H': 'history',
         '#S': 'suspended',
         '#RP': 'resetPassword',
         '#RI': 'reproveIdentity',
@@ -102,6 +105,7 @@ describe('build-partial-update-state-command', () => {
       },
       ExpressionAttributeValues: {
         ':b': { BOOL: false },
+        ':h': { L: [] },
         ':s': { BOOL: false },
         ':rp': { BOOL: true },
         ':ri': { BOOL: true },
@@ -110,7 +114,7 @@ describe('build-partial-update-state-command', () => {
       },
       UpdateExpression: 'SET #B = :b, #S = :s, #RP = :rp, #RI = :ri, #UA = :ua, #RIdA = :rida',
     };
-    const command = buildPartialUpdateAccountStateCommand(state, userAction, 4444, resetPasswordEventBody,[]);
+    const command = buildPartialUpdateAccountStateCommand(state, userAction, 4444, resetPasswordEventBody, []);
     expect(command).toEqual(expectedOutput);
   });
 
@@ -142,12 +146,11 @@ describe('build-partial-update-state-command', () => {
         ':ua': { N: '4444' },
         ':sa': { N: '123456' },
         ':aa': { N: '4444' },
-        ':empty_list': { L: [] },
         ':h': { L: [{ S: '123456|TICF_CRI|01|reason|originating_component_id|originator_reference_id|requester_id' }] },
         ':int': { S: 'AIS_FORCED_USER_PASSWORD_RESET' },
       },
       UpdateExpression:
-        'SET #B = :b, #S = :s, #RP = :rp, #RI = :ri, #UA = :ua, #INT = :int, #SA = :sa, #AA = :aa, #H = list_append(if_not_exists(#H, :empty_list), :h) REMOVE resetPasswordAt',
+        'SET #B = :b, #S = :s, #RP = :rp, #RI = :ri, #UA = :ua, #INT = :int, #SA = :sa, #AA = :aa, #H = :h REMOVE resetPasswordAt',
     };
     const command = buildPartialUpdateAccountStateCommand(
       state,
@@ -187,12 +190,11 @@ describe('build-partial-update-state-command', () => {
         ':ua': { N: '4444' },
         ':sa': { N: '123456' },
         ':aa': { N: '4444' },
-        ':empty_list': { L: [] },
         ':h': { L: [{ S: '123456|TICF_CRI|01|reason|originating_component_id|originator_reference_id|requester_id' }] },
         ':int': { S: 'AIS_ACCOUNT_UNSUSPENDED' },
       },
       UpdateExpression:
-        'SET #B = :b, #S = :s, #RP = :rp, #RI = :ri, #UA = :ua, #INT = :int, #SA = :sa, #AA = :aa, #H = list_append(if_not_exists(#H, :empty_list), :h)',
+        'SET #B = :b, #S = :s, #RP = :rp, #RI = :ri, #UA = :ua, #INT = :int, #SA = :sa, #AA = :aa, #H = :h',
     };
     const command = buildPartialUpdateAccountStateCommand(
       state,
@@ -233,12 +235,11 @@ describe('build-partial-update-state-command', () => {
         ':ua': { N: '4444' },
         ':sa': { N: '123456' },
         ':aa': { N: '4444' },
-        ':empty_list': { L: [] },
         ':h': { L: [{ S: '123456|TICF_CRI|01|reason|originating_component_id|originator_reference_id|requester_id' }] },
         ':int': { S: 'AIS_FORCED_USER_IDENTITY_VERIFY' },
       },
       UpdateExpression:
-        'SET #B = :b, #S = :s, #RP = :rp, #RI = :ri, #UA = :ua, #INT = :int, #SA = :sa, #AA = :aa, #H = list_append(if_not_exists(#H, :empty_list), :h) REMOVE reprovedIdentityAt',
+        'SET #B = :b, #S = :s, #RP = :rp, #RI = :ri, #UA = :ua, #INT = :int, #SA = :sa, #AA = :aa, #H = :h REMOVE reprovedIdentityAt',
     };
     const command = buildPartialUpdateAccountStateCommand(
       state,
@@ -278,14 +279,13 @@ describe('build-partial-update-state-command', () => {
         ':ua': { N: '4444' },
         ':sa': { N: '1000000' },
         ':aa': { N: '4444' },
-        ':empty_list': { L: [] },
         ':h': {
           L: [{ S: '1000000|TICF_CRI|01|reason|originating_component_id|originator_reference_id|requester_id' }],
         },
         ':int': { S: 'AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY' },
       },
       UpdateExpression:
-        'SET #B = :b, #S = :s, #RP = :rp, #RI = :ri, #UA = :ua, #INT = :int, #SA = :sa, #AA = :aa, #H = list_append(if_not_exists(#H, :empty_list), :h) REMOVE history[0], resetPasswordAt, reprovedIdentityAt',
+        'SET #B = :b, #S = :s, #RP = :rp, #RI = :ri, #UA = :ua, #INT = :int, #SA = :sa, #AA = :aa, #H = :h REMOVE resetPasswordAt, reprovedIdentityAt',
     };
     const interventionEventBodyNoMsTimestamp = {
       ...interventionEventBody,
@@ -296,9 +296,15 @@ describe('build-partial-update-state-command', () => {
       intervention,
       4444,
       interventionEventBodyNoMsTimestamp as unknown as TxMAIngressEvent,
-      ['1611937409000|TICF_CRI|02|reason|originating_component_id|originator_reference_id|requester_id'],
+      ['1706544554234|TICF_CRI|02|reason|originating_component_id|originator_reference_id|requester_id'],
       AISInterventionTypes.AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY,
     );
+    expectedOutput.ExpressionAttributeValues[':h'] = {
+      L: [
+        { S: '1706544554234|TICF_CRI|02|reason|originating_component_id|originator_reference_id|requester_id' },
+        { S: '1000000|TICF_CRI|01|reason|originating_component_id|originator_reference_id|requester_id' },
+      ],
+    };
     expect(command).toEqual(expectedOutput);
   });
 

--- a/src/commons/test/build-partial-update-state-command.test.ts
+++ b/src/commons/test/build-partial-update-state-command.test.ts
@@ -8,9 +8,9 @@ jest.mock('../../commons/metrics');
 jest.mock('../../commons/get-current-timestamp', () => ({
   getCurrentTimestamp: jest.fn().mockImplementation(() => {
     return {
-      milliseconds: 1_234_567_890,
+      milliseconds: 1706544555234,
       isoString: 'today',
-      seconds: 1_234_567,
+      seconds: 1706544555,
     };
   }),
 }));
@@ -79,7 +79,7 @@ describe('build-partial-update-state-command', () => {
       },
       UpdateExpression: 'SET #B = :b, #S = :s, #RP = :rp, #RI = :ri, #UA = :ua, #RPswdA = :rpswda',
     };
-    const command = buildPartialUpdateAccountStateCommand(state, userAction, 4444, resetPasswordEventBody);
+    const command = buildPartialUpdateAccountStateCommand(state, userAction, 4444, resetPasswordEventBody, []);
     expect(command).toEqual(expectedOutput);
   });
 
@@ -110,7 +110,7 @@ describe('build-partial-update-state-command', () => {
       },
       UpdateExpression: 'SET #B = :b, #S = :s, #RP = :rp, #RI = :ri, #UA = :ua, #RIdA = :rida',
     };
-    const command = buildPartialUpdateAccountStateCommand(state, userAction, 4444, resetPasswordEventBody);
+    const command = buildPartialUpdateAccountStateCommand(state, userAction, 4444, resetPasswordEventBody,[]);
     expect(command).toEqual(expectedOutput);
   });
 
@@ -154,6 +154,7 @@ describe('build-partial-update-state-command', () => {
       intervention,
       4444,
       interventionEventBody,
+      [],
       AISInterventionTypes.AIS_FORCED_USER_PASSWORD_RESET,
     );
     expect(command).toEqual(expectedOutput);
@@ -198,6 +199,7 @@ describe('build-partial-update-state-command', () => {
       intervention,
       4444,
       interventionEventBody,
+      [],
       AISInterventionTypes.AIS_ACCOUNT_UNSUSPENDED,
     );
     expect(command).toEqual(expectedOutput);
@@ -243,6 +245,7 @@ describe('build-partial-update-state-command', () => {
       intervention,
       4444,
       interventionEventBody,
+      [],
       AISInterventionTypes.AIS_FORCED_USER_IDENTITY_VERIFY,
     );
     expect(command).toEqual(expectedOutput);
@@ -282,7 +285,7 @@ describe('build-partial-update-state-command', () => {
         ':int': { S: 'AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY' },
       },
       UpdateExpression:
-        'SET #B = :b, #S = :s, #RP = :rp, #RI = :ri, #UA = :ua, #INT = :int, #SA = :sa, #AA = :aa, #H = list_append(if_not_exists(#H, :empty_list), :h) REMOVE resetPasswordAt, reprovedIdentityAt',
+        'SET #B = :b, #S = :s, #RP = :rp, #RI = :ri, #UA = :ua, #INT = :int, #SA = :sa, #AA = :aa, #H = list_append(if_not_exists(#H, :empty_list), :h) REMOVE history[0], resetPasswordAt, reprovedIdentityAt',
     };
     const interventionEventBodyNoMsTimestamp = {
       ...interventionEventBody,
@@ -293,6 +296,7 @@ describe('build-partial-update-state-command', () => {
       intervention,
       4444,
       interventionEventBodyNoMsTimestamp as unknown as TxMAIngressEvent,
+      ['1611937409000|TICF_CRI|02|reason|originating_component_id|originator_reference_id|requester_id'],
       AISInterventionTypes.AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY,
     );
     expect(command).toEqual(expectedOutput);
@@ -306,7 +310,7 @@ describe('build-partial-update-state-command', () => {
       reproveIdentity: true,
     };
     const intervention = EventsEnum.FRAUD_BLOCK_ACCOUNT;
-    expect(() => buildPartialUpdateAccountStateCommand(state, intervention, 4444, interventionEventBody)).toThrow(
+    expect(() => buildPartialUpdateAccountStateCommand(state, intervention, 4444, interventionEventBody, [])).toThrow(
       new Error('The intervention received did not have an interventionName field.'),
     );
     expect(logAndPublishMetric).toHaveBeenLastCalledWith(MetricNames.INTERVENTION_DID_NOT_HAVE_NAME_IN_CURRENT_CONFIG);

--- a/src/data-types/interfaces.ts
+++ b/src/data-types/interfaces.ts
@@ -11,6 +11,7 @@ export interface DynamoDBStateResult extends StateDetails {
   sentAt?: number;
   appliedAt?: number;
   isAccountDeleted?: boolean;
+  history: string[];
 }
 
 export interface FullAccountInformation {

--- a/src/handlers/interventions-processor-handler.ts
+++ b/src/handlers/interventions-processor-handler.ts
@@ -103,6 +103,7 @@ async function processSQSRecord(record: SQSRecord) {
     eventName,
     currentTimestamp.milliseconds,
     recordBody,
+    itemFromDB?.history ?? [],
     statusResult.interventionName,
   );
   logger.debug(`${LOGS_PREFIX_SENSITIVE_INFO} Updating user status`, { userId, partialCommandInput });

--- a/src/handlers/status-retriever-handler.ts
+++ b/src/handlers/status-retriever-handler.ts
@@ -84,7 +84,7 @@ function validateEvent(userId: string) {
 }
 
 /**
- * Function to transform the response from DynamobDB into an object.
+ * Function to transform the response from DynamoDB into an object.
  * @param item - Response from DynamoDB
  * @returns - An object with all the required fields for the handler response. Creates a default object if any fields are undefined.
  * Updates timestamps to now if they are returned as null.

--- a/src/infra/main/template.yaml
+++ b/src/infra/main/template.yaml
@@ -194,6 +194,7 @@ Resources:
           TABLE_NAME:
             Fn::ImportValue: !Sub "${CoreStackName}-AccountStatusTableName"
           TXMA_QUEUE_URL: !Ref TxMAEgressQueue
+          HISTORY_RETENTION_SECONDS: 63072000
       Tags:
         Product: !Ref ProductTagValue
         System: !Ref SystemTagValue

--- a/src/services/app-config-service.ts
+++ b/src/services/app-config-service.ts
@@ -41,6 +41,10 @@ export class AppConfigService {
     return this.validateIsHTTPSUrl('TXMA_QUEUE_URL');
   }
 
+  public get historyRetentionSeconds(): number {
+    return this.validateNumberEnvVars('HISTORY_RETENTION_SECONDS');
+  }
+
   /**
    * A method for validating environment variables.
    *

--- a/src/services/dynamo-database-service.ts
+++ b/src/services/dynamo-database-service.ts
@@ -43,7 +43,7 @@ export class DynamoDatabaseService {
   public async getAccountStateInformation(userId: string): Promise<DynamoDBStateResult | undefined> {
     const parameters = this.getInputParameterForDatabaseQuery(userId);
     parameters.ProjectionExpression =
-      'blocked, suspended, resetPassword, reproveIdentity, sentAt, appliedAt, isAccountDeleted';
+      'blocked, suspended, resetPassword, reproveIdentity, sentAt, appliedAt, isAccountDeleted, history';
     const response: QueryCommandOutput = await this.dynamoClient.send(new QueryCommand(parameters));
     return this.validateQueryResponse<DynamoDBStateResult>(response);
   }

--- a/src/services/test/app-config-service.test.ts
+++ b/src/services/test/app-config-service.test.ts
@@ -77,6 +77,7 @@ describe('AppConfigService', () => {
     expect(appConfig.metricServiceName).toEqual('test');
     expect(appConfig.maxRetentionSeconds).toEqual(12_345);
     expect(appConfig.txmaEgressQueueUrl).toEqual('https://sqs.eu-west-2.amazonaws.com/111122223333/TxMAQueue');
+    expect(appConfig.historyRetentionSeconds).toEqual(63072000);
   });
 
   it('should throw an error if the environmental variable is not a number', () => {

--- a/src/services/test/dynamo-database-service.test.ts
+++ b/src/services/test/dynamo-database-service.test.ts
@@ -96,7 +96,7 @@ describe('Dynamo DB Service', () => {
       KeyConditionExpression: '#pk = :id_value',
       ExpressionAttributeNames: { '#pk': 'pk' },
       ExpressionAttributeValues: { ':id_value': { S: 'abc' } },
-      ProjectionExpression: 'blocked, suspended, resetPassword, reproveIdentity, sentAt, appliedAt, isAccountDeleted',
+      ProjectionExpression: 'blocked, suspended, resetPassword, reproveIdentity, sentAt, appliedAt, isAccountDeleted, history',
     };
     queryCommandMock.resolvesOnce({ Items: items });
     await new DynamoDatabaseService('abc').getAccountStateInformation('abc');

--- a/src/services/test/validate-event.test.ts
+++ b/src/services/test/validate-event.test.ts
@@ -36,6 +36,7 @@ const dynamoDBResult: DynamoDBStateResult = {
   sentAt: timestamp.milliseconds - 5000,
   appliedAt: timestamp.milliseconds - 5000,
   isAccountDeleted: false,
+  history: []
 };
 describe('event-validation', () => {
   afterEach(() => {


### PR DESCRIPTION
## Proposed changes

### What changed
1. Added env var to keep retention period
2. Because we're not allowed to do a SET and a REMOVE on the same attribute in one operation, it would have been inefficient time-wise to perform and wait for 2 dynamodb updates, hence the reason why I opted to compute the history list and replace it

### Why did it change
To adhere with the DI data retention period

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- List any related PRs -->
- [ATB-1447](https://govukverify.atlassian.net/browse/ATB-1447)

## Testing
1. new env var present
<img width="677" alt="Screenshot 2024-01-29 at 18 56 10" src="https://github.com/govuk-one-login/account-interventions-service/assets/124037159/7483b377-25fc-4c04-9362-9460a20cfc2c">

2. For testing purposes, set it to 86400 to make sure we have expired items
<img width="677" alt="Screenshot 2024-01-29 at 18 57 14" src="https://github.com/govuk-one-login/account-interventions-service/assets/124037159/2e560697-f385-4f70-b0b5-a9ab4059dd10">

3. All items in the history that will be removed:
![Screenshot 2024-01-29 at 18 58 02](https://github.com/govuk-one-login/account-interventions-service/assets/124037159/62145b02-0a96-4172-b624-a4be920bb8c2)

4. Event sent:
![Screenshot 2024-01-29 at 19 04 57](https://github.com/govuk-one-login/account-interventions-service/assets/124037159/f227e877-d775-47cb-aae3-16d0da12941c)

5. Results:
![Screenshot 2024-01-29 at 23 50 23](https://github.com/govuk-one-login/account-interventions-service/assets/124037159/e4d1b903-174f-4a14-bad4-8d821441e7f8)


## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [x] Tested changes and included test evidence in the PR, if appropriate
- [x] Included all required tags and other properties for any new resources in the SAM template
- [x] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [x] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [x] Ensured that no log lines include PII or other sensitive data
- [x] Implemented unit testing for any new logic implemented, if appropriate
- [x] Ensured that all commits in this PR are signed
- [x] Ensured appropriate code coverage is maintained by unit tests
- [x] Checked SonarCube and ensured no code smells were added


[ATB-1447]: https://govukverify.atlassian.net/browse/ATB-1447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ