### PR TITLE
ATB-1513 | Update lambda log level environment variable

### DIFF
--- a/src/infra/main/template.yaml
+++ b/src/infra/main/template.yaml
@@ -132,7 +132,7 @@ Globals:
     KmsKeyArn: !GetAtt LambdaEnvironmentVariableEncryptionKey.Arn
     Environment:
       Variables:
-        LOG_LEVEL: !FindInMap [ EnvConfig, !Ref Environment, LambdaLogLevel ]
+        POWERTOOLS_LOG_LEVEL: !FindInMap [ EnvConfig, !Ref Environment, LambdaLogLevel ]
         POWERTOOLS_SERVICE_NAME: !Ref AWS::StackName
         CLOUDWATCH_METRICS_NAMESPACE: !Ref SystemTagValue
         AWS_LAMBDA_EXEC_WRAPPER: /opt/dynatrace


### PR DESCRIPTION
## Proposed changes
[ATB-1513](https://govukverify.atlassian.net/browse/ATB-1513)

### What changed
updated `LOG_LEVEL` environment variable to `POWERTOOLS_LOG_LEVEL`

### Why did it change
The environment variable that the powertools lambda logger dependency uses has been updated in the documentation to POWERTOOLS_LOG_LEVEL (the LOG_LEVEL is now a legacy name, although it is currently still being supported)

## Testing
Locally, passes `yarn lint:iac`
<img width="1201" alt="Screenshot 2024-03-05 at 14 41 38" src="https://github.com/govuk-one-login/account-interventions-service/assets/130994595/77c4b92f-bb8e-4358-b201-94e6334b030c">

Stack successfully deploys:
<img width="719" alt="Screenshot 2024-03-05 at 14 46 22" src="https://github.com/govuk-one-login/account-interventions-service/assets/130994595/e72b6b7a-9096-48bb-976c-66a7b6ece78f">

Shows in each lambdas environment variables in AWS:
<img width="1066" alt="Screenshot 2024-03-05 at 14 51 33" src="https://github.com/govuk-one-login/account-interventions-service/assets/130994595/f9c4c18d-d0f0-4061-81ab-c4dede682cec">

Cloudwatch logs retain functionality:
<img width="1411" alt="Screenshot 2024-03-05 at 15 03 21" src="https://github.com/govuk-one-login/account-interventions-service/assets/130994595/171f991f-3b17-4e28-a4a0-708c02c43799">

## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [x] Tested changes and included test evidence in the PR, if appropriate
- [ ] Included all required tags and other properties for any new resources in the SAM template
- [x] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [ ] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [ ] Ensured that no log lines include PII or other sensitive data
- [ ] Implemented unit testing for any new logic implemented, if appropriate
- [x] Ensured that all commits in this PR are signed
- [ ] Ensured appropriate code coverage is maintained by unit tests
- [ ] Checked SonarCube and ensured no code smells were added


[ATB-1513]: https://govukverify.atlassian.net/browse/ATB-1513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ