### PR TITLE
ATB-1810: Optimise time to run the feature-tests in parallel

### DIFF
--- a/feature-tests/package.json
+++ b/feature-tests/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "jest --runInBand",
+    "test": "jest",
     "lint:code": "eslint --ext .ts .",
     "lint:code:fix": "yarn lint:code --fix"
   },

--- a/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
@@ -49,7 +49,7 @@ defineFeature(feature, (test) => {
     when(
       /^I invoke an API to retrieve the intervention status of the user's account. With history (.*)$/,
       async (historyValue) => {
-        await timeDelayForTestEnvironment();
+        await timeDelayForTestEnvironment(1000);
         response = await invokeGetAccountState(testUserId, historyValue);
       },
     );
@@ -487,7 +487,7 @@ defineFeature(feature, (test) => {
     });
 
     and(/^I invoke an API to retrieve the deleted intervention status of the user's account$/, async () => {
-      await timeDelayForTestEnvironment(1500);
+      await timeDelayForTestEnvironment(2000);
       getItem = await getRecordFromTable(testUserId);
       response = await invokeGetAccountState(testUserId, true);
     });

--- a/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
@@ -49,7 +49,7 @@ defineFeature(feature, (test) => {
     when(
       /^I invoke an API to retrieve the intervention status of the user's account. With history (.*)$/,
       async (historyValue) => {
-        await timeDelayForTestEnvironment(1500);
+        await timeDelayForTestEnvironment(2000);
         response = await invokeGetAccountState(testUserId, historyValue);
       },
     );

--- a/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
@@ -495,6 +495,7 @@ defineFeature(feature, (test) => {
     then(
       /^I expect response for (.*) with valid deleted marker fields for the userId$/,
       async (aisEventType: keyof typeof aisEventResponse) => {
+        await timeDelayForTestEnvironment();
         console.log(`Received`, { response });
         const eventTypes = [
           'unSuspendAction',

--- a/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
@@ -495,7 +495,7 @@ defineFeature(feature, (test) => {
     then(
       /^I expect response for (.*) with valid deleted marker fields for the userId$/,
       async (aisEventType: keyof typeof aisEventResponse) => {
-        await timeDelayForTestEnvironment();
+        await timeDelayForTestEnvironment(1000);
         console.log(`Received`, { response });
         const eventTypes = [
           'unSuspendAction',

--- a/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
@@ -49,7 +49,7 @@ defineFeature(feature, (test) => {
     when(
       /^I invoke an API to retrieve the intervention status of the user's account. With history (.*)$/,
       async (historyValue) => {
-        await timeDelayForTestEnvironment(1500);
+        await timeDelayForTestEnvironment();
         response = await invokeGetAccountState(testUserId, historyValue);
       },
     );
@@ -487,7 +487,7 @@ defineFeature(feature, (test) => {
     });
 
     and(/^I invoke an API to retrieve the deleted intervention status of the user's account$/, async () => {
-      await timeDelayForTestEnvironment();
+      await timeDelayForTestEnvironment(1000);
       getItem = await getRecordFromTable(testUserId);
       response = await invokeGetAccountState(testUserId, true);
     });
@@ -495,7 +495,6 @@ defineFeature(feature, (test) => {
     then(
       /^I expect response for (.*) with valid deleted marker fields for the userId$/,
       async (aisEventType: keyof typeof aisEventResponse) => {
-        await timeDelayForTestEnvironment(1000);
         console.log(`Received`, { response });
         const eventTypes = [
           'unSuspendAction',

--- a/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
@@ -487,7 +487,7 @@ defineFeature(feature, (test) => {
     });
 
     and(/^I invoke an API to retrieve the deleted intervention status of the user's account$/, async () => {
-      await timeDelayForTestEnvironment(1000);
+      await timeDelayForTestEnvironment(1500);
       getItem = await getRecordFromTable(testUserId);
       response = await invokeGetAccountState(testUserId, true);
     });

--- a/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
@@ -49,7 +49,7 @@ defineFeature(feature, (test) => {
     when(
       /^I invoke an API to retrieve the intervention status of the user's account. With history (.*)$/,
       async (historyValue) => {
-        await timeDelayForTestEnvironment(1000);
+        await timeDelayForTestEnvironment(1500);
         response = await invokeGetAccountState(testUserId, historyValue);
       },
     );
@@ -477,7 +477,7 @@ defineFeature(feature, (test) => {
   }) => {
     given(/^I send an (.*) intervention to the TxMA ingress SQS queue which will be deleted$/, async (aisEventType) => {
       await sendSQSEvent(testUserId, aisEventType);
-      await timeDelayForTestEnvironment();
+      await timeDelayForTestEnvironment(1000);
     });
 
     when(/^I send a message with the userId to the Delete SNS Topic$/, async () => {
@@ -487,7 +487,7 @@ defineFeature(feature, (test) => {
     });
 
     and(/^I invoke an API to retrieve the deleted intervention status of the user's account$/, async () => {
-      await timeDelayForTestEnvironment(2000);
+      await timeDelayForTestEnvironment(2500);
       getItem = await getRecordFromTable(testUserId);
       response = await invokeGetAccountState(testUserId, true);
     });

--- a/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
@@ -81,7 +81,7 @@ defineFeature(feature, (test) => {
     );
 
     when(/^I invoke an API to retrieve the intervention status of the account$/, async () => {
-      await timeDelayForTestEnvironment(1500);
+      await timeDelayForTestEnvironment();
       response = await invokeGetAccountState(testUserId, true);
     });
 
@@ -113,7 +113,7 @@ defineFeature(feature, (test) => {
     when(
       /^I invoke the API to retrieve the intervention status of the user's account. With history (.*)$/,
       async (historyValue) => {
-        await timeDelayForTestEnvironment(1500);
+        await timeDelayForTestEnvironment();
         response = await invokeGetAccountState(testUserId, historyValue);
       },
     );
@@ -147,7 +147,7 @@ defineFeature(feature, (test) => {
       async (allowableAisEventType, originalAisEventType) => {
         console.log('sending first message to put the user in : ' + originalAisEventType);
         await sendSQSEvent(testUserId, originalAisEventType);
-        await timeDelayForTestEnvironment(500);
+        await timeDelayForTestEnvironment();
         console.log('sending second message to put the user in : ' + allowableAisEventType);
         await sendSQSEvent(testUserId, allowableAisEventType);
       },
@@ -156,7 +156,7 @@ defineFeature(feature, (test) => {
     when(
       /^I invoke the API to retrieve the allowable intervention status of the user's account. With history (.*)$/,
       async (historyValue) => {
-        await timeDelayForTestEnvironment(500);
+        await timeDelayForTestEnvironment();
         response = await invokeGetAccountState(testUserId, historyValue);
       },
     );
@@ -185,7 +185,7 @@ defineFeature(feature, (test) => {
       async (nonAllowableAisEventType, originalAisEventType) => {
         console.log('sending first message to put the user in : ' + originalAisEventType);
         await sendSQSEvent(testUserId, originalAisEventType);
-        await timeDelayForTestEnvironment(500);
+        await timeDelayForTestEnvironment();
         console.log('sending second message to put the user in : ' + nonAllowableAisEventType);
         await sendSQSEvent(testUserId, nonAllowableAisEventType);
       },
@@ -194,7 +194,7 @@ defineFeature(feature, (test) => {
     when(
       /^I invoke the API to retrieve the non-allowable intervention status of the user's account. With history (.*)$/,
       async (historyValue) => {
-        await timeDelayForTestEnvironment(500);
+        await timeDelayForTestEnvironment();
         response = await invokeGetAccountState(testUserId, historyValue);
       },
     );
@@ -223,7 +223,7 @@ defineFeature(feature, (test) => {
       async (allowableAisEventType, originalAisEventType) => {
         console.log('sending first message to put the user in : ' + originalAisEventType);
         await sendSQSEvent(testUserId, originalAisEventType);
-        await timeDelayForTestEnvironment(500);
+        await timeDelayForTestEnvironment();
         console.log('sending second message to put the user in : ' + allowableAisEventType);
         await sendSQSEvent(testUserId, allowableAisEventType);
       },
@@ -232,7 +232,7 @@ defineFeature(feature, (test) => {
     when(
       /^I invoke the API to retrieve the intervention status of the user's account with history (.*)$/,
       async (historyValue) => {
-        await timeDelayForTestEnvironment(500);
+        await timeDelayForTestEnvironment();
         response = await invokeGetAccountState(testUserId, historyValue);
       },
     );
@@ -268,16 +268,16 @@ defineFeature(feature, (test) => {
       async function (allowableAisEventType, originalAisEventType) {
         console.log('sending first message to put the user in : ' + originalAisEventType);
         await sendSQSEvent(testUserId, originalAisEventType);
-        await timeDelayForTestEnvironment(500);
+        await timeDelayForTestEnvironment();
         console.log('sending second message to put the user in : ' + allowableAisEventType);
         await sendSQSEvent(testUserId, allowableAisEventType);
-        await timeDelayForTestEnvironment(500);
+        await timeDelayForTestEnvironment();
       },
     );
 
     when(/^I invoke API to retrieve the intervention status of the user's account$/, async () => {
       response = await invokeGetAccountState(testUserId, false);
-      await timeDelayForTestEnvironment(500);
+      await timeDelayForTestEnvironment();
     });
 
     then(/^I expect the response (.*) with the correct time stamp when the event was applied$/, async (values) => {
@@ -291,7 +291,7 @@ defineFeature(feature, (test) => {
 
     and(/^I send a new intervention event type (.*)$/, async (aisEventType) => {
       await sendSQSEvent(testUserId, aisEventType);
-      await timeDelayForTestEnvironment(500);
+      await timeDelayForTestEnvironment();
       response = await invokeGetAccountState(testUserId, true);
     });
 
@@ -315,7 +315,7 @@ defineFeature(feature, (test) => {
       async (allowableAisEventType, originalAisEventType) => {
         console.log('sending first message to put the user in : ' + originalAisEventType);
         await sendSQSEvent(testUserId, originalAisEventType);
-        await timeDelayForTestEnvironment(1500);
+        await timeDelayForTestEnvironment();
         console.log('sending second message to put the user in : ' + allowableAisEventType);
         await sendSQSEvent(testUserId, allowableAisEventType);
       },
@@ -324,7 +324,7 @@ defineFeature(feature, (test) => {
     when(
       /^I invoke the API to retrieve the allowable intervention status of the user's account with (.*)$/,
       async (historyValue) => {
-        await timeDelayForTestEnvironment(500);
+        await timeDelayForTestEnvironment();
         response = await invokeGetAccountState(testUserId, historyValue);
       },
     );
@@ -354,30 +354,30 @@ defineFeature(feature, (test) => {
         console.log('sending first message to put the user in : passwordResetRequired');
         await sendSQSEvent(testUserId, `pswResetRequired`);
 
-        await timeDelayForTestEnvironment(500);
+        await timeDelayForTestEnvironment();
         console.log('sending second message to put the user in : suspendNoAction');
         await sendSQSEvent(testUserId, `suspendNoAction`);
 
-        await timeDelayForTestEnvironment(500);
+        await timeDelayForTestEnvironment();
         console.log('sending third message to put the user in : idResetRequired');
         await sendSQSEvent(testUserId, `idResetRequired`);
 
-        await timeDelayForTestEnvironment(500);
+        await timeDelayForTestEnvironment();
         console.log('sending fourth message to put the user in : pswAndIdResetRequired');
         await sendSQSEvent(testUserId, `pswAndIdResetRequired`);
 
-        await timeDelayForTestEnvironment(500);
+        await timeDelayForTestEnvironment();
         console.log('sending fifth message to put the user in : block');
         await sendSQSEvent(testUserId, `block`);
 
-        await timeDelayForTestEnvironment(500);
+        await timeDelayForTestEnvironment();
         console.log('sending sixth message to put the user in : unblock');
         await sendSQSEvent(testUserId, `unblock`);
       },
     );
 
     when(/^I invoke apiGateway to retreive the status of the valid userId with history as true$/, async () => {
-      await timeDelayForTestEnvironment(500);
+      await timeDelayForTestEnvironment();
       response = await invokeGetAccountState(testUserId, true);
     });
 
@@ -408,7 +408,7 @@ defineFeature(feature, (test) => {
     });
 
     when(/^I invoke the API to retrieve the intervention status of the user's account$/, async () => {
-      await timeDelayForTestEnvironment(1500);
+      await timeDelayForTestEnvironment();
       response = await invokeGetAccountState(testUserId, true);
     });
 
@@ -432,13 +432,13 @@ defineFeature(feature, (test) => {
         blocked: response.state.blocked,
         history: stringifiedHistory,
       };
-      await timeDelayForTestEnvironment(500);
+      await timeDelayForTestEnvironment();
       await updateItemInTable(testUserId, updateHistoryTimeStampInTable);
     });
 
     and(/^I send an another (.*) event and then invoke the API$/, async (allowableEventType) => {
       await sendSQSEvent(testUserId, allowableEventType);
-      await timeDelayForTestEnvironment(1500);
+      await timeDelayForTestEnvironment();
       response = await invokeGetAccountState(testUserId, true);
     });
 
@@ -477,7 +477,7 @@ defineFeature(feature, (test) => {
   }) => {
     given(/^I send an (.*) intervention to the TxMA ingress SQS queue which will be deleted$/, async (aisEventType) => {
       await sendSQSEvent(testUserId, aisEventType);
-      await timeDelayForTestEnvironment(2500);
+      await timeDelayForTestEnvironment();
     });
 
     when(/^I send a message with the userId to the Delete SNS Topic$/, async () => {
@@ -487,7 +487,7 @@ defineFeature(feature, (test) => {
     });
 
     and(/^I invoke an API to retrieve the deleted intervention status of the user's account$/, async () => {
-      await timeDelayForTestEnvironment(2500);
+      await timeDelayForTestEnvironment();
       getItem = await getRecordFromTable(testUserId);
       response = await invokeGetAccountState(testUserId, true);
     });

--- a/feature-tests/tests/resources/step-definitions/invoke-api-gateway-unhappy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/invoke-api-gateway-unhappy-path.step.ts
@@ -30,7 +30,7 @@ defineFeature(feature, (test) => {
     });
 
     when(/^I invoke the API to retrieve the intervention status of the account$/, async () => {
-      await timeDelayForTestEnvironment(1500);
+      await timeDelayForTestEnvironment();
       response = await invokeGetAccountState(testUserId, true);
       console.log(`Received`, { response });
     });
@@ -165,7 +165,7 @@ defineFeature(feature, (test) => {
     });
 
     when(/^I invoke apiGateway to retreive the status userId with (.*)$/, async (historyValue) => {
-      await timeDelayForTestEnvironment(1500);
+      await timeDelayForTestEnvironment();
       response = await invokeGetAccountState(testUserId, historyValue);
     });
 
@@ -187,13 +187,13 @@ defineFeature(feature, (test) => {
     and(
       /^I send an other invalid event with invalid status (.*) to the txma sqs queue$/,
       async (invalidAisEventType) => {
-        await timeDelayForTestEnvironment(1500);
+        await timeDelayForTestEnvironment();
         await sendInvalidSQSEvent(testUserId, invalidAisEventType);
       },
     );
 
     when(/^I invoke an apiGateway to retreive the status of the userId$/, async () => {
-      await timeDelayForTestEnvironment(1500);
+      await timeDelayForTestEnvironment();
       response = await invokeGetAccountState(testUserId, true);
     });
 

--- a/feature-tests/utils/utility.ts
+++ b/feature-tests/utils/utility.ts
@@ -1,6 +1,6 @@
 const delay = (ms: number | undefined) => new Promise((resolve) => setTimeout(resolve, ms));
 
-export async function timeDelayForTestEnvironment(ms = 2000) {
+export async function timeDelayForTestEnvironment(ms = 500) {
   console.log('Wait for endpoint operations to process');
   await delay(ms);
 }


### PR DESCRIPTION
## Proposed changes
<!-- Include the Jira ticket number in square brackets as prefix, eg `ATB-1810: Optimise time to run the feature-tests in parallel` -->

### What changed
Optimise time to run the feature-tests in parallel
<!-- Describe the changes in detail - the "what"-->

### Why did it change
To reduce the time
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- List any related PRs -->
- [ATB-1810](https://govukverify.atlassian.net/browse/ATB-1810)

## Testing
<img width="292" alt="Screenshot 2024-08-12 at 15 16 23" src="https://github.com/user-attachments/assets/59f05159-76ed-4576-8ed8-bb7a6f263576">

<!-- Please give an overview of how the changes were tested -->
<!-- Please specify if changes were tested locally and how, include evidence where relevant -->
<!-- Please specify if changes were deployed and tested in the AWS Account and how, include evidence where relevant -->

## Checklists
- [ ] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [ ] Tested changes and included test evidence in the PR, if appropriate
- [ ] Included all required tags and other properties for any new resources in the SAM template
- [ ] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [ ] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [ ] Ensured that no log lines include PII or other sensitive data
- [ ] Implemented unit testing for any new logic implemented, if appropriate
- [ ] Ensured that all commits in this PR are signed
- [ ] Ensured appropriate code coverage is maintained by unit tests
- [ ] Checked SonarCube and ensured no code smells were added


[ATB-1810]: https://govukverify.atlassian.net/browse/ATB-1810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ