### PR TITLE
ATB-1712: configured STAGING VPC and Endpoint details for Orch Auth s…

### DIFF
--- a/src/infra/main/template.yaml
+++ b/src/infra/main/template.yaml
@@ -112,10 +112,10 @@ Mappings:
       TxMAAccountID: 178023842775
       TxMAIngressQueueARN: arn:aws:sqs:eu-west-2:178023842775:self-staging-EC-SQS-Output-Queue-accountsIntervention
       TxMAIngressQueueKmsKeyARN: arn:aws:kms:eu-west-2:178023842775:key/e388cb30-2d78-431f-b1a6-847549a815aa
-      OrchestrationVPCID: vpc-0ca40c7d13490419d # Auth & Orchestration Staging VPC ID
-      AuthenticationVPCID: vpc-0b6f4a5d72f84ed0c # Authentication Sandbox VPC ID
+      OrchestrationVPCID: vpc-0217499e2982d99ca # Orchestration Staging VPC ID
+      AuthenticationVPCID: vpc-0ca40c7d13490419d # Authentication Staging VPC ID
       OneLoginHomeVPCID: vpc-02e4eb3b0cffc08b0 # Performance testing VPC ID
-      UniqueVPCEndpointIDs: vpce-040f33c3489ff777b,vpce-0339d04aeb67de9da # Auth/Orch Sandbox & Staging VPC endpoint IDs
+      UniqueVPCEndpointIDs: vpce-040f33c3489ff777b,vpce-0339d04aeb67de9da,vpce-0a81481bcd8257f5e # Auth/Orch Staging VPC endpoint IDs
       DynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables # pragma: allowlist secret
     integration:
       LambdaLogLevel: INFO


### PR DESCRIPTION
## Proposed changes
configured STAGING VPC and Endpoint details for Orch Auth split

### What changed
Staging config for VPC and VPC Endpoint allow listing

### Why did it change
Orch have moved to a new AWS Account

### Issue tracking
- [ATB-1712](https://govukverify.atlassian.net/browse/ATB-1712)

## Testing
Staging only changes - only testable once deployed

## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [ ] Tested changes and included test evidence in the PR, if appropriate
- [ ] Included all required tags and other properties for any new resources in the SAM template
- [ ] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [ ] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [ ] Ensured that no log lines include PII or other sensitive data
- [ ] Implemented unit testing for any new logic implemented, if appropriate
- [x] Ensured that all commits in this PR are signed
- [ ] Ensured appropriate code coverage is maintained by unit tests
- [x] Checked SonarCube and ensured no code smells were added


[ATB-1712]: https://govukverify.atlassian.net/browse/ATB-1712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ