### PR TITLE
ATB-1478: TxMA Egress Messages needs to include all `intervention` attributes in outgoing messages

### DIFF
--- a/src/data-types/interfaces.ts
+++ b/src/data-types/interfaces.ts
@@ -69,6 +69,8 @@ export interface TxMAEgressBasicExtensions {
   trigger_event_id: string;
   trigger_event: string;
   intervention_code: string | undefined;
+  [key: string]: unknown;
+  [key: number]: unknown;
 }
 export interface TxMAIngressEvent {
   event_name: TriggerEventsEnum;
@@ -98,6 +100,8 @@ interface Intervention {
   originating_component_id?: string;
   originator_reference_id?: string;
   audit_level?: string;
+  [key: string]: unknown;
+  [key: number]: unknown;
 }
 
 export interface DeleteStatusUpdateSNSMessage {

--- a/src/data-types/interfaces.ts
+++ b/src/data-types/interfaces.ts
@@ -68,7 +68,7 @@ export interface TxMAEgressExtensions extends TxMAEgressBasicExtensions {
 export interface TxMAEgressBasicExtensions {
   trigger_event_id: string;
   trigger_event: string;
-  intervention_code: string | undefined;
+  intervention_code?: string;
   [key: string | number]: unknown;
 }
 export interface TxMAIngressEvent {

--- a/src/data-types/interfaces.ts
+++ b/src/data-types/interfaces.ts
@@ -99,8 +99,7 @@ interface Intervention {
   originating_component_id?: string;
   originator_reference_id?: string;
   audit_level?: string;
-  [key: string]: unknown;
-  [key: number]: unknown;
+  [key: string | number]: unknown;
 }
 
 export interface DeleteStatusUpdateSNSMessage {

--- a/src/data-types/interfaces.ts
+++ b/src/data-types/interfaces.ts
@@ -69,8 +69,7 @@ export interface TxMAEgressBasicExtensions {
   trigger_event_id: string;
   trigger_event: string;
   intervention_code: string | undefined;
-  [key: string]: unknown;
-  [key: number]: unknown;
+  [key: string | number]: unknown;
 }
 export interface TxMAIngressEvent {
   event_name: TriggerEventsEnum;

--- a/src/services/send-audit-events.ts
+++ b/src/services/send-audit-events.ts
@@ -94,7 +94,6 @@ function buildExtensions(
     return {
       trigger_event: txMAIngressEvent.event_name,
       trigger_event_id: txMAIngressEvent.event_id ?? 'UNKNOWN',
-      intervention_code: txMAIngressEvent.extensions?.intervention?.intervention_code,
       ...txMAIngressEvent.extensions?.intervention,
       description: userLedActionList.includes(ingressEventName)
         ? 'USER_LED_ACTION'
@@ -108,7 +107,7 @@ function buildExtensions(
   return {
     trigger_event: txMAIngressEvent.event_name,
     trigger_event_id: txMAIngressEvent.event_id ?? 'UNKNOWN',
-    intervention_code: txMAIngressEvent.extensions?.intervention?.intervention_code,
+    ...txMAIngressEvent.extensions?.intervention,
   };
 }
 

--- a/src/services/send-audit-events.ts
+++ b/src/services/send-audit-events.ts
@@ -95,6 +95,7 @@ function buildExtensions(
       trigger_event: txMAIngressEvent.event_name,
       trigger_event_id: txMAIngressEvent.event_id ?? 'UNKNOWN',
       intervention_code: txMAIngressEvent.extensions?.intervention?.intervention_code,
+      ...txMAIngressEvent.extensions?.intervention,
       description: userLedActionList.includes(ingressEventName)
         ? 'USER_LED_ACTION'
         : stateEngineOutput.interventionName!,

--- a/src/services/test/send-audit-events.test.ts
+++ b/src/services/test/send-audit-events.test.ts
@@ -202,6 +202,7 @@ const sqsCommandInputForFutureInterventions = {
       trigger_event: 'TICF_ACCOUNT_INTERVENTION',
       trigger_event_id: '123',
       intervention_code: '01',
+      intervention_reason: 'reason'
     },
   }),
 };


### PR DESCRIPTION
## Proposed changes
This PR merges changes to include all intervention attribute fields from the a source intervention event into the outgoing message to txma

### What changed
- in the send audit event file, when the egress event is built, its extension attribute will not contain all of the fields contained under the intervention field in the original event
- updated interface and unit tests

### Why did it change
Include all intervention information 

### Issue tracking
- [ATB-1478](https://govukverify.atlassian.net/browse/ATB-1478)

## Testing
added unit test for new logic
deployed changes to AWS account and sent events with extra fields:
applied event
![Screenshot 2024-02-01 at 09 07 22](https://github.com/govuk-one-login/account-interventions-service/assets/110468890/db29c98c-6040-429f-8b2e-511a57476de4)
event in the future
![Screenshot 2024-02-01 at 09 10 59](https://github.com/govuk-one-login/account-interventions-service/assets/110468890/9c9df02a-5f7c-4f82-8b4e-67f3664221a4)

## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [x] Tested changes and included test evidence in the PR, if appropriate
- [x] Included all required tags and other properties for any new resources in the SAM template
- [x] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [x] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [x] Ensured that no log lines include PII or other sensitive data
- [x] Implemented unit testing for any new logic implemented, if appropriate
- [x] Ensured that all commits in this PR are signed
- [x] Ensured appropriate code coverage is maintained by unit tests
- [x] Checked SonarCube and ensured no code smells were added


[ATB-1478]: https://govukverify.atlassian.net/browse/ATB-1478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ