### PR TITLE
ATB 1491 - Fix docker container issue with node 20.x

### DIFF
--- a/feature-tests/Dockerfile
+++ b/feature-tests/Dockerfile
@@ -1,7 +1,7 @@
 # Set the base image.
 FROM amazonlinux:latest
 RUN yum install -y gcc-c++ make
-RUN curl -sL https://rpm.nodesource.com/setup_18.x
+RUN curl -sL https://rpm.nodesource.com/setup_lts.x | bash -
 RUN yum install -y nodejs
 RUN npm install yarn -g
 


### PR DESCRIPTION
## Proposed changes
[ATB-1491](https://govukverify.atlassian.net/browse/ATB-1491)

### What changed
Changed docker file to allow it to install node 20 correctly

### Why did it change
the package.json in feature tests was forcing a node20 version, docker was installing node 18 and encountering errors when trying to build.

## Testing
Docker builds locally:
<img width="990" alt="Screenshot 2024-02-01 at 15 58 39" src="https://github.com/govuk-one-login/account-interventions-service/assets/130994595/f9ded267-fc18-4806-a37f-6ce8bbbcbb6d">
Feature tests still passing:
<img width="996" alt="Screenshot 2024-02-01 at 16 22 26" src="https://github.com/govuk-one-login/account-interventions-service/assets/130994595/22c194f2-639d-4d3c-8921-5462b31e6ba6">

## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [x] Tested changes and included test evidence in the PR, if appropriate
- [ ] Included all required tags and other properties for any new resources in the SAM template
- [ ] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [ ] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [ ] Ensured that no log lines include PII or other sensitive data
- [ ] Implemented unit testing for any new logic implemented, if appropriate
- [x] Ensured that all commits in this PR are signed
- [ ] Ensured appropriate code coverage is maintained by unit tests
- [ ] Checked SonarCube and ensured no code smells were added


[ATB-1491]: https://govukverify.atlassian.net/browse/ATB-1491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ