### PR TITLE
OLH-2283 - Fix to accept correct structure of an account deletion event.

### DIFF
--- a/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
@@ -5,6 +5,7 @@ import {
   purgeEgressQueue,
   filterUserIdInMessages,
   sendEnhancedSQSEvent,
+  sendDeleteEvent,
 } from '../../../utils/send-sqs-message';
 import { invokeGetAccountState } from '../../../utils/invoke-apigateway-lambda';
 import {
@@ -483,7 +484,7 @@ defineFeature(feature, (test) => {
     });
 
     when(/^I send a message  a delete event intervention to TxMA ingress SQS queue$/, async () => {
-      await sendSQSEvent(testUserId, 'deleteEvent');
+      await sendDeleteEvent(testUserId);
       console.log(`AIS Record Deleted via SQS Message Sent`);
     });
 

--- a/feature-tests/utils/ais-events.ts
+++ b/feature-tests/utils/ais-events.ts
@@ -203,22 +203,4 @@ export const aisEvents: {
       govuk_signin_journey_id: '',
     },
   },
-
-  deleteEvent: {
-    event_name: 'AUTH_DELETE_ACCOUNT',
-    event_id: '442a5554-720d-4d90-9e35-cf0090be3c23',
-    timestamp: 1_730_807_241,
-    event_timestamp_ms: 1_730_807_241_588,
-    client_id: 'UNKNOWN',
-    component_id: 'UNKNOWN',
-    user: {
-      user_id: 'urn:fdc:gov.uk:2022:USER_ONE',
-      email: '',
-      phone: 'UNKNOWN',
-      ip_address: '',
-      session_id: '',
-      persistent_session_id: '',
-      govuk_signin_journey_id: '',
-    },
-  },
 };

--- a/feature-tests/utils/send-sqs-message.ts
+++ b/feature-tests/utils/send-sqs-message.ts
@@ -30,20 +30,8 @@ export async function sendSQSEvent(testUserId: string, aisEventType: keyof typeo
 export async function sendDeleteEvent(testUserId: string) {
   const body = {
     event_name: 'AUTH_DELETE_ACCOUNT',
-    event_id: '123',
-    timestamp: 1_730_815_689,
-    event_timestamp_ms: 1_730_815_689_933,
-    client_id: 'UNKNOWN',
-    component_id: 'UNKNOWN',
-    user: {
-      user_id: testUserId,
-      email: '',
-      phone: 'UNKNOWN',
-      ip_address: '',
-      session_id: '',
-      persistent_session_id: '',
-      govuk_signin_journey_id: '',
-    },
+    user_id: testUserId,
+    txma: { configVersion: '1.0.4' },
   };
 
   const mockRecord = {

--- a/src/data-types/interfaces.ts
+++ b/src/data-types/interfaces.ts
@@ -66,12 +66,12 @@ export interface TxMAEgressDeletionEvent {
 
 interface TxMAIngressDeletionEvent {
   event_name: 'AUTH_DELETE_ACCOUNT';
-  timestamp: number;
-  event_timestamp_ms?: number;
-  event_timestamp_ms_formatted?: string;
-  component_id?: string;
-  user: TxmaUser;
-  extensions: TxMAEgressExtensions | TxMAEgressBasicExtensions;
+  user_id: string;
+  txma: Txmaconfig;
+}
+
+interface Txmaconfig {
+  configVersion: string;
 }
 
 export type TxMAEgressEvent = TxMAEgressInterventionEvent | TxMAIngressDeletionEvent;

--- a/src/handlers/tests/txma-handler.test.ts
+++ b/src/handlers/tests/txma-handler.test.ts
@@ -1,5 +1,5 @@
-import { SQSEvent, SQSRecord } from 'aws-lambda'
-import { handler } from '../txma-handler'
+import {SQSEvent, SQSRecord} from 'aws-lambda'
+import {handler} from '../txma-handler'
 import {sendBatchSqsMessage} from '../../services/send-sqs-message'
 
 jest.mock('../../services/send-sqs-message')
@@ -28,72 +28,66 @@ const createMockRecord = (eventDetails: any) => {
 
 
 describe('TxMA Handler', () => {
-    const OLD_ENV = process.env
-    let mockEvent: SQSEvent
-    let mockRecord: SQSRecord
-    const mockContext = {
-        callbackWaitsForEmptyEventLoop: true,
-        functionVersion: '$LATEST',
-        functionName: 'foo-bar-function',
-        memoryLimitInMB: '128',
-        logGroupName: '/aws/lambda/foo-bar-function-123456abcdef',
-        logStreamName: '2021/03/09/[$LATEST]abcdef123456abcdef123456abcdef123456',
-        invokedFunctionArn: 'arn:aws:lambda:eu-west-1:123456789012:function:foo-bar-function',
-        awsRequestId: 'c6af9ac6-7b61-11e6-9a41-93e812345678',
-        getRemainingTimeInMillis: () => 1234,
-        done: () => console.log('Done!'),
-        fail: () => console.log('Failed!'),
-        succeed: () => console.log('Succeeded!'),
-    }
+  const OLD_ENV = process.env
+  let mockEvent: SQSEvent
+  let mockRecord: SQSRecord
+  const mockContext = {
+    callbackWaitsForEmptyEventLoop: true,
+    functionVersion: '$LATEST',
+    functionName: 'foo-bar-function',
+    memoryLimitInMB: '128',
+    logGroupName: '/aws/lambda/foo-bar-function-123456abcdef',
+    logStreamName: '2021/03/09/[$LATEST]abcdef123456abcdef123456abcdef123456',
+    invokedFunctionArn: 'arn:aws:lambda:eu-west-1:123456789012:function:foo-bar-function',
+    awsRequestId: 'c6af9ac6-7b61-11e6-9a41-93e812345678',
+    getRemainingTimeInMillis: () => 1234,
+    done: () => console.log('Done!'),
+    fail: () => console.log('Failed!'),
+    succeed: () => console.log('Succeeded!'),
+  }
 
-    beforeEach(() => {
-        process.env = { ...OLD_ENV }
-    })
+  beforeEach(() => {
+    process.env = {...OLD_ENV}
+  })
 
-    afterEach(() => {
-        process.env = OLD_ENV
-        jest.clearAllMocks();
-    })
+  afterEach(() => {
+    process.env = OLD_ENV
+    jest.clearAllMocks();
+  })
 
-    it('Sends an SQS message to the delete queue', async () => {
-      let deleteEvent = {
-        event_name: 'AUTH_DELETE_ACCOUNT',
-        event_id: '442a5554-720d-4d90-9e35-cf0090be3c23',
-        timestamp: 1_730_807_241,
-        event_timestamp_ms: 1_730_807_241_588,
-        client_id: 'UNKNOWN',
-        component_id: 'UNKNOWN',
-        user: {
-          user_id: 'urn:fdc:gov.uk:2022:USER_ONE',
-          email: '',
-          phone: 'UNKNOWN',
-          ip_address: '',
-          session_id: '',
-          persistent_session_id: '',
-          govuk_signin_journey_id: '',
-        },
-      };
-      mockRecord = createMockRecord(deleteEvent);
-      mockEvent = { Records: [mockRecord] };
+  it('Sends an SQS message to the delete queue', async () => {
+    let deleteEvent = {
+      event_name: "AUTH_DELETE_ACCOUNT",
+      user_id: "urn:fdc:gov.uk:2022:USER_ONE",
+      txma: {"configVersion": "1.0.4"}
+    };
+    mockRecord = createMockRecord(deleteEvent);
+    mockEvent = {Records: [mockRecord]};
 
-        process.env['ACCOUNT_DELETION_SQS_QUEUE'] = 'delete_queue'
-        process.env['ACCOUNT_INTERVENTION_SQS_QUEUE'] = 'intervention_queue'
-        await handler(mockEvent, mockContext);
-        expect(mockSendBatchSqsMessage).toHaveBeenCalledWith([{"Id": "0", "MessageBody": "{\"Message\":\"{\\\"event_name\\\":\\\"AUTH_DELETE_ACCOUNT\\\",\\\"user_id\\\":\\\"urn:fdc:gov.uk:2022:USER_ONE\\\"}\"}"}], 'delete_queue')
-    })
+    process.env['ACCOUNT_DELETION_SQS_QUEUE'] = 'delete_queue'
+    process.env['ACCOUNT_INTERVENTION_SQS_QUEUE'] = 'intervention_queue'
+    await handler(mockEvent, mockContext);
+    expect(mockSendBatchSqsMessage).toHaveBeenCalledWith([{
+      "Id": "0",
+      "MessageBody": "{\"Message\":\"{\\\"event_name\\\":\\\"AUTH_DELETE_ACCOUNT\\\",\\\"user_id\\\":\\\"urn:fdc:gov.uk:2022:USER_ONE\\\"}\"}"
+    }], 'delete_queue')
+  })
 
-    it('Sends an SQS message to the intervention queue', async () => {
-      let otherInterventionEvent = {
-        event_name: 'TICF_ACCOUNT_INTERVENTION',
-        user_id: 'hello'
-      };
-      mockRecord = createMockRecord(otherInterventionEvent);
-      mockEvent = { Records: [mockRecord] };
-      process.env['ACCOUNT_DELETION_SQS_QUEUE'] = 'delete_queue'
-      process.env['ACCOUNT_INTERVENTION_SQS_QUEUE'] = 'intervention_queue'
-      await handler(mockEvent, mockContext);
-      expect(mockSendBatchSqsMessage).toHaveBeenCalledWith([{"Id": "0", "MessageBody": "{\"event_name\":\"TICF_ACCOUNT_INTERVENTION\",\"user_id\":\"hello\"}"}], 'intervention_queue')
-    })
+  it('Sends an SQS message to the intervention queue', async () => {
+    let otherInterventionEvent = {
+      event_name: 'TICF_ACCOUNT_INTERVENTION',
+      user_id: 'hello'
+    };
+    mockRecord = createMockRecord(otherInterventionEvent);
+    mockEvent = {Records: [mockRecord]};
+    process.env['ACCOUNT_DELETION_SQS_QUEUE'] = 'delete_queue'
+    process.env['ACCOUNT_INTERVENTION_SQS_QUEUE'] = 'intervention_queue'
+    await handler(mockEvent, mockContext);
+    expect(mockSendBatchSqsMessage).toHaveBeenCalledWith([{
+      "Id": "0",
+      "MessageBody": "{\"event_name\":\"TICF_ACCOUNT_INTERVENTION\",\"user_id\":\"hello\"}"
+    }], 'intervention_queue')
+  })
 
   it('Sends throw an error if delete queue not configured', async () => {
     process.env['ACCOUNT_INTERVENTION_SQS_QUEUE'] = 'intervention_queue'

--- a/src/handlers/txma-handler.ts
+++ b/src/handlers/txma-handler.ts
@@ -32,7 +32,7 @@ export const handler = async (event: SQSEvent, context: Context): Promise<void> 
     const body: TxMAEgressEvent = JSON.parse(record.body);
     if (body.event_name === 'AUTH_DELETE_ACCOUNT') {
       addMetric(MetricNames.RECIEVED_TXMA_ACCOUNT_DELETE);
-      const deletionEvent: TxMAEgressDeletionEvent = { event_name: 'AUTH_DELETE_ACCOUNT', user_id: body.user.user_id };
+      const deletionEvent: TxMAEgressDeletionEvent = { event_name: 'AUTH_DELETE_ACCOUNT', user_id: body.user_id };
       const messageBody = {
         Message: JSON.stringify(deletionEvent),
       };


### PR DESCRIPTION
## Proposed changes
OLH-2283 - Fix to accept correct structure of an account deletion event.
https://govukverify.atlassian.net/browse/OLH-2283

### What changed
Following account deletion errors in prod due to incorrect structure of AIs event expectation, this fix assumes the correct structure as
"event_name":"AUTH_DELETE_ACCOUNT","user_id":"urn:fdc:gov.uk:2022:blah","txma":{"configVersion":"1.0.4"}}
### Why did it change
Fix prod issue

### Issue tracking

## Testing
Deployed to dev and tested
## Checklists 

