### PR TITLE
ATB -1554 | Updating Alarm Severities 

### DIFF
--- a/src/infra/alarm/template.yaml
+++ b/src/infra/alarm/template.yaml
@@ -624,7 +624,7 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Ref AlertingSNSHighAlertNotificationTopicARN
+        - !Ref AlertingSNSLowAlertNotificationTopicARN
       AlarmDescription: "Messages from TxMA have an average latency above 5s."
       Namespace: !Ref SystemTagValue
       MetricName: EVENT_DELIVERY_LATENCY
@@ -643,7 +643,7 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Ref AlertingSNSHighAlertNotificationTopicARN
+        - !Ref AlertingSNSLowAlertNotificationTopicARN
       AlarmDescription: "Messages from TxMA have a maximum latency above 10s."
       Namespace: !Ref SystemTagValue
       MetricName: EVENT_DELIVERY_LATENCY

--- a/src/infra/alarm/template.yaml
+++ b/src/infra/alarm/template.yaml
@@ -55,7 +55,7 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Ref AlertingSNSHighAlertNotificationTopicARN
+        - !Ref AlertingSNSLowAlertNotificationTopicARN
       AlarmDescription: "TxMA Egress queue processing too slow"
       ComparisonOperator: GreaterThanThreshold
       Threshold: 600
@@ -93,7 +93,7 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Ref AlertingSNSHighAlertNotificationTopicARN
+        - !Ref AlertingSNSLowAlertNotificationTopicARN
       AlarmDescription: "TxMA Egress queue has too many messages"
       ComparisonOperator: GreaterThanThreshold
       Threshold: 50
@@ -131,7 +131,7 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Ref AlertingSNSHighAlertNotificationTopicARN
+        - !Ref AlertingSNSLowAlertNotificationTopicARN
       AlarmDescription: "TxMA Egress DLQ has too many messages"
       ComparisonOperator: GreaterThanThreshold
       Threshold: 10
@@ -304,7 +304,7 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Ref AlertingSNSHighAlertNotificationTopicARN
+        - !Ref AlertingSNSLowAlertNotificationTopicARN
       AlarmDescription: "Too many Interventions received were not allowed on current account state."
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Threshold: 5
@@ -346,7 +346,7 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Ref AlertingSNSHighAlertNotificationTopicARN
+        - !Ref AlertingSNSLowAlertNotificationTopicARN
       AlarmDescription: "Too many received intervention events are invalid."
       Namespace: !Ref SystemTagValue
       MetricName: INVALID_EVENT_RECEIVED
@@ -441,7 +441,7 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Ref AlertingSNSHighAlertNotificationTopicARN
+        - !Ref AlertingSNSLowAlertNotificationTopicARN
       AlarmDescription: "Too many intervention event messages are out of order."
       Namespace: !Ref SystemTagValue
       MetricName: INTERVENTION_EVENT_STALE
@@ -600,25 +600,6 @@ Resources:
 # Cloudwatch alarms for TxMA Latency
 #
 
-  AverageTxMALatencyOver1Sec:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      ActionsEnabled: true
-      AlarmActions:
-        - !Ref AlertingSNSLowAlertNotificationTopicARN
-      AlarmDescription: "Messages from TxMA have an average latency of 1s."
-      Namespace: !Ref SystemTagValue
-      MetricName: EVENT_DELIVERY_LATENCY
-      ComparisonOperator: GreaterThanThreshold
-      Statistic: Average
-      Threshold: 1000
-      EvaluationPeriods: 1
-      Period: 60
-      TreatMissingData: notBreaching
-      Dimensions:
-        - Name: service
-          Value: InterventionsProcessorFunction
-
   AverageTxMALatencyOver2Sec:
     Type: AWS::CloudWatch::Alarm
     Properties:
@@ -723,7 +704,7 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Ref AlertingSNSHighAlertNotificationTopicARN
+        - !Ref AlertingSNSLowAlertNotificationTopicARN
       AlarmDescription: "History string may be missing required components"
       Namespace: !Ref SystemTagValue
       MetricName: INVALID_HISTORY_STRING


### PR DESCRIPTION
## Proposed changes
<!-- Include the Jira ticket number in square brackets as prefix, eg `ATB-XXXX: Description of Change` -->
ATB-1554 | Review Alarm Thresholds and Severities [Part 1 - looking at severities only]
### What changed
<!-- Describe the changes in detail - the "what"-->

Changed the following from High to Low:
- TxMAEgressQueueProcessingTooSlow
- TxMAEgressQueueTooManyMessages
- TxMAEgressDLQTooManyMessages
- TooManyInterventionNotAllowed
- TooManyInvalidEventsReceived
- TooManyInterventionEventStale
- InvalidHistoryString

Removed AverageTxMALatencyOver1Sec Alarm because we believe it will be too sensitive to have. 

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->

Refining Alarm severities prior to integrating with Pager Duty 
### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- List any related PRs -->
- [ATB-1554](https://govukverify.atlassian.net/browse/ATB-1554)

## Testing
<!-- Please give an overview of how the changes were tested -->
<!-- Please specify if changes were tested locally and how, include evidence where relevant -->
<!-- Please specify if changes were deployed and tested in the AWS Account and how, include evidence where relevant -->

## Checklists
- [ ] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [ ] Tested changes and included test evidence in the PR, if appropriate
- [ ] Included all required tags and other properties for any new resources in the SAM template
- [ ] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [ ] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [ ] Ensured that no log lines include PII or other sensitive data
- [ ] Implemented unit testing for any new logic implemented, if appropriate
- [ ] Ensured that all commits in this PR are signed
- [ ] Ensured appropriate code coverage is maintained by unit tests
- [ ] Checked SonarCube and ensured no code smells were added


[ATB-1554]: https://govukverify.atlassian.net/browse/ATB-1554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ