### PR TITLE
ATB-1473: Add Egress Queue Methods

### DIFF
--- a/feature-tests/apiEndpoints/endpoints.ts
+++ b/feature-tests/apiEndpoints/endpoints.ts
@@ -8,9 +8,9 @@ export default class EndPoints {
       ? `https://sqs.${process.env.AWS_REGION}.amazonaws.com/013758878511/${process.env.SAM_STACK_NAME}-TxMAIngressQueue`
       : process.env.CFN_TxMAIngressSqsQueueUrl;
   public static SQS_EGRESS_QUEUE_URL =
-      process.env.TEST_ENVIRONMENT === 'dev'
-        ? `https://sqs.${process.env.AWS_REGION}.amazonaws.com/013758878511/${process.env.SAM_STACK_NAME}-TxMAEgressQueue`
-        : process.env.CFN_TxMAEgressSqsQueueUrl;    
+    process.env.TEST_ENVIRONMENT === 'dev'
+      ? `https://sqs.${process.env.AWS_REGION}.amazonaws.com/013758878511/${process.env.SAM_STACK_NAME}-TxMAEgressQueue`
+      : process.env.CFN_TxMAEgressSqsQueueUrl;
   public static PATH_AIS = '/ais/';
   public static INVOKE_PRIVATE_API_GATEWAY = `${process.env.SAM_STACK_NAME}-InvokePrivateAPIGatewayFunction`;
   public static TABLE_NAME = 'ais-core-account-status';

--- a/feature-tests/apiEndpoints/endpoints.ts
+++ b/feature-tests/apiEndpoints/endpoints.ts
@@ -7,6 +7,10 @@ export default class EndPoints {
     process.env.TEST_ENVIRONMENT === 'dev'
       ? `https://sqs.${process.env.AWS_REGION}.amazonaws.com/013758878511/${process.env.SAM_STACK_NAME}-TxMAIngressQueue`
       : process.env.CFN_TxMAIngressSqsQueueUrl;
+  public static SQS_EGRESS_QUEUE_URL =
+      process.env.TEST_ENVIRONMENT === 'dev'
+        ? `https://sqs.${process.env.AWS_REGION}.amazonaws.com/013758878511/${process.env.SAM_STACK_NAME}-TxMAEgressQueue`
+        : process.env.CFN_TxMAEgressSqsQueueUrl;    
   public static PATH_AIS = '/ais/';
   public static INVOKE_PRIVATE_API_GATEWAY = `${process.env.SAM_STACK_NAME}-InvokePrivateAPIGatewayFunction`;
   public static TABLE_NAME = 'ais-core-account-status';

--- a/feature-tests/run-tests.sh
+++ b/feature-tests/run-tests.sh
@@ -15,6 +15,7 @@ cp -R /utils . 2>/dev/null || :
 
 # run tests and save the exit code
 declare test_run_result
+export tagFilter=@regression
 yarn test 1>/dev/null
 test_run_result=$?
 

--- a/feature-tests/run-tests.sh
+++ b/feature-tests/run-tests.sh
@@ -15,7 +15,7 @@ cp -R /utils . 2>/dev/null || :
 
 # run tests and save the exit code
 declare test_run_result
-yarn test
+yarn test 1>/dev/null
 test_run_result=$?
 
 # store report to dir where pipeline will export from

--- a/feature-tests/run-tests.sh
+++ b/feature-tests/run-tests.sh
@@ -15,7 +15,7 @@ cp -R /utils . 2>/dev/null || :
 
 # run tests and save the exit code
 declare test_run_result
-yarn test 1>/dev/null
+yarn test
 test_run_result=$?
 
 # store report to dir where pipeline will export from

--- a/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-HappyPath.feature
+++ b/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-HappyPath.feature
@@ -5,6 +5,7 @@ Feature: Invoke-APIGateway-HappyPath.feature
         Given I send an <aisEventType> intervention message to the TxMA ingress SQS queue
         When I invoke the API to retrieve the intervention status of the user's account. With history <historyValue>
         Then I expect the response with all the valid state flags for <aisEventType>
+        And I expect the response with next allowable intervention types in TXMA Egress Queue for <aisEventType>
         Examples:
             | aisEventType              | historyValue |
             | pswResetRequired          | false        |
@@ -22,6 +23,7 @@ Feature: Invoke-APIGateway-HappyPath.feature
         Given I send an <allowableAisEventType> allowable intervention event message to the TxMA ingress SQS queue for a Account in <originalAisEventType> state
         When I invoke the API to retrieve the allowable intervention status of the user's account. With history <historyValue>
         Then I expect the response with all the valid state fields for the <allowableAisEventType>
+        And I expect response with next allowable intervention types in TXMA Egress Queue for the <allowableAisEventType>
         Examples:
             | originalAisEventType  | allowableAisEventType | historyValue |
             # passsword reset account status to new intervention type
@@ -60,6 +62,7 @@ Feature: Invoke-APIGateway-HappyPath.feature
         Given I send an <nonAllowableAisEventType> non-allowable intervention event message to the TxMA ingress SQS queue for a Account in <originalAisEventType> state
         When I invoke the API to retrieve the non-allowable intervention status of the user's account. With history <historyValue>
         Then I expect the response with all the state fields for the <originalAisEventType>
+        And I expect next allowable intervention types in TXMA Egress Queue response for the <originalAisEventType>
         Examples:
             | originalAisEventType  | nonAllowableAisEventType  | historyValue |
             # password reset required account status to new intervention type
@@ -88,7 +91,8 @@ Feature: Invoke-APIGateway-HappyPath.feature
     Scenario Outline: Get Request to /ais/userId - Password and Id non-allowable Transition from <originalAisEventType> to <nonAllowableAisEventType> - Returns expected data
         Given I send an <nonAllowableAisEventType> non-allowable event type password or id Reset intervention message to the TxMA ingress SQS queue for a Account in <originalAisEventType> state
         When I invoke the API to retrieve the intervention status of the user's account with history <historyValue>
-        Then I expect response with valid fields for <originalAisEventType>, <interventionType> with state flags as <blocked>, <suspended>, <resetPassword> and <reproveIdentity>
+        Then I expect response with valid fields for <interventionType> with state flags as <blocked>, <suspended>, <resetPassword> and <reproveIdentity>
+        And  I expect response with next allowable intervention types in TXMA Egress Queue for <originalAisEventType> with <interventionType>
         Examples:
             | originalAisEventType  | nonAllowableAisEventType  | historyValue | interventionType                                   | blocked | suspended | resetPassword | reproveIdentity |
             | pswResetRequired      | userActionPswResetSuccess | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false   | false     | false         | false           |

--- a/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-HappyPath.feature
+++ b/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-HappyPath.feature
@@ -17,7 +17,7 @@ Feature: Invoke-APIGateway-HappyPath.feature
             | userActionPswResetSuccess | false        |
             | unSuspendAction           | false        |
 
-    @regression
+    @regression @test
     Scenario Outline: Happy Path - Get Request to /ais/userId - allowable Transition from <originalAisEventType> to <allowableAisEventType> - Return expected data
         Given I send an <allowableAisEventType> allowable intervention event message to the TxMA ingress SQS queue for a Account in <originalAisEventType> state
         When I invoke the API to retrieve the allowable intervention status of the user's account. With history <historyValue>

--- a/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-HappyPath.feature
+++ b/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-HappyPath.feature
@@ -100,7 +100,7 @@ Feature: Invoke-APIGateway-HappyPath.feature
             | pswAndIdResetRequired | userActionIdResetSuccess  | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false   | true      | true          | false           |
             | pswAndIdResetRequired | userActionPswResetSuccess | false        | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | false   | true      | false         | true            |
 
-    @regression
+    @regression @historyTests
     Scenario Outline: Happy Path - Get Request to /ais/userId - allowable Transition from <originalAisEventType> to <allowableAisEventType> - Get Request to /ais/userId - Returns expected data with history values
         Given I send an updated request to the SQS queue with intervention data of the type <allowableAisEventType> from <originalAisEventType>
         When I invoke the API to retrieve the allowable intervention status of the user's account with <historyValue>
@@ -134,7 +134,7 @@ Feature: Invoke-APIGateway-HappyPath.feature
             | pswAndIdResetRequired | idResetRequired       | true         |
             | pswAndIdResetRequired | unSuspendAction       | true         |
 
-    @smoke @regression
+    @regression
     Scenario Outline: Happy Path - Get Request to /ais/userId - Field Validation - Returns Expected Data for <aisEventType> with specific field validation
         Given I send a invalid request to sqs queue with no userId and <aisEventType>, <testUserId> data
         When I invoke apiGateway to retreive the status of the invalid userId with <historyValue>

--- a/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-HappyPath.feature
+++ b/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-HappyPath.feature
@@ -88,7 +88,7 @@ Feature: Invoke-APIGateway-HappyPath.feature
     Scenario Outline: Get Request to /ais/userId - Password and Id non-allowable Transition from <originalAisEventType> to <nonAllowableAisEventType> - Returns expected data
         Given I send an <nonAllowableAisEventType> non-allowable event type password or id Reset intervention message to the TxMA ingress SQS queue for a Account in <originalAisEventType> state
         When I invoke the API to retrieve the intervention status of the user's account with history <historyValue>
-        Then I expect response with valid fields for <interventionType> with state flags as <blocked>, <suspended>, <resetPassword> and <reproveIdentity>
+        Then I expect response with valid fields for <originalAisEventType>, <interventionType> with state flags as <blocked>, <suspended>, <resetPassword> and <reproveIdentity>
         Examples:
             | originalAisEventType  | nonAllowableAisEventType  | historyValue | interventionType                                   | blocked | suspended | resetPassword | reproveIdentity |
             | pswResetRequired      | userActionPswResetSuccess | false        | AIS_FORCED_USER_PASSWORD_RESET                     | false   | false     | false         | false           |

--- a/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-HappyPath.feature
+++ b/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-HappyPath.feature
@@ -17,7 +17,7 @@ Feature: Invoke-APIGateway-HappyPath.feature
             | userActionPswResetSuccess | false        |
             | unSuspendAction           | false        |
 
-    @regression @test
+    @regression
     Scenario Outline: Happy Path - Get Request to /ais/userId - allowable Transition from <originalAisEventType> to <allowableAisEventType> - Return expected data
         Given I send an <allowableAisEventType> allowable intervention event message to the TxMA ingress SQS queue for a Account in <originalAisEventType> state
         When I invoke the API to retrieve the allowable intervention status of the user's account. With history <historyValue>

--- a/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
@@ -75,10 +75,9 @@ defineFeature(feature, (test) => {
       async (allowableAisEventType, originalAisEventType) => {
         console.log('sending first message to put the user in : ' + originalAisEventType);
         await sendSQSEvent(testUserId, originalAisEventType);
+        await timeDelayForTestEnvironment(500);
         console.log('sending second message to put the user in : ' + allowableAisEventType);
-        await timeDelayForTestEnvironment(500);
         await sendSQSEvent(testUserId, allowableAisEventType);
-        await timeDelayForTestEnvironment(500);
       },
     );
 

--- a/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
@@ -25,6 +25,7 @@ defineFeature(feature, (test) => {
     given,
     when,
     then,
+    and,
   }) => {
     given(/^I send an (.*) intervention message to the TxMA ingress SQS queue$/, async (aisEventType) => {
       await sendSQSEvent(testUserId, aisEventType);
@@ -42,14 +43,6 @@ defineFeature(feature, (test) => {
       /^I expect the response with all the valid state flags for (.*)$/,
       async (aisEventType: keyof typeof aisEventResponse) => {
         console.log(`Received`, { response });
-        const events = ['userActionIdResetSuccess', 'userActionPswResetSuccess'];
-
-        if (!events.includes(aisEventType)) {
-          const receivedMessage = await filterUserIdInMessages(testUserId);
-          const body = receivedMessage[0].Body;
-          const extensions = body ? JSON.parse(body).extensions : {};
-          expect(extensions.allowable_interventions).toEqual(aisEventResponse[aisEventType].allowable_interventions);
-        }
         const eventTypes = ['unSuspendAction', 'unblock'];
         if (eventTypes.includes(aisEventType)) {
           expect(response.intervention.description).toBe('AIS_NO_INTERVENTION');
@@ -63,12 +56,26 @@ defineFeature(feature, (test) => {
         expect(response.auditLevel).toBe(aisEventResponse[aisEventType].auditLevel);
       },
     );
+
+    and(
+      /^I expect the response with next allowable intervention types in TXMA Egress Queue for (.*)$/,
+      async (aisEventType: keyof typeof aisEventResponse) => {
+        const events = ['userActionIdResetSuccess', 'userActionPswResetSuccess'];
+        if (!events.includes(aisEventType)) {
+          const receivedMessage = await filterUserIdInMessages(testUserId);
+          const body = receivedMessage[0].Body;
+          const extensions = body ? JSON.parse(body).extensions : {};
+          expect(extensions.allowable_interventions).toEqual(aisEventResponse[aisEventType].allowable_interventions);
+        }
+      },
+    );
   });
 
   test('Happy Path - Get Request to /ais/userId - allowable Transition from <originalAisEventType> to <allowableAisEventType> - Return expected data', ({
     given,
     when,
     then,
+    and,
   }) => {
     given(
       /^I send an (.*) allowable intervention event message to the TxMA ingress SQS queue for a Account in (.*) state$/,
@@ -93,7 +100,18 @@ defineFeature(feature, (test) => {
       /^I expect the response with all the valid state fields for the (.*)$/,
       async (allowableAisEventType: keyof typeof aisEventResponse) => {
         console.log(`Received`, { response });
+        expect(response.intervention.description).toBe(aisEventResponse[allowableAisEventType].description);
+        expect(response.state.blocked).toBe(aisEventResponse[allowableAisEventType].blocked);
+        expect(response.state.suspended).toBe(aisEventResponse[allowableAisEventType].suspended);
+        expect(response.state.resetPassword).toBe(aisEventResponse[allowableAisEventType].resetPassword);
+        expect(response.state.reproveIdentity).toBe(aisEventResponse[allowableAisEventType].reproveIdentity);
+        expect(response.auditLevel).toBe(aisEventResponse[allowableAisEventType].auditLevel);
+      },
+    );
 
+    and(
+      /^I expect response with next allowable intervention types in TXMA Egress Queue for the (.*)$/,
+      async (allowableAisEventType: keyof typeof aisEventResponse) => {
         const receivedMessage = await filterUserIdInMessages(testUserId);
 
         const message = receivedMessage.find((object) => {
@@ -104,13 +122,6 @@ defineFeature(feature, (test) => {
         expect(body.extensions?.allowable_interventions).toEqual(
           aisEventResponse[allowableAisEventType].allowable_interventions,
         );
-
-        expect(response.intervention.description).toBe(aisEventResponse[allowableAisEventType].description);
-        expect(response.state.blocked).toBe(aisEventResponse[allowableAisEventType].blocked);
-        expect(response.state.suspended).toBe(aisEventResponse[allowableAisEventType].suspended);
-        expect(response.state.resetPassword).toBe(aisEventResponse[allowableAisEventType].resetPassword);
-        expect(response.state.reproveIdentity).toBe(aisEventResponse[allowableAisEventType].reproveIdentity);
-        expect(response.auditLevel).toBe(aisEventResponse[allowableAisEventType].auditLevel);
       },
     );
   });
@@ -119,6 +130,7 @@ defineFeature(feature, (test) => {
     given,
     when,
     then,
+    and,
   }) => {
     given(
       /^I send an (.*) non-allowable intervention event message to the TxMA ingress SQS queue for a Account in (.*) state$/,
@@ -143,7 +155,18 @@ defineFeature(feature, (test) => {
       /^I expect the response with all the state fields for the (.*)$/,
       async (originalAisEventType: keyof typeof aisEventResponse) => {
         console.log(`Received`, { response });
+        expect(response.intervention.description).toBe(aisEventResponse[originalAisEventType].description);
+        expect(response.state.blocked).toBe(aisEventResponse[originalAisEventType].blocked);
+        expect(response.state.suspended).toBe(aisEventResponse[originalAisEventType].suspended);
+        expect(response.state.resetPassword).toBe(aisEventResponse[originalAisEventType].resetPassword);
+        expect(response.state.reproveIdentity).toBe(aisEventResponse[originalAisEventType].reproveIdentity);
+        expect(response.auditLevel).toBe(aisEventResponse[originalAisEventType].auditLevel);
+      },
+    );
 
+    and(
+      /^I expect next allowable intervention types in TXMA Egress Queue response for the (.*)$/,
+      async (originalAisEventType: keyof typeof aisEventResponse) => {
         const receivedMessage = await filterUserIdInMessages(testUserId);
 
         const message = receivedMessage.find((object) => {
@@ -154,12 +177,6 @@ defineFeature(feature, (test) => {
         expect(body.extensions.allowable_interventions).toEqual(
           aisEventResponse[originalAisEventType].allowable_interventions,
         );
-        expect(response.intervention.description).toBe(aisEventResponse[originalAisEventType].description);
-        expect(response.state.blocked).toBe(aisEventResponse[originalAisEventType].blocked);
-        expect(response.state.suspended).toBe(aisEventResponse[originalAisEventType].suspended);
-        expect(response.state.resetPassword).toBe(aisEventResponse[originalAisEventType].resetPassword);
-        expect(response.state.reproveIdentity).toBe(aisEventResponse[originalAisEventType].reproveIdentity);
-        expect(response.auditLevel).toBe(aisEventResponse[originalAisEventType].auditLevel);
       },
     );
   });
@@ -168,6 +185,7 @@ defineFeature(feature, (test) => {
     given,
     when,
     then,
+    and,
   }) => {
     given(
       /^I send an (.*) non-allowable event type password or id Reset intervention message to the TxMA ingress SQS queue for a Account in (.*) state$/,
@@ -189,9 +207,8 @@ defineFeature(feature, (test) => {
     );
 
     then(
-      /^I expect response with valid fields for (.*), (.*) with state flags as (.*), (.*), (.*) and (.*)$/,
+      /^I expect response with valid fields for (.*) with state flags as (.*), (.*), (.*) and (.*)$/,
       async (
-        originalAisEventType: keyof typeof aisEventResponse,
         interventionType: string,
         blocked: string,
         suspended: string,
@@ -199,7 +216,18 @@ defineFeature(feature, (test) => {
         reproveIdentity: string,
       ) => {
         console.log(`Received`, { response });
+        expect(response.intervention.description).toBe(interventionType);
+        expect(response.state.blocked).toBe(JSON.parse(blocked));
+        expect(response.state.suspended).toBe(JSON.parse(suspended));
+        expect(response.state.resetPassword).toBe(JSON.parse(resetPassword));
+        expect(response.state.reproveIdentity).toBe(JSON.parse(reproveIdentity));
+        expect(response.auditLevel).toBe('standard');
+      },
+    );
 
+    and(
+      /^I expect response with next allowable intervention types in TXMA Egress Queue for (.*) with (.*)$/,
+      async (originalAisEventType: keyof typeof aisEventResponse, interventionType: string) => {
         const receivedMessage = await filterUserIdInMessages(testUserId);
         const message = receivedMessage.find((object) => {
           const objectBody = object.Body ? JSON.parse(object.Body) : {};
@@ -209,13 +237,6 @@ defineFeature(feature, (test) => {
         expect(body.extensions.allowable_interventions).toEqual(
           aisEventResponse[originalAisEventType].allowable_interventions,
         );
-
-        expect(response.intervention.description).toBe(interventionType);
-        expect(response.state.blocked).toBe(JSON.parse(blocked));
-        expect(response.state.suspended).toBe(JSON.parse(suspended));
-        expect(response.state.resetPassword).toBe(JSON.parse(resetPassword));
-        expect(response.state.reproveIdentity).toBe(JSON.parse(reproveIdentity));
-        expect(response.auditLevel).toBe('standard');
       },
     );
   });

--- a/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
@@ -46,9 +46,12 @@ defineFeature(feature, (test) => {
 
         if (!events.includes(aisEventType)) {
           const receivedMessage = await filterUserIdInMessages(testUserId);
-          const body: any = receivedMessage[0].Body;
-          const extensions: any = JSON.parse(body).extensions;
-          expect(await extensions.allowable_interventions).toEqual(
+          expect(receivedMessage).toEqual(aisEventResponse[aisEventType].allowable_interventions);
+          const body = receivedMessage[0].Body;
+          expect(body).toEqual(aisEventResponse[aisEventType].allowable_interventions);
+          const extensions = body ? JSON.parse(body).extensions : {};
+          expect(extensions).toEqual(aisEventResponse[aisEventType].allowable_interventions);
+          expect(extensions.allowable_interventions).toEqual(
             aisEventResponse[aisEventType].allowable_interventions,
           );
         }

--- a/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
@@ -46,14 +46,9 @@ defineFeature(feature, (test) => {
 
         if (!events.includes(aisEventType)) {
           const receivedMessage = await filterUserIdInMessages(testUserId);
-          expect(receivedMessage).toEqual(aisEventResponse[aisEventType].allowable_interventions);
           const body = receivedMessage[0].Body;
-          expect(body).toEqual(aisEventResponse[aisEventType].allowable_interventions);
           const extensions = body ? JSON.parse(body).extensions : {};
-          expect(extensions).toEqual(aisEventResponse[aisEventType].allowable_interventions);
-          expect(extensions.allowable_interventions).toEqual(
-            aisEventResponse[aisEventType].allowable_interventions,
-          );
+          expect(extensions.allowable_interventions).toEqual(aisEventResponse[aisEventType].allowable_interventions);
         }
         const eventTypes = ['unSuspendAction', 'unblock'];
         if (eventTypes.includes(aisEventType)) {

--- a/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
@@ -101,10 +101,10 @@ defineFeature(feature, (test) => {
 
         const message = receivedMessage.find((object) => {
           const objectBody = object.Body ? JSON.parse(object.Body) : {};
-          return objectBody.extensions.description === aisEventResponse[allowableAisEventType].description;
+          return objectBody.extensions?.description === aisEventResponse[allowableAisEventType].description;
         });
         const body = message?.Body ? JSON.parse(message?.Body) : {};
-        expect(body.extensions.allowable_interventions).toEqual(
+        expect(body.extensions?.allowable_interventions).toEqual(
           aisEventResponse[allowableAisEventType].allowable_interventions,
         );
 

--- a/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
@@ -2,7 +2,7 @@ import { defineFeature, loadFeature } from 'jest-cucumber';
 import { generateRandomTestUserId } from '../../../utils/generate-random-test-user-id';
 import { sendSQSEvent, purgeEgressQueue, filterUserIdInMessages } from '../../../utils/send-sqs-message';
 import { invokeGetAccountState } from '../../../utils/invoke-apigateway-lambda';
-import { timeDelayForTestEnvironment } from '../../../utils/utility';
+import { attemptParseJSON, timeDelayForTestEnvironment } from '../../../utils/utility';
 import { aisEventResponse } from '../../../utils/ais-events-responses';
 
 const feature = loadFeature('./tests/resources/features/aisGET/InvokeApiGateWay-HappyPath.feature');
@@ -64,7 +64,7 @@ defineFeature(feature, (test) => {
         if (!events.includes(aisEventType)) {
           const receivedMessage = await filterUserIdInMessages(testUserId);
           const body = receivedMessage[0].Body;
-          const extensions = body ? JSON.parse(body).extensions : {};
+          const extensions = body ? attemptParseJSON(body).extensions : {};
           expect(extensions.allowable_interventions).toEqual(aisEventResponse[aisEventType].allowable_interventions);
         }
       },
@@ -115,10 +115,10 @@ defineFeature(feature, (test) => {
         const receivedMessage = await filterUserIdInMessages(testUserId);
 
         const message = receivedMessage.find((object) => {
-          const objectBody = object.Body ? JSON.parse(object.Body) : {};
+          const objectBody = object.Body ? attemptParseJSON(object.Body) : {};
           return objectBody.extensions?.description === aisEventResponse[allowableAisEventType].description;
         });
-        const body = message?.Body ? JSON.parse(message?.Body) : {};
+        const body = message?.Body ? attemptParseJSON(message?.Body) : {};
         expect(body.extensions?.allowable_interventions).toEqual(
           aisEventResponse[allowableAisEventType].allowable_interventions,
         );
@@ -170,10 +170,10 @@ defineFeature(feature, (test) => {
         const receivedMessage = await filterUserIdInMessages(testUserId);
 
         const message = receivedMessage.find((object) => {
-          const objectBody = object.Body ? JSON.parse(object.Body) : {};
+          const objectBody = object.Body ? attemptParseJSON(object.Body) : {};
           return objectBody.extensions.description === aisEventResponse[originalAisEventType].description;
         });
-        const body = message?.Body ? JSON.parse(message.Body) : {};
+        const body = message?.Body ? attemptParseJSON(message.Body) : {};
         expect(body.extensions.allowable_interventions).toEqual(
           aisEventResponse[originalAisEventType].allowable_interventions,
         );
@@ -230,10 +230,10 @@ defineFeature(feature, (test) => {
       async (originalAisEventType: keyof typeof aisEventResponse, interventionType: string) => {
         const receivedMessage = await filterUserIdInMessages(testUserId);
         const message = receivedMessage.find((object) => {
-          const objectBody = object.Body ? JSON.parse(object.Body) : {};
+          const objectBody = object.Body ? attemptParseJSON(object.Body) : {};
           return objectBody.extensions.description === interventionType;
         });
-        const body = message?.Body ? JSON.parse(message.Body) : {};
+        const body = message?.Body ? attemptParseJSON(message.Body) : {};
         expect(body.extensions.allowable_interventions).toEqual(
           aisEventResponse[originalAisEventType].allowable_interventions,
         );

--- a/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
@@ -39,10 +39,14 @@ defineFeature(feature, (test) => {
       /^I expect the response with all the valid state flags for (.*)$/,
       async (aisEventType: keyof typeof aisEventResponse) => {
         console.log(`Received`, { response });
+        const events = ['userActionIdResetSuccess','userActionPswResetSuccess']
+
+        if(!events.includes(aisEventType)){
         const receivedMessage: any  = await receiveMessagesFromEgressOueue();
         let body: any = receivedMessage.Messages[0].Body;
         const extensions = JSON.parse(body).extensions;
         expect(await extensions.allowable_interventions).toEqual(aisEventResponse[aisEventType].allowable_interventions);
+        }
         const eventTypes = ['unSuspendAction', 'unblock'];
         if (eventTypes.includes(aisEventType)) {
           expect(response.intervention.description).toBe('AIS_NO_INTERVENTION');

--- a/feature-tests/utils/ais-events-responses.ts
+++ b/feature-tests/utils/ais-events-responses.ts
@@ -10,6 +10,7 @@ export const aisEventResponse = {
     interventionHistory: 'FRAUD_FORCED_USER_PASSWORD_RESET',
     reason: 'password reset - 04',
     auditLevel: 'standard',
+    allowable_interventions: ['01','02','03','05','06']
   },
 
   suspendNoAction: {
@@ -23,6 +24,7 @@ export const aisEventResponse = {
     interventionHistory: 'FRAUD_SUSPEND_ACCOUNT',
     reason: 'suspend - 01',
     auditLevel: 'standard',
+    allowable_interventions: ['02','03','04','05','06']
   },
 
   block: {
@@ -36,6 +38,7 @@ export const aisEventResponse = {
     interventionHistory: 'FRAUD_BLOCK_ACCOUNT',
     reason: 'block - 03',
     auditLevel: 'standard',
+    allowable_interventions: ['07']
   },
 
   idResetRequired: {
@@ -49,6 +52,7 @@ export const aisEventResponse = {
     interventionHistory: 'FRAUD_FORCED_USER_IDENTITY_REVERIFICATION',
     reason: 'id reset - 05',
     auditLevel: 'standard',
+    allowable_interventions: ['01', '02', '03', '04', '06']
   },
 
   pswAndIdResetRequired: {
@@ -62,6 +66,7 @@ export const aisEventResponse = {
     interventionHistory: 'FRAUD_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_REVERIFICATION',
     reason: 'password and id reset - 06',
     auditLevel: 'standard',
+    allowable_interventions: ['01', '02', '03', '04', '05']
   },
 
   unblock: {
@@ -75,6 +80,7 @@ export const aisEventResponse = {
     interventionHistory: 'FRAUD_UNBLOCK_ACCOUNT',
     reason: 'unblock - 07',
     auditLevel: 'standard',
+    allowable_interventions: ['01', '03', '04', '05', '06']
   },
 
   userActionIdResetSuccess: {
@@ -88,6 +94,7 @@ export const aisEventResponse = {
     interventionHistory: '',
     reason: '',
     auditLevel: 'standard',
+    allowable_interventions: ['01', '03', '04', '05', '06']
   },
 
   userActionPswResetSuccess: {
@@ -101,6 +108,7 @@ export const aisEventResponse = {
     interventionHistory: '',
     reason: '',
     auditLevel: 'standard',
+    allowable_interventions: ['01', '03', '04', '05', '06']
   },
 
   unSuspendAction: {
@@ -114,5 +122,6 @@ export const aisEventResponse = {
     interventionHistory: 'FRAUD_UNSUSPEND_ACCOUNT',
     reason: 'unsuspend - 02',
     auditLevel: 'standard',
+    allowable_interventions: ['01', '03', '04', '05', '06']
   },
 };

--- a/feature-tests/utils/ais-events-responses.ts
+++ b/feature-tests/utils/ais-events-responses.ts
@@ -10,7 +10,7 @@ export const aisEventResponse = {
     interventionHistory: 'FRAUD_FORCED_USER_PASSWORD_RESET',
     reason: 'password reset - 04',
     auditLevel: 'standard',
-    allowable_interventions: ['01','02','03','05','06']
+    allowable_interventions: ['01', '02', '03', '05', '06'],
   },
 
   suspendNoAction: {
@@ -24,7 +24,7 @@ export const aisEventResponse = {
     interventionHistory: 'FRAUD_SUSPEND_ACCOUNT',
     reason: 'suspend - 01',
     auditLevel: 'standard',
-    allowable_interventions: ['02','03','04','05','06']
+    allowable_interventions: ['02', '03', '04', '05', '06'],
   },
 
   block: {
@@ -38,7 +38,7 @@ export const aisEventResponse = {
     interventionHistory: 'FRAUD_BLOCK_ACCOUNT',
     reason: 'block - 03',
     auditLevel: 'standard',
-    allowable_interventions: ['07']
+    allowable_interventions: ['07'],
   },
 
   idResetRequired: {
@@ -52,7 +52,7 @@ export const aisEventResponse = {
     interventionHistory: 'FRAUD_FORCED_USER_IDENTITY_REVERIFICATION',
     reason: 'id reset - 05',
     auditLevel: 'standard',
-    allowable_interventions: ['01', '02', '03', '04', '06']
+    allowable_interventions: ['01', '02', '03', '04', '06'],
   },
 
   pswAndIdResetRequired: {
@@ -66,7 +66,7 @@ export const aisEventResponse = {
     interventionHistory: 'FRAUD_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_REVERIFICATION',
     reason: 'password and id reset - 06',
     auditLevel: 'standard',
-    allowable_interventions: ['01', '02', '03', '04', '05']
+    allowable_interventions: ['01', '02', '03', '04', '05'],
   },
 
   unblock: {
@@ -80,7 +80,7 @@ export const aisEventResponse = {
     interventionHistory: 'FRAUD_UNBLOCK_ACCOUNT',
     reason: 'unblock - 07',
     auditLevel: 'standard',
-    allowable_interventions: ['01', '03', '04', '05', '06']
+    allowable_interventions: ['01', '03', '04', '05', '06'],
   },
 
   userActionIdResetSuccess: {
@@ -94,7 +94,7 @@ export const aisEventResponse = {
     interventionHistory: '',
     reason: '',
     auditLevel: 'standard',
-    allowable_interventions: ['01', '03', '04', '05', '06']
+    allowable_interventions: ['01', '03', '04', '05', '06'],
   },
 
   userActionPswResetSuccess: {
@@ -108,7 +108,7 @@ export const aisEventResponse = {
     interventionHistory: '',
     reason: '',
     auditLevel: 'standard',
-    allowable_interventions: ['01', '03', '04', '05', '06']
+    allowable_interventions: ['01', '03', '04', '05', '06'],
   },
 
   unSuspendAction: {
@@ -122,6 +122,6 @@ export const aisEventResponse = {
     interventionHistory: 'FRAUD_UNSUSPEND_ACCOUNT',
     reason: 'unsuspend - 02',
     auditLevel: 'standard',
-    allowable_interventions: ['01', '03', '04', '05', '06']
+    allowable_interventions: ['01', '03', '04', '05', '06'],
   },
 };

--- a/feature-tests/utils/send-sqs-message.ts
+++ b/feature-tests/utils/send-sqs-message.ts
@@ -41,7 +41,7 @@ export async function purgeEgressQueue() {
   };
   try {
     await sqs.purgeQueue(parameters);
-    await timeDelayForTestEnvironment(6000);
+    await timeDelayForTestEnvironment(5000);
     console.log('Purge Success');
   } catch (error) {
     console.log('Error', error);

--- a/feature-tests/utils/send-sqs-message.ts
+++ b/feature-tests/utils/send-sqs-message.ts
@@ -48,7 +48,7 @@ export async function purgeEgressQueue() {
   }
 }
 
-export async function receiveMessagesFromEgressOueue() {
+export async function receiveMessagesFromEgressQueue() {
   const sqs = new SQS({ apiVersion: '2012-11-05', region: process.env.AWS_REGION });
   let response;
   const queueURL = EndPoints.SQS_EGRESS_QUEUE_URL;
@@ -78,7 +78,7 @@ export async function receiveMessagesFromEgressOueue() {
 }
 
 export async function filterUserIdInMessages(testUserId: string) {
-  const messages = await receiveMessagesFromEgressOueue();
+  const messages = await receiveMessagesFromEgressQueue();
   const filteredMessageByUserId = messages.filter((message) => {
     const messageBody = message.Body ? JSON.parse(message.Body) : {};
     return messageBody.user.user_id === testUserId;

--- a/feature-tests/utils/send-sqs-message.ts
+++ b/feature-tests/utils/send-sqs-message.ts
@@ -49,18 +49,18 @@ export async function purgeEgressOueue() {
 
 export async function receiveMessagesFromEgressOueue() {
   const sqs = new SQS({ apiVersion: '2012-11-05', region: process.env.AWS_REGION });
-  let data;
+  let response;
   const queueURL = EndPoints.SQS_EGRESS_QUEUE_URL;
   const parameters = {
     QueueUrl: queueURL,
 };
   try {
-    data = (await sqs.receiveMessage(parameters)).Messages;
+    response = await sqs.receiveMessage(parameters);
   } catch (error) {
     console.log('Error', error);
   }
-  console.log('data message', data);
-  return data;
+  console.log('data message', response);
+  return response;
 }
 
 

--- a/feature-tests/utils/send-sqs-message.ts
+++ b/feature-tests/utils/send-sqs-message.ts
@@ -79,9 +79,11 @@ export async function receiveMessagesFromEgressOueue() {
 
 export async function filterUserIdInMessages(testUserId: string) {
   const messages = await receiveMessagesFromEgressOueue();
+  console.log({messages});
   const filteredMessageByUserId = messages.filter((message) => {
     const messageBody = message.Body ? JSON.parse(message.Body) : {};
     return messageBody.user.user_id === testUserId;
   });
+  console.log({filteredMessageByUserId});
   return filteredMessageByUserId;
 }

--- a/feature-tests/utils/send-sqs-message.ts
+++ b/feature-tests/utils/send-sqs-message.ts
@@ -1,7 +1,7 @@
 import { SQS } from '@aws-sdk/client-sqs';
 import { aisEvents } from './ais-events';
 import EndPoints from '../apiEndpoints/endpoints';
-import { CurrentTimeDescriptor, timeDelayForTestEnvironment } from '../utils/utility';
+import { CurrentTimeDescriptor, timeDelayForTestEnvironment, attemptParseJSON } from '../utils/utility';
 
 export async function sendSQSEvent(testUserId: string, aisEventType: keyof typeof aisEvents) {
   const currentTime = getCurrentTimestamp();
@@ -80,7 +80,7 @@ export async function receiveMessagesFromEgressQueue() {
 export async function filterUserIdInMessages(testUserId: string) {
   const messages = await receiveMessagesFromEgressQueue();
   const filteredMessageByUserId = messages.filter((message) => {
-    const messageBody = message.Body ? JSON.parse(message.Body) : {};
+    const messageBody = message.Body ? attemptParseJSON(message.Body) : {};
     return messageBody.user.user_id === testUserId;
   });
   return filteredMessageByUserId;

--- a/feature-tests/utils/send-sqs-message.ts
+++ b/feature-tests/utils/send-sqs-message.ts
@@ -32,3 +32,35 @@ function getCurrentTimestamp(date = new Date()): CurrentTimeDescriptor {
     seconds: Math.floor(date.valueOf() / 1000),
   };
 }
+
+export async function purgeEgressOueue() {
+  const sqs = new SQS({ apiVersion: '2012-11-05', region: process.env.AWS_REGION });
+  const queueURL = EndPoints.SQS_EGRESS_QUEUE_URL;
+  const parameters = {
+    QueueUrl: queueURL,
+  };
+  try {
+    await sqs.purgeQueue(parameters);
+    console.log('Purge Success');
+  } catch (error) {
+    console.log('Error', error);
+  }
+}
+
+export async function receiveMessagesFromEgressOueue() {
+  const sqs = new SQS({ apiVersion: '2012-11-05', region: process.env.AWS_REGION });
+  let data;
+  const queueURL = EndPoints.SQS_EGRESS_QUEUE_URL;
+  const parameters = {
+    QueueUrl: queueURL,
+};
+  try {
+    data = (await sqs.receiveMessage(parameters)).Messages;
+  } catch (error) {
+    console.log('Error', error);
+  }
+  console.log('data message', data);
+  return data;
+}
+
+

--- a/feature-tests/utils/send-sqs-message.ts
+++ b/feature-tests/utils/send-sqs-message.ts
@@ -79,11 +79,9 @@ export async function receiveMessagesFromEgressOueue() {
 
 export async function filterUserIdInMessages(testUserId: string) {
   const messages = await receiveMessagesFromEgressOueue();
-  console.log({messages});
   const filteredMessageByUserId = messages.filter((message) => {
     const messageBody = message.Body ? JSON.parse(message.Body) : {};
     return messageBody.user.user_id === testUserId;
   });
-  console.log({filteredMessageByUserId});
   return filteredMessageByUserId;
 }

--- a/feature-tests/utils/utility.ts
+++ b/feature-tests/utils/utility.ts
@@ -40,3 +40,12 @@ export type InformationFromTable = {
   accountDeletedAt?: number;
   pk?: string;
 };
+
+export function attemptParseJSON(jsonString: string) {
+  try {
+    return JSON.parse(jsonString);
+  } catch (error) {
+    console.log('Error parsing JSON', { error });
+    return {};
+  }
+}

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from 'fs';
+import { join, resolve } from 'path';
+import { yamlParse } from 'yaml-cfn';
+import { CleanWebpackPlugin } from 'clean-webpack-plugin';
+
+const TYPESCRIPT_FILE_EXT = '.ts';
+const JAVASCRIPT_FILE_EXT = '.js';
+const SAM_TEMPLATE_DIR = './src/infra/main/template.yaml';
+const HANDLERS_DIR = './src/handlers';
+const FUNCTION_TYPE = 'AWS::Serverless::Function';
+
+// read SAM template
+const { Globals, Resources } = yamlParse(readFileSync(join(__dirname, SAM_TEMPLATE_DIR), 'utf-8'));
+
+// find the files to bundle by getting the CodeUri and Handler info for each node function
+const entry = Object.values(Resources)
+  .filter((resource) => Object.keys(resource as any).includes('Type'))
+  .filter((resource: any) => resource.Type === FUNCTION_TYPE)
+  .filter((resource: any) => (resource.Properties?.Runtime ?? Globals?.Function?.Runtime).startsWith('nodejs'))
+  .map((resource: any) => {
+    return {
+      filename: resource.Properties.Handler.split('.')[0] as string, // get filename to bundle
+      entryPath: resource.Properties.CodeUri.replaceAll('../', './') // flatten relative path to the project root
+        .replaceAll('dist/', '') // remove the outDir as it is bundled directly into dist
+        .split('/')
+        .splice(1)
+        .join('/') as string, // get out dir for bundle
+    };
+  })
+
+  // create the entry definitions fow webpack
+  .reduce(
+    (resources, resource) =>
+      Object.assign(resources, {
+        [`${resource.entryPath}/${resource.filename}`]: `${HANDLERS_DIR}/${resource.filename}${TYPESCRIPT_FILE_EXT}`,
+      }),
+    {},
+  );
+
+const webpackConfig = {
+  mode: process.env['NODE_ENV']?.trim().startsWith('dev') ? 'development' : 'production',
+  devtool: process.env['NODE_ENV']?.trim().startsWith('dev') ? 'eval-cheap-source-map' : undefined,
+  module: {
+    rules: [
+      {
+        test: new RegExp(`\\${TYPESCRIPT_FILE_EXT}$`),
+        loader: 'ts-loader',
+        exclude: /node_modules/,
+      },
+    ],
+  },
+  resolve: { extensions: [TYPESCRIPT_FILE_EXT, JAVASCRIPT_FILE_EXT] },
+  target: ['node', 'es2023'],
+  entry,
+  output: {
+    filename: `[name]${JAVASCRIPT_FILE_EXT}`,
+    path: resolve(__dirname, 'dist'),
+    library: {
+      type: 'commonjs2',
+    },
+  },
+  plugins: [new CleanWebpackPlugin()],
+};
+
+export default webpackConfig;


### PR DESCRIPTION
## Proposed changes
<!-- Include the Jira ticket number in square brackets as prefix, eg `ATB-1473: Add Egress Queue Methods` -->

### What changed
Added SQS Egress Queue methods to purge and receive the messages

### Why did it change
To validate the next allowable intervention types for the ais event types in the SQS Egress Queue messages


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- List any related PRs -->
- [ATB-1473](https://govukverify.atlassian.net/browse/ATB-1473)

## Testing
<img width="281" alt="Screenshot 2024-02-08 at 15 50 56" src="https://github.com/govuk-one-login/account-interventions-service/assets/111756919/75b31276-8278-4e41-84e0-e60e977955a4">

<img width="431" alt="Screenshot 2024-02-13 at 13 53 46" src="https://github.com/govuk-one-login/account-interventions-service/assets/111756919/90b94e7b-7bdd-4214-88f6-76556bf98429">


<!-- Please give an overview of how the changes were tested -->
<!-- Please specify if changes were tested locally and how, include evidence where relevant -->
<!-- Please specify if changes were deployed and tested in the AWS Account and how, include evidence where relevant -->

## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [x] Tested changes and included test evidence in the PR, if appropriate
- [ ] Included all required tags and other properties for any new resources in the SAM template
- [ ] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [ ] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [ ] Ensured that no log lines include PII or other sensitive data
- [ ] Implemented unit testing for any new logic implemented, if appropriate
- [ ] Ensured that all commits in this PR are signed
- [ ] Ensured appropriate code coverage is maintained by unit tests
- [ ] Checked SonarCube and ensured no code smells were added


[ATB-1473]: https://govukverify.atlassian.net/browse/ATB-1473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ