### PR TITLE
Metric Dimensions

### DIFF
--- a/src/commons/metrics.ts
+++ b/src/commons/metrics.ts
@@ -32,6 +32,11 @@ export function addMetric(
   }
 }
 
+/**
+ * Function to check if any metrics are currently stored in the buffer
+ * it serialises the data stored in the buffer and checks if the Metrics array has any elements
+ * If so it returns true, false otherwise
+ */
 function checkIfAnyMetricToPublish() {
   const emfOutput: EmfOutput = metric.serializeMetrics();
   return emfOutput._aws.CloudWatchMetrics[0] ? emfOutput._aws.CloudWatchMetrics[0].Metrics.length > 0 : false;

--- a/src/commons/metrics.ts
+++ b/src/commons/metrics.ts
@@ -21,6 +21,12 @@ export function addMetric(
   for (const data of metadata) {
     metric.addMetadata(data.key, data.value);
   }
-  metric.addMetric(metricName, MetricUnits.Count, value);
-  if (dimensions) metric.addDimensions(dimensions);
+  if (dimensions) {
+    metric.publishStoredMetrics();
+    metric.addDimensions(dimensions);
+    metric.addMetric(metricName, MetricUnits.Count, value);
+    metric.publishStoredMetrics();
+  } else {
+    metric.addMetric(metricName, MetricUnits.Count, value);
+  }
 }

--- a/src/commons/metrics.ts
+++ b/src/commons/metrics.ts
@@ -1,5 +1,6 @@
 import { AppConfigService } from '../services/app-config-service';
 import { Metrics, MetricUnits } from '@aws-lambda-powertools/metrics';
+import { EmfOutput } from '@aws-lambda-powertools/metrics/lib/types';
 
 const namespace = AppConfigService.getInstance().cloudWatchMetricsWorkSpace;
 const service = AppConfigService.getInstance().metricServiceName;
@@ -22,11 +23,16 @@ export function addMetric(
     metric.addMetadata(data.key, data.value);
   }
   if (dimensions) {
-    metric.publishStoredMetrics();
+    if (checkIfAnyMetricToPublish()) metric.publishStoredMetrics();
     metric.addDimensions(dimensions);
     metric.addMetric(metricName, MetricUnits.Count, value);
     metric.publishStoredMetrics();
   } else {
     metric.addMetric(metricName, MetricUnits.Count, value);
   }
+}
+
+function checkIfAnyMetricToPublish() {
+  const emfOutput: EmfOutput = metric.serializeMetrics();
+  return emfOutput._aws.CloudWatchMetrics[0] ? emfOutput._aws.CloudWatchMetrics[0].Metrics.length > 0 : false;
 }

--- a/src/commons/test/metrics.test.ts
+++ b/src/commons/test/metrics.test.ts
@@ -9,7 +9,7 @@ const mockPublishStoredMetrics = Metrics.prototype.publishStoredMetrics as jest.
 const mockAddMetadata = Metrics.prototype.addMetadata as jest.Mock;
 const mockAddMetric = Metrics.prototype.addMetric as jest.Mock;
 const mockAddDimensions = Metrics.prototype.addDimensions as jest.Mock;
-mockSerialiseMetrics.mockReturnValue({ _aws: 'this is the serialised data' });
+mockSerialiseMetrics.mockReturnValue({ _aws: { CloudWatchMetrics : [ { Metrics : [ "some metrics "] } ] } } );
 
 describe('metrics', () => {
   beforeEach(() => {

--- a/src/commons/test/metrics.test.ts
+++ b/src/commons/test/metrics.test.ts
@@ -41,6 +41,6 @@ describe('metrics', () => {
     expect(mockAddMetric).toHaveBeenCalledTimes(1);
     expect(mockAddMetric).toHaveBeenCalledWith('testMetricName', 'Count', 1);
     expect(mockAddDimensions).toHaveBeenCalledWith({ dimensionKey : 'dimensionValue' })
-    expect(mockPublishStoredMetrics).not.toHaveBeenCalled()
+    expect(mockPublishStoredMetrics).toHaveBeenCalledTimes(2)
   })
 });


### PR DESCRIPTION
This PR merges changes needed to ensure that metrics only get logged with dimensions where those are relevant/expected. When using the add metric method and passing it dimensions to add, those dimensions are added to all of the metrics currently stored in the buffer. This causes dimensions being applied to metrics that should not have them. The proposed solution is to publish metric if any are stored before we add any dimensions, once the dimensions are added the buffer should be flushed (publish metrics) so that the passed dimensions are only used for the specific metric

## Proposed changes

### What changed
- added logic inside the addMetric function to publish stored metrics (if any) before dimensions are added
- added logic inside the addMetric function to publish stored metrics after adding a metric with dimension so that those dimensions are not applied to subsequent metrics being published

### Why did it change
So to only apply dimensions where required and still keep publishing metric operation to a minimum

### Issue tracking


## Testing
Deployed to account:
- event applied metric logged with only eventName dimension: user was put into psw and id reset required
![Screenshot 2024-03-20 at 21 20 00](https://github.com/govuk-one-login/account-interventions-service/assets/110468890/d1a84805-8f0e-455c-b518-6d6c5f23971b)

- time to resolve metric logged with only type dimensions: psw marked as reset and then identity marked as reset
![Screenshot 2024-03-20 at 21 21 41](https://github.com/govuk-one-login/account-interventions-service/assets/110468890/9e502326-ebee-4c40-bd06-3e08e2a9ce0b)
![Screenshot 2024-03-20 at 21 27 31](https://github.com/govuk-one-login/account-interventions-service/assets/110468890/71837abc-c9a9-420f-a02e-8c14eb46f35a)

- account is blocked 
![Screenshot 2024-03-20 at 21 36 01](https://github.com/govuk-one-login/account-interventions-service/assets/110468890/65c14c50-c40a-47a1-b5b5-93778da02683)

- account is unblocked
![Screenshot 2024-03-20 at 21 36 58](https://github.com/govuk-one-login/account-interventions-service/assets/110468890/e37cf33a-8c09-4577-9dcc-0b466a6bc7a3)

- account is suspended
![Screenshot 2024-03-20 at 21 37 56](https://github.com/govuk-one-login/account-interventions-service/assets/110468890/914097b4-0e29-470a-a20c-ae5ca4e4edb0)

- account is deleted
![Screenshot 2024-03-20 at 21 39 21](https://github.com/govuk-one-login/account-interventions-service/assets/110468890/1bd4ed09-a12b-4212-bd41-9fab20686b99)

## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [x] Tested changes and included test evidence in the PR, if appropriate
- [ ] Included all required tags and other properties for any new resources in the SAM template
- [ ] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [ ] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [x] Ensured that no log lines include PII or other sensitive data
- [x] Implemented unit testing for any new logic implemented, if appropriate
- [x] Ensured that all commits in this PR are signed
- [x] Ensured appropriate code coverage is maintained by unit tests
- [ ] Checked SonarCube and ensured no code smells were added
