### PR TITLE
ATB-1691: improved INTERVENTION_IGNORED_IN_FUTURE to not trigger alar…

### DIFF
--- a/src/data-types/errors.ts
+++ b/src/data-types/errors.ts
@@ -38,3 +38,10 @@ export class TooManyRecordsError extends Error {
     this.name = 'TooManyRecordsError';
   }
 }
+
+export class RetryEventError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RetryEventError';
+  }
+}

--- a/src/handlers/interventions-processor-handler.ts
+++ b/src/handlers/interventions-processor-handler.ts
@@ -10,7 +10,7 @@ import {
   TriggerEventsEnum,
 } from '../data-types/constants';
 import { DynamoDBStateResult, StateDetails, TxMAIngressEvent } from '../data-types/interfaces';
-import { StateTransitionError, TooManyRecordsError, ValidationError } from '../data-types/errors';
+import { RetryEventError, StateTransitionError, TooManyRecordsError, ValidationError } from '../data-types/errors';
 import {
   attemptToParseJson,
   validateEventAgainstSchema,
@@ -141,6 +141,9 @@ async function handleError(error: unknown, record: SQSRecord) {
       JSON.parse(record.body) as TxMAIngressEvent,
       error.output,
     );
+  } else if (error instanceof RetryEventError) {
+    logger.warn('RetryEventError caught, message will be retried.', { errorMessage: error.message });
+    return record.messageId;
   } else {
     logger.error('Error caught, message will be retried.', { errorMessage: (error as Error).message });
     return record.messageId;

--- a/src/handlers/tests/interventions-processor-lambda.test.ts
+++ b/src/handlers/tests/interventions-processor-lambda.test.ts
@@ -369,8 +369,13 @@ describe('intervention processor handler', () => {
         interventionEventBodyInTheFuture,
       );
       expect(publishTimeToResolveMetrics).not.toHaveBeenCalled();
-      expect(logger.error).toHaveBeenCalledWith("Error caught, message will be retried.", { errorMessage: 'Event is in the future. It will be retried' });
-
+      expect(logger.warn).toHaveBeenCalledWith("Event with timestamp in the future.", {
+        currentTime: "1970-01-15T06:56:07.890Z",
+        emittedAt: "1970-01-15T06:56:12.890Z",
+        event: "FRAUD_BLOCK_ACCOUNT",
+        eventName: "TICF_ACCOUNT_INTERVENTION",
+        msInTheFuture: 5000,
+      });
     });
 
     it('should ignore the event if body is invalid', async () => {

--- a/src/services/test/validate-event.test.ts
+++ b/src/services/test/validate-event.test.ts
@@ -246,7 +246,7 @@ describe('event-validation', () => {
     };
     await expect(async () => {
       await validateEventIsNotInFuture(EventsEnum.FRAUD_SUSPEND_ACCOUNT, eventInTheFuture);
-    }).rejects.toThrow(new Error('Event is in the future. It will be retried'));
+    }).rejects.toThrow(new Error('Event has timestamp that is in the future.'));
     expect(addMetric).toHaveBeenCalledWith(MetricNames.INTERVENTION_IGNORED_IN_FUTURE);
     expect(sendAuditEvent).toHaveBeenCalledWith(
       'AIS_EVENT_IGNORED_IN_FUTURE',


### PR DESCRIPTION
Improved INTERVENTION_IGNORED_IN_FUTURE to not trigger alarm and have improved logging

## Proposed changes
<!-- Include the Jira ticket number in square brackets as prefix, eg `ATB-XXXX: Description of Change` -->

### What changed
Originally, when a event was received with a future timestamp it was thrown as an Error to be redriven, however the catch all error handler logs at an ERROR level causing `InterventionsProcessorMetricErrorsCanary` alarm to be triggered

Therefore added another discreet error type that is caught logged with WARN level and then retried instead.  Also improved the logged information when `INTERVENTION_IGNORED_IN_FUTURE` occurs so that next time we can determine the source and the actual timings involved.

### Why did it change
Better logging and not to trigger `InterventionsProcessorMetricErrorsCanary` alarm

### Issue tracking
- [ATB-1691](https://govukverify.atlassian.net/browse/ATB-1691)

## Testing
covered by unit tests

## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [x] Tested changes and included test evidence in the PR, if appropriate
- [ ] Included all required tags and other properties for any new resources in the SAM template
- [ ] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [ ] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [x] Ensured that no log lines include PII or other sensitive data
- [x] Implemented unit testing for any new logic implemented, if appropriate
- [x] Ensured that all commits in this PR are signed
- [x] Ensured appropriate code coverage is maintained by unit tests
- [x] Checked SonarCube and ensured no code smells were added


[ATB-1691]: https://govukverify.atlassian.net/browse/ATB-1691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ