### PR TITLE
ATB-1551: added unhappy path scenarios around history values

### DIFF
--- a/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-UnHappyPath.feature
+++ b/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-UnHappyPath.feature
@@ -57,3 +57,17 @@ Feature: Invoke-APIGateway-UnHappyPath.feature
             | suspendNoAction | text/html        | */*    | Missing Authentication Token |
             | suspendNoAction | application/json |        | Missing Authentication Token |
             | suspendNoAction |                  | */*    | Missing Authentication Token |
+
+    @regression
+    Scenario Outline: UnHappy Path - Get Request to /ais/userId - Mixed Case History values - Returns Expected Data for <aisEventType>
+        Given I send an valid <aisEventType> request to sqs queue
+        When I invoke apiGateway to retreive the status userId with <historyValue>
+        Then I should receive the response with no history items for the ais endpoint
+        Examples:
+            | aisEventType    | historyValue |
+            | suspendNoAction | FALSE        |
+            | suspendNoAction | tRuE         |
+            | suspendNoAction | TrueFalse    |
+            | suspendNoAction | Truee        |
+            | suspendNoAction | *&           |
+            | suspendNoAction | TRUE         |

--- a/feature-tests/tests/resources/step-definitions/invoke-api-gateway-unhappy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/invoke-api-gateway-unhappy-path.step.ts
@@ -6,6 +6,7 @@ import { timeDelayForTestEnvironment } from '../../../utils/utility';
 import EndPoints from '../../../apiEndpoints/endpoints';
 import request from 'supertest';
 import { App } from 'supertest/types';
+import { InvokeCommand, LambdaClient } from '@aws-sdk/client-lambda';
 
 const feature = loadFeature('./tests/resources/features/aisGET/InvokeApiGateWay-UnHappyPath.feature');
 
@@ -154,4 +155,26 @@ defineFeature(feature, (test) => {
       }
     });
   });
+
+  test('UnHappy Path - Get Request to /ais/userId - Mixed Case History values - Returns Expected Data for <aisEventType>', ({
+    given,
+    when,
+    then,
+  }) => {
+    given(/^I send an valid (.*) request to sqs queue$/, async function (aisEventType) {
+          await sendSQSEvent(testUserId, aisEventType);
+    });
+
+    when(
+      /^I invoke apiGateway to retreive the status userId with (.*)$/,
+      async (historyValue) => {
+        await timeDelayForTestEnvironment(1500);
+        response = await invokeGetAccountState(testUserId, historyValue);
+      }
+    );
+
+    then(/^I should receive the response with no history items for the ais endpoint$/, async () => {
+        expect(response.history).toBeFalsy();
+      });
+    });
 });

--- a/feature-tests/tests/resources/step-definitions/invoke-api-gateway-unhappy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/invoke-api-gateway-unhappy-path.step.ts
@@ -6,7 +6,6 @@ import { timeDelayForTestEnvironment } from '../../../utils/utility';
 import EndPoints from '../../../apiEndpoints/endpoints';
 import request from 'supertest';
 import { App } from 'supertest/types';
-import { InvokeCommand, LambdaClient } from '@aws-sdk/client-lambda';
 
 const feature = loadFeature('./tests/resources/features/aisGET/InvokeApiGateWay-UnHappyPath.feature');
 
@@ -162,19 +161,16 @@ defineFeature(feature, (test) => {
     then,
   }) => {
     given(/^I send an valid (.*) request to sqs queue$/, async function (aisEventType) {
-          await sendSQSEvent(testUserId, aisEventType);
+      await sendSQSEvent(testUserId, aisEventType);
     });
 
-    when(
-      /^I invoke apiGateway to retreive the status userId with (.*)$/,
-      async (historyValue) => {
-        await timeDelayForTestEnvironment(1500);
-        response = await invokeGetAccountState(testUserId, historyValue);
-      }
-    );
+    when(/^I invoke apiGateway to retreive the status userId with (.*)$/, async (historyValue) => {
+      await timeDelayForTestEnvironment(1500);
+      response = await invokeGetAccountState(testUserId, historyValue);
+    });
 
     then(/^I should receive the response with no history items for the ais endpoint$/, async () => {
-        expect(response.history).toBeFalsy();
-      });
+      expect(response.history).toBeFalsy();
     });
+  });
 });

--- a/src/infra/alarm/template.yaml
+++ b/src/infra/alarm/template.yaml
@@ -55,7 +55,7 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Ref AlertingSNSHighAlertNotificationTopicARN
+        - !Ref AlertingSNSLowAlertNotificationTopicARN
       AlarmDescription: "TxMA Egress queue processing too slow"
       ComparisonOperator: GreaterThanThreshold
       Threshold: 600
@@ -93,7 +93,7 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Ref AlertingSNSHighAlertNotificationTopicARN
+        - !Ref AlertingSNSLowAlertNotificationTopicARN
       AlarmDescription: "TxMA Egress queue has too many messages"
       ComparisonOperator: GreaterThanThreshold
       Threshold: 50
@@ -131,7 +131,7 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Ref AlertingSNSHighAlertNotificationTopicARN
+        - !Ref AlertingSNSLowAlertNotificationTopicARN
       AlarmDescription: "TxMA Egress DLQ has too many messages"
       ComparisonOperator: GreaterThanThreshold
       Threshold: 10
@@ -304,7 +304,7 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Ref AlertingSNSHighAlertNotificationTopicARN
+        - !Ref AlertingSNSLowAlertNotificationTopicARN
       AlarmDescription: "Too many Interventions received were not allowed on current account state."
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Threshold: 5
@@ -346,7 +346,7 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Ref AlertingSNSHighAlertNotificationTopicARN
+        - !Ref AlertingSNSLowAlertNotificationTopicARN
       AlarmDescription: "Too many received intervention events are invalid."
       Namespace: !Ref SystemTagValue
       MetricName: INVALID_EVENT_RECEIVED
@@ -441,7 +441,7 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Ref AlertingSNSHighAlertNotificationTopicARN
+        - !Ref AlertingSNSLowAlertNotificationTopicARN
       AlarmDescription: "Too many intervention event messages are out of order."
       Namespace: !Ref SystemTagValue
       MetricName: INTERVENTION_EVENT_STALE
@@ -600,25 +600,6 @@ Resources:
 # Cloudwatch alarms for TxMA Latency
 #
 
-  AverageTxMALatencyOver1Sec:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      ActionsEnabled: true
-      AlarmActions:
-        - !Ref AlertingSNSLowAlertNotificationTopicARN
-      AlarmDescription: "Messages from TxMA have an average latency of 1s."
-      Namespace: !Ref SystemTagValue
-      MetricName: EVENT_DELIVERY_LATENCY
-      ComparisonOperator: GreaterThanThreshold
-      Statistic: Average
-      Threshold: 1000
-      EvaluationPeriods: 1
-      Period: 60
-      TreatMissingData: notBreaching
-      Dimensions:
-        - Name: service
-          Value: InterventionsProcessorFunction
-
   AverageTxMALatencyOver2Sec:
     Type: AWS::CloudWatch::Alarm
     Properties:
@@ -643,7 +624,7 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Ref AlertingSNSHighAlertNotificationTopicARN
+        - !Ref AlertingSNSLowAlertNotificationTopicARN
       AlarmDescription: "Messages from TxMA have an average latency above 5s."
       Namespace: !Ref SystemTagValue
       MetricName: EVENT_DELIVERY_LATENCY
@@ -662,7 +643,7 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Ref AlertingSNSHighAlertNotificationTopicARN
+        - !Ref AlertingSNSLowAlertNotificationTopicARN
       AlarmDescription: "Messages from TxMA have a maximum latency above 10s."
       Namespace: !Ref SystemTagValue
       MetricName: EVENT_DELIVERY_LATENCY
@@ -723,7 +704,7 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Ref AlertingSNSHighAlertNotificationTopicARN
+        - !Ref AlertingSNSLowAlertNotificationTopicARN
       AlarmDescription: "History string may be missing required components"
       Namespace: !Ref SystemTagValue
       MetricName: INVALID_HISTORY_STRING


### PR DESCRIPTION
## Proposed changes
<!-- Include the Jira ticket number in square brackets as prefix, eg `ATB-1551: added unhappy path scenarios around history values` -->

### What changed
<!-- Describe the changes in detail - the "what"-->

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- List any related PRs -->
- [ATB-1551](https://govukverify.atlassian.net/browse/ATB-1551)

## Testing
<!-- Please give an overview of how the changes were tested -->
<!-- Please specify if changes were tested locally and how, include evidence where relevant -->
<!-- Please specify if changes were deployed and tested in the AWS Account and how, include evidence where relevant -->

## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [x] Tested changes and included test evidence in the PR, if appropriate
- [ ] Included all required tags and other properties for any new resources in the SAM template
- [ ] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [ ] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [ ] Ensured that no log lines include PII or other sensitive data
- [ ] Implemented unit testing for any new logic implemented, if appropriate
- [ ] Ensured that all commits in this PR are signed
- [ ] Ensured appropriate code coverage is maintained by unit tests
- [ ] Checked SonarCube and ensured no code smells were added


[ATB-1551]: https://govukverify.atlassian.net/browse/ATB-1551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ