### PR TITLE
ATB-1692: Pact can-i-deploy check

### DIFF
--- a/.github/workflows/manual-publish-main-to-dev.yaml
+++ b/.github/workflows/manual-publish-main-to-dev.yaml
@@ -37,6 +37,13 @@ jobs:
     with:
       gitRef: ${{ inputs.gitRef }}
 
+  provider_contract_tests:
+    name: Provider Contract Tests
+    uses: ./.github/workflows/pact-test-api-provider.yaml
+    secrets: inherit # pragma: allowlist secret
+    with:
+      gitRef: ${{ inputs.gitRef }}
+
   publish_artifacts:
     name: "Publish Image & Template"
     runs-on: ubuntu-latest

--- a/.github/workflows/merge-main-to-main.yaml
+++ b/.github/workflows/merge-main-to-main.yaml
@@ -36,6 +36,13 @@ jobs:
     with:
       gitRef: ${{ inputs.gitRef }}
 
+  provider_contract_tests:
+    name: Provider Contract Tests
+    uses: ./.github/workflows/pact-test-api-provider.yaml
+    secrets: inherit # pragma: allowlist secret
+    with:
+      gitRef: ${{ inputs.gitRef }}
+
   publish_artifacts:
     name: "Publish Image & Template"
     runs-on: ubuntu-latest

--- a/.github/workflows/pact-test-api-provider.yaml
+++ b/.github/workflows/pact-test-api-provider.yaml
@@ -8,6 +8,7 @@ env:
   GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
   PROVIDER_APP_VERSION: ${{ github.sha }}
   PUBLISH_RESULT: false
+  PACT_BROKER_CAN_I_DEPLOY_DRY_RUN: true
 
 on:
   push:
@@ -70,3 +71,7 @@ jobs:
         run: |
           yarn connect:pact:broker
           yarn test:pact:provider
+
+      - name: Run can-i-deploy check for AIS provider api
+        if: github.ref_name == 'main'
+        run: yarn pact:can-i-deploy

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:pact:consumer": "jest --group=contract --runInBand --testPathPattern=\"src/contract-testing/consumer/*\"",
     "connect:pact:broker": "tsc src/contract-testing/test-helpers/connect-to-pact-broker.ts && node src/contract-testing/test-helpers/connect-to-pact-broker.js",
     "pact:publish:contracts": "tsc src/contract-testing/test-helpers/publish-pacts.ts && node src/contract-testing/test-helpers/publish-pacts.js",
+    "pact:can-i-deploy": "pact-broker can-i-deploy --pacticipant  \"AccountInterventionServiceProvider\" --version \"$(git rev-parse HEAD)\" --broker-base-url=$PACT_BROKER_URL --broker-username $PACT_BROKER_USER --broker-password $PACT_BROKER_PASSWORD",
     "lint": "yarn lint:code && yarn lint:spec && yarn lint:iac",
     "lint:code": "eslint --ext .ts .",
     "lint:code:fix": "yarn lint:code --fix",


### PR DESCRIPTION
## Proposed changes
This PR merges changes to add a step to the pact provider test workflow to check that it is okay to deploy the current version.

### What changed
Added can i deploy command to package.json file. This command is invoked in a step inside the provider testing workflow. This only gets executed if the current branch reference is main, as we are only publishing contracts from main to the broker. 
This workflow is now also part of the deployment workflows to dev and build so that if those tests fail the deployment does not go ahead. 

### Why did it change
Protect against deploying a breaking change

### Issue tracking
- [ATB-1692](https://govukverify.atlassian.net/browse/ATB-1692)

## Testing
run command locally while on main:
![Screenshot 2024-05-21 at 15 32 55](https://github.com/govuk-one-login/account-interventions-service/assets/110468890/1aaab337-938a-4d02-bd41-12da4efc5f20)




[ATB-1692]: https://govukverify.atlassian.net/browse/ATB-1692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ