### PR TITLE
Fix : Pact workflow fix

### DIFF
--- a/.github/workflows/pact-test-api-provider.yaml
+++ b/.github/workflows/pact-test-api-provider.yaml
@@ -17,7 +17,7 @@ on:
       - yarn.lock
       - tsconfig.json
       - .node-version
-      - .github/workflows/acceptance-checks.yaml
+      - .github/workflows/pact-test-api-provider.yaml
     branches:
       - main
   pull_request:
@@ -27,7 +27,7 @@ on:
       - yarn.lock
       - tsconfig.json
       - .node-version
-      - .github/workflows/acceptance-checks.yaml
+      - .github/workflows/pact-test-api-provider.yaml
     branches:
       - main
     types:

--- a/.github/workflows/pact-test-message-consumer.yaml
+++ b/.github/workflows/pact-test-message-consumer.yaml
@@ -6,7 +6,7 @@ env:
   PACT_BROKER_URL: ${{ secrets.PACT_BROKER_URL }}
   PACT_BROKER_SOURCE_SECRET: ${{ secrets.PACT_BROKER_SOURCE_SECRET }}
   GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
-  PROVIDER_APP_VERSION: ${{ github.sha }}
+  CONSUMER_APP_VERSION: ${{ github.sha }}
 
 on:
   push:

--- a/.github/workflows/pact-test-message-consumer.yaml
+++ b/.github/workflows/pact-test-message-consumer.yaml
@@ -16,7 +16,7 @@ on:
       - yarn.lock
       - tsconfig.json
       - .node-version
-      - .github/workflows/acceptance-checks.yaml
+      - .github/workflows/pact-test-message-consumer.yaml
     branches:
       - main
   pull_request:
@@ -26,7 +26,7 @@ on:
       - yarn.lock
       - tsconfig.json
       - .node-version
-      - .github/workflows/acceptance-checks.yaml
+      - .github/workflows/pact-test-message-consumer.yaml
     branches:
       - main
     types:


### PR DESCRIPTION
## Proposed changes
This PR merges a small change in to correct the naming of an environment variable in the consumer pact testing workflow to allow pact to publish to the broker

### What changed
Renamed `PROVIDER_APP_VERSION` --> `CONSUMER_APP_VERSION`

### Why did it change
Allow publishing of pacts

