### PR TITLE
ATB-1650 | Update API Spec and Lambda Permissions to enable Lambda Rollback through ClickOps

### DIFF
--- a/src/handlers/status-retriever-handler.ts
+++ b/src/handlers/status-retriever-handler.ts
@@ -20,7 +20,7 @@ const dynamoDatabaseServiceInstance = new DynamoDatabaseService(appConfig.tableN
 export const handle = async (event: APIGatewayEvent, context: Context): Promise<APIGatewayProxyResult> => {
   logger.addContext(context);
 
-  logger.debug('I am the new version of the lambda 143!');
+  logger.debug('I am the new version of the lambda 144!');
 
   if (!event.pathParameters?.['userId']) {
     addMetric(MetricNames.INVALID_SUBJECT_ID);

--- a/src/handlers/status-retriever-handler.ts
+++ b/src/handlers/status-retriever-handler.ts
@@ -20,8 +20,6 @@ const dynamoDatabaseServiceInstance = new DynamoDatabaseService(appConfig.tableN
 export const handle = async (event: APIGatewayEvent, context: Context): Promise<APIGatewayProxyResult> => {
   logger.addContext(context);
 
-  logger.debug('I am the new version of the lambda 144!');
-
   if (!event.pathParameters?.['userId']) {
     addMetric(MetricNames.INVALID_SUBJECT_ID);
     metric.publishStoredMetrics();

--- a/src/handlers/status-retriever-handler.ts
+++ b/src/handlers/status-retriever-handler.ts
@@ -20,6 +20,8 @@ const dynamoDatabaseServiceInstance = new DynamoDatabaseService(appConfig.tableN
 export const handle = async (event: APIGatewayEvent, context: Context): Promise<APIGatewayProxyResult> => {
   logger.addContext(context);
 
+  logger.debug('I am the new version of the lambda!');
+
   if (!event.pathParameters?.['userId']) {
     addMetric(MetricNames.INVALID_SUBJECT_ID);
     metric.publishStoredMetrics();

--- a/src/handlers/status-retriever-handler.ts
+++ b/src/handlers/status-retriever-handler.ts
@@ -20,7 +20,7 @@ const dynamoDatabaseServiceInstance = new DynamoDatabaseService(appConfig.tableN
 export const handle = async (event: APIGatewayEvent, context: Context): Promise<APIGatewayProxyResult> => {
   logger.addContext(context);
 
-  logger.debug('I am the new version of the lambda!');
+  logger.debug('I am the new version of the lambda 143!');
 
   if (!event.pathParameters?.['userId']) {
     addMetric(MetricNames.INVALID_SUBJECT_ID);

--- a/src/infra/main/template.yaml
+++ b/src/infra/main/template.yaml
@@ -127,7 +127,7 @@ Globals:
     Architectures:
       - arm64
     Tracing: Active
-    AutoPublishAlias: latest
+    AutoPublishAlias: live
     CodeUri: ../../handlers
     KmsKeyArn: !GetAtt LambdaEnvironmentVariableEncryptionKey.Arn
     Environment:
@@ -213,11 +213,16 @@ Resources:
 
 
   InterventionsProcessorFunctionInvokePermission:
-    Type: 'AWS::Lambda::Permission'
+    DependsOn: InterventionsProcessorFunctionAliaslive
+    Type: AWS::Lambda::Permission
     Properties:
-      FunctionName: !GetAtt InterventionsProcessorFunction.Arn
-      Action: 'lambda:InvokeFunction'
-      Principal: 'sqs.amazonaws.com'
+      FunctionName: !Join
+        - ':'
+        - - 'function'
+          - !Select [ 6, !Split [ ':', !GetAtt InterventionsProcessorFunction.Arn ] ]
+          - 'live'
+      Action: lambda:InvokeFunction
+      Principal: sqs.amazonaws.com
       SourceAccount: !If
         - IsInternal
         - !Ref AWS::AccountId
@@ -426,10 +431,15 @@ Resources:
         EntryPoints:
           - account-deletion-processor-handler.ts
 
-  AccountDeletionProcessorResourcePolicy:
+  AccountDeletionProcessorFunctionPermission:
+    DependsOn: AccountDeletionProcessorFunctionAliaslive
     Type: AWS::Lambda::Permission
     Properties:
-      FunctionName: !Ref AccountDeletionProcessorFunction
+      FunctionName: !Join
+        - ':'
+        - - 'function'
+          - !Select [ 6, !Split [ ':', !GetAtt AccountDeletionProcessorFunction.Arn ] ]
+          - 'live'
       Action: lambda:InvokeFunction
       Principal: sns.amazonaws.com
       SourceAccount: !Ref AWS::AccountId
@@ -1203,6 +1213,8 @@ Resources:
             Location: "../../specs/api.yaml"
       Description: "Private REST API that provides method to interact with the Account Interventions Services"
       StageName: !Ref ApiStageName
+      OpenApiVersion: 3.0.3
+      PropagateTags: true
       Auth:
         ResourcePolicy:
           IntrinsicVpcWhitelist:
@@ -1292,9 +1304,14 @@ Resources:
       FilterPattern: ""
 
   PrivateGatewayStatusRetrieverFunctionPermission:
+    DependsOn: StatusRetrieverFunctionAliaslive
     Type: AWS::Lambda::Permission
     Properties:
-      FunctionName: !Ref StatusRetrieverFunction
+      FunctionName: !Join
+        - ':'
+        - - 'function'
+          - !Select [ 6, !Split [ ':', !GetAtt StatusRetrieverFunction.Arn ] ]
+          - 'live'
       Action: lambda:InvokeFunction
       Principal: apigateway.amazonaws.com
       SourceAccount: !Ref AWS::AccountId

--- a/src/specs/api.yaml
+++ b/src/specs/api.yaml
@@ -65,7 +65,7 @@ paths:
         httpMethod: "POST"
         type: aws_proxy
         uri:
-          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${StatusRetrieverFunction.Arn}/invocations"
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${StatusRetrieverFunction.Arn}:live/invocations"
 
 components:
   schemas:

--- a/src/specs/api.yaml
+++ b/src/specs/api.yaml
@@ -65,7 +65,7 @@ paths:
         httpMethod: "POST"
         type: aws_proxy
         uri:
-          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${StatusRetrieverFunction.Arn}:latest/invocations"
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${StatusRetrieverFunction.Arn}/invocations"
 
 components:
   schemas:

--- a/src/specs/api.yaml
+++ b/src/specs/api.yaml
@@ -65,7 +65,7 @@ paths:
         httpMethod: "POST"
         type: aws_proxy
         uri:
-          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${StatusRetrieverFunction.Arn}/invocations"
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${StatusRetrieverFunction.Arn}:latest/invocations"
 
 components:
   schemas:


### PR DESCRIPTION
## Proposed changes
<!-- Include the Jira ticket number in square brackets as prefix, eg `ATB-XXXX: Description of Change` -->
ATB-1650 | Update Api Spec and Lambda Permissions to enable Lambda Rollback through ClickOps

### What changed
<!-- Describe the changes in detail - the "what"-->
- Updated API Spec to reference to live instead of latest  
- Updated `AWS::Lambda::Permission` resource to reference Alias at the `FunctionName` property so that when the Trigger  is attached to our Alias version,  This is important so that if we ever need to rollback our Lambda / new version is created, the trigger will be attached to the correct version of the Lambda function and uses the latest version rather than any older version so no unexpected behaviour can take place. 


### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
Testing out ClickOps as a Lambda Rollback Option 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- List any related PRs -->
- [ATB-1650](https://govukverify.atlassian.net/browse/ATB-1650)

## Testing
<!-- Please give an overview of how the changes were tested -->
<!-- Please specify if changes were tested locally and how, include evidence where relevant -->
<!-- Please specify if changes were deployed and tested in the AWS Account and how, include evidence where relevant -->

**Status Retriever** 
Prior to Rollback:
<img width="1130" alt="Screenshot 2024-04-26 at 13 49 32" src="https://github.com/govuk-one-login/account-interventions-service/assets/116737136/3cf84967-3b05-4d7c-8605-0547616bed5c">
After changing Alias - Rollback : 
<img width="1155" alt="Screenshot 2024-04-26 at 13 50 32" src="https://github.com/govuk-one-login/account-interventions-service/assets/116737136/14820adf-1858-42d4-8241-b9b694254707">

**Interventions Processor**
Prior to Rollback: 
<img width="1111" alt="Screenshot 2024-04-26 at 13 40 21" src="https://github.com/govuk-one-login/account-interventions-service/assets/116737136/45479722-2101-4ff0-b6ea-72a6f6f9e6f6">
After changing Alias - Rollback: 
<img width="1123" alt="Screenshot 2024-04-26 at 13 42 12" src="https://github.com/govuk-one-login/account-interventions-service/assets/116737136/98cc1a3a-7eee-4b2f-bec9-f208943fda46">

**Account Deletion** 

Prior to Rollback: 
<img width="1131" alt="Screenshot 2024-04-26 at 13 31 32" src="https://github.com/govuk-one-login/account-interventions-service/assets/116737136/ffad9c67-df7f-4ec3-951c-320ab959ba67">

After changing Alias - Rollback: 
<img width="1119" alt="Screenshot 2024-04-26 at 13 32 46" src="https://github.com/govuk-one-login/account-interventions-service/assets/116737136/4470408d-1be8-43b8-b4f9-2cb33d1afb1d">


## Checklists
- [ ] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [ ] Tested changes and included test evidence in the PR, if appropriate
- [ ] Included all required tags and other properties for any new resources in the SAM template
- [ ] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [ ] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [ ] Ensured that no log lines include PII or other sensitive data
- [ ] Implemented unit testing for any new logic implemented, if appropriate
- [ ] Ensured that all commits in this PR are signed
- [ ] Ensured appropriate code coverage is maintained by unit tests
- [ ] Checked SonarCube and ensured no code smells were added


[ATB-1650]: https://govukverify.atlassian.net/browse/ATB-1650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ