### PR TITLE
ATB-1476: Update feature file steps to match step defs

### DIFF
--- a/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-HappyPath.feature
+++ b/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-HappyPath.feature
@@ -20,7 +20,7 @@ Feature: Invoke-APIGateway-HappyPath.feature
     @regression
     Scenario Outline: Happy Path - Get Request to /ais/userId - allowable Transition from <originalAisEventType> to <allowableAisEventType> - Return expected data
         Given I send an <allowableAisEventType> intervention message to the TxMA ingress SQS queue for a Account in <originalAisEventType> state
-        When I invoke the API to retrieve the intervention status of the user's account. With history <historyValue>
+        When I invoke the API to retrieve the allowable intervention status of the user's account. With history <historyValue>
         Then I expect the response with all the valid state fields for the <allowableAisEventType>
         Examples:
             | originalAisEventType  | allowableAisEventType | historyValue |
@@ -58,8 +58,8 @@ Feature: Invoke-APIGateway-HappyPath.feature
     @regression
     Scenario Outline: Happy Path - Get Request to /ais/userId - non-allowable Transition from <originalAisEventType> to <nonAllowableAisEventType> - Returns expected data
         Given I send an <nonAllowableAisEventType> intervention message to the TxMA ingress SQS queue for a Account in <originalAisEventType> state
-        When I invoke the API to retrieve the intervention status of the user's account. With history <historyValue>
-        Then I expect the response with all the valid state fields for the <originalAisEventType>
+        When I invoke the API to retrieve the non-allowable intervention status of the user's account. With history <historyValue>
+        Then I expect the response with all the state fields for the <originalAisEventType>
         Examples:
             | originalAisEventType  | nonAllowableAisEventType  | historyValue |
             # password reset required account status to new intervention type
@@ -87,7 +87,7 @@ Feature: Invoke-APIGateway-HappyPath.feature
     @regression
     Scenario Outline: Happy Path - Get Request to /ais/userId - non-allowable Transition from <originalAisEventType> to <nonAllowableAisEventType> - Get Request to /ais/userId - Returns expected data with diff flags
         Given I send an <nonAllowableAisEventType> intervention message to the TxMA ingress SQS queue for a Account in <originalAisEventType> state
-        When I invoke the API to retrieve the intervention status of the user's account. With history <historyValue>
+        When I invoke the API to retrieve the intervention status of the user's account with history <historyValue>
         Then I expect response with valid fields for <interventionType> with state flags as <blocked>, <suspended>, <resetPassword> and <reproveIdentity>
         Examples:
             | originalAisEventType  | nonAllowableAisEventType  | historyValue | interventionType                                                 | blocked | suspended | resetPassword | reproveIdentity |
@@ -99,7 +99,7 @@ Feature: Invoke-APIGateway-HappyPath.feature
     @regression
     Scenario Outline: Happy Path - Get Request to /ais/userId - allowable Transition from <originalAisEventType> to <allowableAisEventType> - Get Request to /ais/userId - Returns expected data with history values
         Given I send an updated request to the SQS queue with intervention data of the type <aisEventType> from <originalAisEventType>
-        When I invoke the API to retrieve the intervention status of the user's account with <historyValue>
+        When I invoke the API to retrieve the allowable intervention status of the user's account with <historyValue>
         Then I expect the response with history values for the <aisEventType>
         Examples:
             | originalAisEventType  | aisEventType          | historyValue |

--- a/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-HappyPath.feature
+++ b/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-HappyPath.feature
@@ -19,7 +19,7 @@ Feature: Invoke-APIGateway-HappyPath.feature
 
     @regression
     Scenario Outline: Happy Path - Get Request to /ais/userId - allowable Transition from <originalAisEventType> to <allowableAisEventType> - Return expected data
-        Given I send an <allowableAisEventType> intervention message to the TxMA ingress SQS queue for a Account in <originalAisEventType> state
+        Given I send an <allowableAisEventType> allowable intervention event message to the TxMA ingress SQS queue for a Account in <originalAisEventType> state
         When I invoke the API to retrieve the allowable intervention status of the user's account. With history <historyValue>
         Then I expect the response with all the valid state fields for the <allowableAisEventType>
         Examples:
@@ -57,7 +57,7 @@ Feature: Invoke-APIGateway-HappyPath.feature
 
     @regression
     Scenario Outline: Happy Path - Get Request to /ais/userId - non-allowable Transition from <originalAisEventType> to <nonAllowableAisEventType> - Returns expected data
-        Given I send a <nonAllowableAisEventType> intervention message to the TxMA ingress SQS queue for a Account in <originalAisEventType> state
+        Given I send an <nonAllowableAisEventType> non-allowable intervention event message to the TxMA ingress SQS queue for a Account in <originalAisEventType> state
         When I invoke the API to retrieve the non-allowable intervention status of the user's account. With history <historyValue>
         Then I expect the response with all the state fields for the <originalAisEventType>
         Examples:
@@ -85,8 +85,8 @@ Feature: Invoke-APIGateway-HappyPath.feature
             | block                 | unSuspendAction           | false        |
 
     @regression
-    Scenario Outline: Happy Path - Get Request to /ais/userId - non-allowable Transition from <originalAisEventType> to <nonAllowableAisEventType> - Get Request to /ais/userId - Returns expected data with diff flags
-        Given I send <nonAllowableAisEventType> intervention message to the TxMA ingress SQS queue for a Account in <originalAisEventType> state
+    Scenario Outline: Get Request to /ais/userId - Password and Id non-allowable Transition from <originalAisEventType> to <nonAllowableAisEventType> - Returns expected data
+        Given I send an <nonAllowableAisEventType> non-allowable event type password or id Reset intervention message to the TxMA ingress SQS queue for a Account in <originalAisEventType> state
         When I invoke the API to retrieve the intervention status of the user's account with history <historyValue>
         Then I expect response with valid fields for <interventionType> with state flags as <blocked>, <suspended>, <resetPassword> and <reproveIdentity>
         Examples:

--- a/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-HappyPath.feature
+++ b/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-HappyPath.feature
@@ -57,7 +57,7 @@ Feature: Invoke-APIGateway-HappyPath.feature
 
     @regression
     Scenario Outline: Happy Path - Get Request to /ais/userId - non-allowable Transition from <originalAisEventType> to <nonAllowableAisEventType> - Returns expected data
-        Given I send an <nonAllowableAisEventType> intervention message to the TxMA ingress SQS queue for a Account in <originalAisEventType> state
+        Given I send a <nonAllowableAisEventType> intervention message to the TxMA ingress SQS queue for a Account in <originalAisEventType> state
         When I invoke the API to retrieve the non-allowable intervention status of the user's account. With history <historyValue>
         Then I expect the response with all the state fields for the <originalAisEventType>
         Examples:
@@ -86,7 +86,7 @@ Feature: Invoke-APIGateway-HappyPath.feature
 
     @regression
     Scenario Outline: Happy Path - Get Request to /ais/userId - non-allowable Transition from <originalAisEventType> to <nonAllowableAisEventType> - Get Request to /ais/userId - Returns expected data with diff flags
-        Given I send an <nonAllowableAisEventType> intervention message to the TxMA ingress SQS queue for a Account in <originalAisEventType> state
+        Given I send <nonAllowableAisEventType> intervention message to the TxMA ingress SQS queue for a Account in <originalAisEventType> state
         When I invoke the API to retrieve the intervention status of the user's account with history <historyValue>
         Then I expect response with valid fields for <interventionType> with state flags as <blocked>, <suspended>, <resetPassword> and <reproveIdentity>
         Examples:

--- a/feature-tests/tests/resources/features/aisGET/InvokeMultipleUsers-HappyPath.feature
+++ b/feature-tests/tests/resources/features/aisGET/InvokeMultipleUsers-HappyPath.feature
@@ -1,6 +1,6 @@
 Feature: Invoke-MultipleUsers-HappyPath.feature
 
-    @txma
+    @txma @regression
     Scenario Outline: Happy Path - create multiple users - Returns Expected Data for <aisEventType>
         Given I invoke an API to retrieve the <aisEventType> status to the <numberOfusers> accounts. With history <historyValue>
         And I update the Id reset flag to TRUE

--- a/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
@@ -70,7 +70,7 @@ defineFeature(feature, (test) => {
     );
 
     when(
-      /^I invoke the API to retrieve the intervention status of the user's account. With history (.*)$/,
+      /^I invoke the API to retrieve the allowable intervention status of the user's account. With history (.*)$/,
       async (historyValue) => {
         await timeDelayForTestEnvironment(500);
         response = await invokeGetAccountState(testUserId, historyValue);
@@ -108,7 +108,7 @@ defineFeature(feature, (test) => {
     );
 
     when(
-      /^I invoke the API to retrieve the intervention status of the user's account. With history (.*)$/,
+      /^I invoke the API to retrieve the non-allowable intervention status of the user's account. With history (.*)$/,
       async (historyValue) => {
         await timeDelayForTestEnvironment(500);
         response = await invokeGetAccountState(testUserId, historyValue);
@@ -116,7 +116,7 @@ defineFeature(feature, (test) => {
     );
 
     then(
-      /^I expect the response with all the valid state fields for the (.*)$/,
+      /^I expect the response with all the state fields for the (.*)$/,
       async (originalAisEventType: keyof typeof aisEventResponse) => {
         console.log(`Received`, { response });
         expect(response.intervention.description).toBe(aisEventResponse[originalAisEventType].description);
@@ -146,7 +146,7 @@ defineFeature(feature, (test) => {
     );
 
     when(
-      /^I invoke the API to retrieve the intervention status of the user's account. With history (.*)$/,
+      /^I invoke the API to retrieve the intervention status of the user's account with history (.*)$/,
       async (historyValue) => {
         await timeDelayForTestEnvironment(500);
         response = await invokeGetAccountState(testUserId, historyValue);
@@ -190,7 +190,7 @@ defineFeature(feature, (test) => {
     );
 
     when(
-      /^I invoke the API to retrieve the intervention status of the user's account with (.*)$/,
+      /^I invoke the API to retrieve the allowable intervention status of the user's account with (.*)$/,
       async (historyValue) => {
         await timeDelayForTestEnvironment(500);
         response = await invokeGetAccountState(testUserId, historyValue);

--- a/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
@@ -97,7 +97,7 @@ defineFeature(feature, (test) => {
     then,
   }) => {
     given(
-      /^I send an (.*) intervention message to the TxMA ingress SQS queue for a Account in (.*) state$/,
+      /^I send a (.*) intervention message to the TxMA ingress SQS queue for a Account in (.*) state$/,
       async (nonAllowableAisEventType, originalAisEventType) => {
         console.log('sending first message to put the user in : ' + originalAisEventType);
         await sendSQSEvent(testUserId, originalAisEventType);
@@ -135,7 +135,7 @@ defineFeature(feature, (test) => {
     then,
   }) => {
     given(
-      /^I send an (.*) intervention message to the TxMA ingress SQS queue for a Account in (.*) state$/,
+      /^I send (.*) intervention message to the TxMA ingress SQS queue for a Account in (.*) state$/,
       async (nonAllowableAisEventType, originalAisEventType) => {
         console.log('sending first message to put the user in : ' + originalAisEventType);
         await sendSQSEvent(testUserId, originalAisEventType);

--- a/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
@@ -59,7 +59,7 @@ defineFeature(feature, (test) => {
     then,
   }) => {
     given(
-      /^I send an (.*) intervention message to the TxMA ingress SQS queue for a Account in (.*) state$/,
+      /^I send an (.*) allowable intervention event message to the TxMA ingress SQS queue for a Account in (.*) state$/,
       async (allowableAisEventType, originalAisEventType) => {
         console.log('sending first message to put the user in : ' + originalAisEventType);
         await sendSQSEvent(testUserId, originalAisEventType);
@@ -97,7 +97,7 @@ defineFeature(feature, (test) => {
     then,
   }) => {
     given(
-      /^I send a (.*) intervention message to the TxMA ingress SQS queue for a Account in (.*) state$/,
+      /^I send an (.*) non-allowable intervention event message to the TxMA ingress SQS queue for a Account in (.*) state$/,
       async (nonAllowableAisEventType, originalAisEventType) => {
         console.log('sending first message to put the user in : ' + originalAisEventType);
         await sendSQSEvent(testUserId, originalAisEventType);
@@ -129,13 +129,13 @@ defineFeature(feature, (test) => {
     );
   });
 
-  test('Happy Path - Get Request to /ais/userId - non-allowable Transition from <originalAisEventType> to <nonAllowableAisEventType> - Get Request to /ais/userId - Returns expected data with diff flags', ({
+  test('Get Request to /ais/userId - Password and Id non-allowable Transition from <originalAisEventType> to <nonAllowableAisEventType> - Returns expected data', ({
     given,
     when,
     then,
   }) => {
     given(
-      /^I send (.*) intervention message to the TxMA ingress SQS queue for a Account in (.*) state$/,
+      /^I send an (.*) non-allowable event type password or id Reset intervention message to the TxMA ingress SQS queue for a Account in (.*) state$/,
       async (nonAllowableAisEventType, originalAisEventType) => {
         console.log('sending first message to put the user in : ' + originalAisEventType);
         await sendSQSEvent(testUserId, originalAisEventType);


### PR DESCRIPTION
## Proposed changes
<!-- Include the Jira ticket number in square brackets as prefix, eg `ATB-1476: Update feature file steps to match step defs` -->

### What changed
<!-- Describe the changes in detail - the "what"-->

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- List any related PRs -->
- [ATB-1476](https://govukverify.atlassian.net/browse/ATB-1476)

## Testing
<img width="308" alt="Screenshot 2024-01-26 at 14 03 46" src="https://github.com/govuk-one-login/account-interventions-service/assets/111756919/f56b9df9-51c9-46bf-87c8-c22c9d5210a6">

<!-- Please give an overview of how the changes were tested -->
<!-- Please specify if changes were tested locally and how, include evidence where relevant -->
<!-- Please specify if changes were deployed and tested in the AWS Account and how, include evidence where relevant -->

## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [x] Tested changes and included test evidence in the PR, if appropriate
- [ ] Included all required tags and other properties for any new resources in the SAM template
- [ ] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [ ] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [ ] Ensured that no log lines include PII or other sensitive data
- [ ] Implemented unit testing for any new logic implemented, if appropriate
- [ ] Ensured that all commits in this PR are signed
- [ ] Ensured appropriate code coverage is maintained by unit tests
- [ ] Checked SonarCube and ensured no code smells were added


[ATB-1476]: https://govukverify.atlassian.net/browse/ATB-1476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ