### PR TITLE
ATB-1552:Implemented the unhappy path scenario for userActionIdResetSuccess

### DIFF
--- a/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-UnHappyPath.feature
+++ b/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-UnHappyPath.feature
@@ -71,3 +71,13 @@ Feature: Invoke-APIGateway-UnHappyPath.feature
             | suspendNoAction | Truee        |
             | suspendNoAction | *&           |
             | suspendNoAction | TRUE         |
+
+    @regression
+    Scenario Outline: UnHappy Path - Get Request to /ais/userId - Level of Confidence for userActionIdResetSuccess - Returns Expected Data for <aisEventType>
+        Given I send a valid request with event <aisEventType> to the sqs queue
+        And I send an other invalid event with invalid level of confidence <invalidAisEventType> to the txma sqs queue
+        When I invoke an apiGateway to retreive the status of the userId
+        Then I should receive the response without the reprovedIdentityAt value
+        Examples:
+            | aisEventType    | invalidAisEventType      |
+            | idResetRequired | userActionIdResetSuccess |

--- a/feature-tests/tests/resources/step-definitions/invoke-api-gateway-unhappy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/invoke-api-gateway-unhappy-path.step.ts
@@ -173,4 +173,32 @@ defineFeature(feature, (test) => {
       expect(response.history).toBeFalsy();
     });
   });
+
+  test('UnHappy Path - Get Request to /ais/userId - Level of Confidence for userActionIdResetSuccess - Returns Expected Data for <aisEventType>', ({
+    given,
+    when,
+    and,
+    then,
+  }) => {
+    given(/^I send a valid request with event (.*) to the sqs queue$/, async function (aisEventType) {
+      await sendSQSEvent(testUserId, aisEventType);
+    });
+
+    and(
+      /^I send an other invalid event with invalid level of confidence (.*) to the txma sqs queue$/,
+      async (invalidAisEventType) => {
+        await timeDelayForTestEnvironment(1500);
+        await sendInvalidSQSEvent(testUserId, invalidAisEventType);
+      },
+    );
+
+    when(/^I invoke an apiGateway to retreive the status of the userId$/, async () => {
+      await timeDelayForTestEnvironment(1500);
+      response = await invokeGetAccountState(testUserId, true);
+    });
+
+    then(/^I should receive the response without the reprovedIdentityAt value$/, async () => {
+      expect(response.intervention.reproveIdentityAt).toBeFalsy();
+    });
+  });
 });

--- a/feature-tests/utils/invalid-ais-events.ts
+++ b/feature-tests/utils/invalid-ais-events.ts
@@ -193,6 +193,29 @@ export const invalidAisEvents = {
       },
     },
   },
+
+  userActionIdResetSuccess: {
+    event_name: 'IPV_IDENTITY_ISSUED',
+    event_id: '123',
+    timestamp: currentTime.seconds,
+    event_timestamp_ms: currentTime.milliseconds,
+    client_id: 'UNKNOWN',
+    component_id: 'UNKNOWN',
+    user: {
+      user_id: 'urn:fdc:gov.uk:2022:USER_ONE',
+      email: '',
+      phone: 'UNKNOWN',
+      ip_address: '',
+      session_id: '',
+      persistent_session_id: '',
+      govuk_signin_journey_id: '',
+    },
+    extensions: {
+      levelOfConfidence: 'P1',
+      ciFail: false,
+      hasMitigations: false,
+    },
+  },
 };
 
 function getCurrentTimestamp(date = new Date()): CurrentTimeDescriptor {


### PR DESCRIPTION
## Proposed changes
<!-- Include the Jira ticket number in square brackets as prefix, eg `ATB-1552:Implemented the unhappy path scenario for userActionIdResetSuccess` -->

### What changed
Implemented unhappy path scenario for user led actions 
<!-- Describe the changes in detail - the "what"-->

### Why did it change
it should only update status on `IPV_IDENTITY_ISSUED` when `levelOfConfidence` equals `P2`. it shouldnt update if the level of confidence is other than p2
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- List any related PRs -->
- [ATB-1552](https://govukverify.atlassian.net/browse/ATB-1552)

## Testing
<img width="409" alt="Screenshot 2024-03-22 at 11 47 32" src="https://github.com/govuk-one-login/account-interventions-service/assets/111756919/ea099d59-db7b-404b-8be3-d0f672df4f8d">

<!-- Please give an overview of how the changes were tested -->
<!-- Please specify if changes were tested locally and how, include evidence where relevant -->
<!-- Please specify if changes were deployed and tested in the AWS Account and how, include evidence where relevant -->

## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [x] Tested changes and included test evidence in the PR, if appropriate
- [ ] Included all required tags and other properties for any new resources in the SAM template
- [ ] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [ ] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [ ] Ensured that no log lines include PII or other sensitive data
- [ ] Implemented unit testing for any new logic implemented, if appropriate
- [ ] Ensured that all commits in this PR are signed
- [ ] Ensured appropriate code coverage is maintained by unit tests
- [ ] Checked SonarCube and ensured no code smells were added


[ATB-1552]: https://govukverify.atlassian.net/browse/ATB-1552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ