### PR TITLE
ATB-1672 | Set the Parameter LambdaCanaryDeployment to AllAtOnce in Dev - Staging Environments

### DIFF
--- a/stack-orchestration/configuration/di-id-reuse-core-build-admin/ais-main-pipeline/parameters.json
+++ b/stack-orchestration/configuration/di-id-reuse-core-build-admin/ais-main-pipeline/parameters.json
@@ -101,6 +101,6 @@
   },
   {
     "ParameterKey": "LambdaDeploymentPreference",
-    "ParameterValue": "None"
+    "ParameterValue": "AllAtOnce"
   }
 ]

--- a/stack-orchestration/configuration/di-id-reuse-core-dev-admin/ais-main-pipeline/parameters.json
+++ b/stack-orchestration/configuration/di-id-reuse-core-dev-admin/ais-main-pipeline/parameters.json
@@ -101,6 +101,6 @@
   },
   {
     "ParameterKey": "LambdaDeploymentPreference",
-    "ParameterValue": "None"
+    "ParameterValue": "AllAtOnce"
   }
 ]

--- a/stack-orchestration/configuration/di-id-reuse-core-staging-admin/ais-main-pipeline/parameters.json
+++ b/stack-orchestration/configuration/di-id-reuse-core-staging-admin/ais-main-pipeline/parameters.json
@@ -97,6 +97,6 @@
   },
   {
     "ParameterKey": "LambdaDeploymentPreference",
-    "ParameterValue": "None"
+    "ParameterValue": "AllAtOnce"
   }
 ]


### PR DESCRIPTION
## Proposed changes
<!-- Include the Jira ticket number in square brackets as prefix, eg `ATB-XXXX: Description of Change` -->
ATB-1672 | Set the Parameter LambdaCanaryDeployment to AllAtOnce in Dev - Staging Environments
### What changed
<!-- Describe the changes in detail - the "what"-->
Set the Parameter LambdaCanaryDeployment to AllAtOnce in Dev - Staging Environments 

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
Advised by Dev Platform to use AllAtOnce so that every environment will be able to use CodeDeploy for deployments - cannot be set to None as means that environments won't even use Canary Deployment. 

A requirement for Canary Deployment is that all environments need to be the same, however notice that it does take extra time for the deployment process so we can set the parameter to AllAtOnce for Dev - Staging and then Canary10Percent10Minutes for Integration and Production. 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- List any related PRs -->
- [ATB-1672](https://govukverify.atlassian.net/browse/ATB-1672)

## Testing
<!-- Please give an overview of how the changes were tested -->
<!-- Please specify if changes were tested locally and how, include evidence where relevant -->
<!-- Please specify if changes were deployed and tested in the AWS Account and how, include evidence where relevant -->

## Checklists
- [ ] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [ ] Tested changes and included test evidence in the PR, if appropriate
- [ ] Included all required tags and other properties for any new resources in the SAM template
- [ ] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [ ] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [ ] Ensured that no log lines include PII or other sensitive data
- [ ] Implemented unit testing for any new logic implemented, if appropriate
- [ ] Ensured that all commits in this PR are signed
- [ ] Ensured appropriate code coverage is maintained by unit tests
- [ ] Checked SonarCube and ensured no code smells were added


[ATB-1672]: https://govukverify.atlassian.net/browse/ATB-1672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ