### PR TITLE
ATB-1482: Validate History values does not exceed 2 years

### DIFF
--- a/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-HappyPath.feature
+++ b/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-HappyPath.feature
@@ -164,12 +164,12 @@ Feature: Invoke-APIGateway-HappyPath.feature
 
 
     @regression
-    Scenario Outline: Happy Path - validate history exceeds 2years - Returns Expected Data for <aisEventType>
+    Scenario Outline: Happy Path - validate history does not contain entries older than 2 years - Returns Expected Data for <aisEventType>
         Given I send an <aisEventType> to a TXMA Ingress queue
         When I invoke the API to retrieve the intervention status of the user's account
         Then I expect the response with <aisEventInterventionType>
         When I update the current transition history time stamp to past in db
-        And I send an another <allowableEventType> and invoke the API
+        And I send an another <allowableEventType> event and then invoke the API
         Then I expect response with <allowableEventInterventionType> and only the latest transition history
         Examples:
             | aisEventType     | aisEventInterventionType       | allowableEventType | historyValue | allowableEventInterventionType |

--- a/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-HappyPath.feature
+++ b/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-HappyPath.feature
@@ -161,3 +161,19 @@ Feature: Invoke-APIGateway-HappyPath.feature
         Given I send a multiple requests to sqs queue to transit from one event type to other event types with single userId
         When I invoke apiGateway to retreive the status of the valid userId with history as true
         Then I should receive every transition event history data in the response for the ais endpoint
+
+
+    @regression
+    Scenario Outline: Happy Path - validate history exceeds 2years - Returns Expected Data for <aisEventType>
+        Given I send an <aisEventType> to a TXMA Ingress queue
+        When I invoke the API to retrieve the intervention status of the user's account
+        Then I expect the response with <aisEventInterventionType>
+        When I update the current transition history time stamp to past in db
+        And I send an another <allowableEventType> and invoke the API
+        Then I expect response with <allowableEventInterventionType> and only the latest transition history
+        Examples:
+            | aisEventType     | aisEventInterventionType       | allowableEventType | historyValue | allowableEventInterventionType |
+            | pswResetRequired | AIS_FORCED_USER_PASSWORD_RESET | block              | true         | AIS_ACCOUNT_BLOCKED            |
+            | suspendNoAction  | AIS_ACCOUNT_SUSPENDED          | unSuspendAction    | true         | AIS_ACCOUNT_UNSUSPENDED        |
+            | block            | AIS_ACCOUNT_BLOCKED            | unblock            | true         | AIS_ACCOUNT_UNBLOCKED          |
+            | pswResetRequired | AIS_FORCED_USER_PASSWORD_RESET | suspendNoAction    | true         | AIS_ACCOUNT_SUSPENDED          |

--- a/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
@@ -409,7 +409,7 @@ defineFeature(feature, (test) => {
     });
   });
 
-  test('Happy Path - validate history exceeds 2years - Returns Expected Data for <aisEventType>', ({
+  test('Happy Path - validate history does not contain entries older than 2 years - Returns Expected Data for <aisEventType>', ({
     given,
     when,
     then,
@@ -448,7 +448,7 @@ defineFeature(feature, (test) => {
       await updateItemInTable(testUserId, updateHistoryTimeStampInTable);
     });
 
-    and(/^I send an another (.*) and invoke the API$/, async (allowableEventType) => {
+    and(/^I send an another (.*) event and then invoke the API$/, async (allowableEventType) => {
       await sendSQSEvent(testUserId, allowableEventType);
       await timeDelayForTestEnvironment(1500);
       response = await invokeGetAccountState(testUserId, true);

--- a/feature-tests/utils/utility.ts
+++ b/feature-tests/utils/utility.ts
@@ -49,3 +49,13 @@ export function attemptParseJSON(jsonString: string) {
     return {};
   }
 }
+
+export function getPastTimestamp(date = new Date()): CurrentTimeDescriptor {
+  date.setFullYear(date.getFullYear() - 2);
+  date.setMonth(date.getMonth() - 2);
+  return {
+    milliseconds: date.valueOf(),
+    isoString: date.toISOString(),
+    seconds: Math.floor(date.valueOf() / 1000),
+  };
+}


### PR DESCRIPTION
## Proposed changes
<!-- Include the Jira ticket number in square brackets as prefix, eg `ATB-1482: Validate History values exceeds 2 years` -->

### What changed
Added scenarios to validate history items that exceeds 2 years

### Why did it change
To improve the coverage

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- List any related PRs -->
- [ATB-1482](https://govukverify.atlassian.net/browse/ATB-1482)

## Testing
<!-- Please give an overview of how the changes were tested -->
<!-- Please specify if changes were tested locally and how, include evidence where relevant -->
<!-- Please specify if changes were deployed and tested in the AWS Account and how, include evidence where relevant -->

## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [x] Tested changes and included test evidence in the PR, if appropriate
- [ ] Included all required tags and other properties for any new resources in the SAM template
- [ ] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [ ] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [ ] Ensured that no log lines include PII or other sensitive data
- [ ] Implemented unit testing for any new logic implemented, if appropriate
- [ ] Ensured that all commits in this PR are signed
- [ ] Ensured appropriate code coverage is maintained by unit tests
- [ ] Checked SonarCube and ensured no code smells were added


[ATB-1482]: https://govukverify.atlassian.net/browse/ATB-1482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ