### PR TITLE
ATB-1580: Remove ConfidenceLevelTooLow alarm

### DIFF
--- a/src/infra/alarm/template.yaml
+++ b/src/infra/alarm/template.yaml
@@ -740,25 +740,6 @@ Resources:
         - Name: service
           Value: InterventionsProcessorFunction
 
-  LevelOfConfidenceTooLow:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      ActionsEnabled: true
-      AlarmActions:
-        - !Ref AlertingSNSLowAlertNotificationTopicARN
-      AlarmDescription: !Sub "Level of confidence is too low. ${RunBookURL}"
-      Namespace: !Ref SystemTagValue
-      MetricName: CONFIDENCE_LEVEL_TOO_LOW
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      Statistic: Sum
-      Unit: Count
-      Threshold: 5
-      EvaluationPeriods: 1
-      Period: 60
-      TreatMissingData: notBreaching
-      Dimensions:
-        - Name: service
-          Value: InterventionsProcessorFunction
 
   InterventionEventStale:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
## Proposed changes
This PR merges changes to remove the `ConfidenceLevelTooLow` Alarm

Rationale: this alarm is triggered when multiple IPV_IDENTITY_ISSUED events are received with a confidence level other than P2. This is creating a lot of noise as those events are legitimate events that users will generate, and when the related metric is logged we do not know the current status of the account and if it is in need of an identity reset, in which case the supplied confidence level is too low. 

As such this alarm is not currently giving us any useful information

I have left a comment on the monitoring runbook to flag this change

### What changed
Deleted alarm from alarm template

### Why did it change
reduce noise 

### Issue tracking

- [ATB-1580](https://govukverify.atlassian.net/browse/ATB-1580)



[ATB-1580]: https://govukverify.atlassian.net/browse/ATB-1580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ