### PR TITLE
ATB-1858: fixed E1022 - Join validation of parameters lint errors

### DIFF
--- a/src/infra/main/template.yaml
+++ b/src/infra/main/template.yaml
@@ -87,7 +87,7 @@ Mappings:
     dev:
       LambdaLogLevel: DEBUG
       AccountDeletionProcessorSNSTopicARN: arn:aws:sns:eu-west-2:985326104449:UserAccountDeletion
-      TxMAAccountID: 484907510598 # di-account-interventions-dev
+      TxMAAccountID: "484907510598" # di-account-interventions-dev
       TxMAIngressQueueARN: "Uses Internal TxMAIngressQueue"
       TxMAIngressQueueKmsKeyARN: "Uses the SQSEncryptionKey with Internal TxMAIngressQueue"
       OrchestrationVPCID: vpc-03688222b1d03a1f7 # di-account-interventions-dev VPC ID
@@ -98,7 +98,7 @@ Mappings:
     build:
       LambdaLogLevel: INFO
       AccountDeletionProcessorSNSTopicARN: arn:aws:sns:eu-west-2:301577035144:UserAccountDeletion
-      TxMAAccountID: 565393035754 # di-account-interventions-build
+      TxMAAccountID: "565393035754" # di-account-interventions-build
       TxMAIngressQueueARN: "Uses Internal TxMAIngressQueue"
       TxMAIngressQueueKmsKeyARN: "Uses the SQSEncryptionKey with Internal TxMAIngressQueue"
       OrchestrationVPCID: vpc-0f30b7754111ecc68 # di-account-interventions-build VPC ID
@@ -109,7 +109,7 @@ Mappings:
     staging:
       LambdaLogLevel: INFO
       AccountDeletionProcessorSNSTopicARN: arn:aws:sns:eu-west-2:539729775994:UserAccountDeletion
-      TxMAAccountID: 178023842775 # di-txma-event-processing-staging
+      TxMAAccountID: "178023842775" # di-txma-event-processing-staging
       TxMAIngressQueueARN: arn:aws:sqs:eu-west-2:178023842775:self-staging-EC-SQS-Output-Queue-accountsIntervention
       TxMAIngressQueueKmsKeyARN: arn:aws:kms:eu-west-2:178023842775:key/e388cb30-2d78-431f-b1a6-847549a815aa
       OrchestrationVPCID: vpc-0217499e2982d99ca # Orchestration Staging VPC ID
@@ -120,7 +120,7 @@ Mappings:
     integration:
       LambdaLogLevel: INFO
       AccountDeletionProcessorSNSTopicARN: arn:aws:sns:eu-west-2:666500506359:UserAccountDeletion
-      TxMAAccountID: 729485541398 # di-txma-event-processing-integration
+      TxMAAccountID: "729485541398" # di-txma-event-processing-integration
       TxMAIngressQueueARN: arn:aws:sqs:eu-west-2:729485541398:self-integration-EC-SQS-Output-Queue-accountsIntervention
       TxMAIngressQueueKmsKeyARN: arn:aws:kms:eu-west-2:729485541398:key/c360ee61-da3b-48de-998e-68cb91743414
       OrchestrationVPCID: vpc-09984eb16fa30fb55 # Orchestration Integration VPC ID
@@ -131,7 +131,7 @@ Mappings:
     production:
       LambdaLogLevel: INFO
       AccountDeletionProcessorSNSTopicARN: arn:aws:sns:eu-west-2:026991849909:UserAccountDeletion
-      TxMAAccountID: 451773080033 # di-txma-event-processing-prod
+      TxMAAccountID: "451773080033" # di-txma-event-processing-prod
       TxMAIngressQueueARN: arn:aws:sqs:eu-west-2:451773080033:self-production-EC-SQS-Output-Queue-accountsIntervention
       TxMAIngressQueueKmsKeyARN: arn:aws:kms:eu-west-2:451773080033:key/5bbb4188-6774-4fe8-a78a-968f5e435295
       OrchestrationVPCID: vpc-058178adacb1c387a # Orchestration Production VPC ID


### PR DESCRIPTION
## Proposed changes
fix E1022 - Join validation of parameters lint errors being reported by `sam validate` in SAM v1.124.0

### What changed
GHA now using new SAM version which is now reporting new linting errors, hence switched to strings by sorrounding values with double quotes

### Why did it change
Lint errors were blocking GHA validating checks
<img width="1359" alt="Screenshot 2024-09-18 at 10 59 23" src="https://github.com/user-attachments/assets/2e8f602c-c282-437e-8e1e-fb557a55a0bc">

### Issue tracking
- [ATB-1858](https://govukverify.atlassian.net/browse/ATB-1858)

## Testing

### Pipeline lint checks passing
<img width="1310" alt="Screenshot 2024-09-18 at 11 17 23" src="https://github.com/user-attachments/assets/27033b9a-a76f-4870-bb04-e99020aa1347">

#### Deployed to dev - ARNs in policy are still well-formed
<img width="1119" alt="Screenshot 2024-09-18 at 11 28 22" src="https://github.com/user-attachments/assets/80f30ca1-e244-421f-aa45-1254fb28a4d4">

## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [x] Tested changes and included test evidence in the PR, if appropriate
- [ ] Included all required tags and other properties for any new resources in the SAM template
- [ ] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [ ] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [ ] Ensured that no log lines include PII or other sensitive data
- [ ] Implemented unit testing for any new logic implemented, if appropriate
- [x] Ensured that all commits in this PR are signed
- [ ] Ensured appropriate code coverage is maintained by unit tests
- [x] Checked SonarCube and ensured no code smells were added


[ATB-1858]: https://govukverify.atlassian.net/browse/ATB-1858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ