### PR TITLE
ATB 1485 | Exclude AUTH_PASSWORD_SUCCESSFUL_FOR_TEST_CLIENT codes from allowable_interventions

### DIFF
--- a/src/data-types/constants.ts
+++ b/src/data-types/constants.ts
@@ -83,8 +83,6 @@ export const userLedActionList: EventsEnum[] = [
   EventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL_FOR_TEST_CLIENT,
 ];
 
-export const nonInterventionsCodes = new Set(['90', '91', '92', '93', '94', '95']);
-
 export const COMPONENT_ID = 'ACCOUNT_INTERVENTION_SERVICE';
 
 export enum HistoryStringParts {

--- a/src/data-types/constants.ts
+++ b/src/data-types/constants.ts
@@ -83,7 +83,7 @@ export const userLedActionList: EventsEnum[] = [
   EventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL_FOR_TEST_CLIENT,
 ];
 
-export const nonInterventionsCodes = new Set(['90', '91', '92', '93']);
+export const nonInterventionsCodes = new Set(['90', '91', '92', '93', '94', '95']);
 
 export const COMPONENT_ID = 'ACCOUNT_INTERVENTION_SERVICE';
 

--- a/src/services/send-audit-events.ts
+++ b/src/services/send-audit-events.ts
@@ -17,11 +17,11 @@ import {
   COMPONENT_ID,
   EventsEnum,
   MetricNames,
-  nonInterventionsCodes,
   State,
   userLedActionList,
 } from '../data-types/constants';
 import { logAndPublishMetric } from '../commons/metrics';
+import { transitionConfiguration } from './account-states/config';
 
 const appConfig = AppConfigService.getInstance();
 
@@ -99,7 +99,7 @@ function buildExtensions(
         ? 'USER_LED_ACTION'
         : stateEngineOutput.interventionName!,
       allowable_interventions: stateEngineOutput.nextAllowableInterventions.filter(
-        (intervention) => !nonInterventionsCodes.has(intervention),
+        (intervention) => transitionConfiguration.edges[intervention]?.interventionName,
       ),
       ...buildAdditionalAttributes(stateEngineOutput, egressEventName),
     };


### PR DESCRIPTION
## Proposed changes

### What changed
Added all non intervention codes to the constant that's holding them.

### Why did it change
At the moment, only codes for AUTH_PASSWORD_RESET_SUCCESSFUL and IPV_IDENTITY_ISSUED are excluded from the allowable_interventions array that’s being sent in the egress message to TxMA.

We need to exclude the codes for AUTH_PASSWORD_RESET_SUCCESSFUL_FOR_TEST_CLIENT as well.
### Issue tracking

- [ATB-1485](https://govukverify.atlassian.net/browse/ATB-1485)

## Testing
Before:
![image](https://github.com/govuk-one-login/account-interventions-service/assets/124037159/be5a244a-ca18-49d1-919a-e465503fe24c)

After:
![image](https://github.com/govuk-one-login/account-interventions-service/assets/124037159/c8fc310d-3818-4b70-a718-bde0f20cc049)

## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [x] Tested changes and included test evidence in the PR, if appropriate
- [x] Included all required tags and other properties for any new resources in the SAM template
- [x] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [x] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [x] Ensured that no log lines include PII or other sensitive data
- [x] Implemented unit testing for any new logic implemented, if appropriate
- [x] Ensured that all commits in this PR are signed
- [x] Ensured appropriate code coverage is maintained by unit tests
- [x] Checked SonarCube and ensured no code smells were added


[ATB-1485]: https://govukverify.atlassian.net/browse/ATB-1485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ