### PR TITLE
OLH-2289 Alarms for the Account Interventions Events Queue

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,6 @@
   "resolutions": {
     "axios": "^1.7.7",
     "cookie": "^0.7.0",
-    "jsonpath-plus": "^10.0.0"
+    "jsonpath-plus": "^10.0.7"
   }
 }

--- a/src/infra/alarm/template.yaml
+++ b/src/infra/alarm/template.yaml
@@ -37,6 +37,14 @@ Parameters:
     Description: "The name of the Account Deletion Processor DLQ"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/ais-main/SQS/AccountDeletionProcessorDLQ/Name" #pragma: allowlist secret
+  AccountInterventionEventsQueueName:
+    Description: "The name of the Account Intervention Events queue"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/ais-main/SQS/AccountInterventionEventsQueue/Name" #pragma: allowlist secret
+  AccountInterventionEventsDLQName:
+    Description: "The name of the Account Intervention Events DLQ"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/ais-main/SQS/AccountInterventionEventsDLQ/Name" #pragma: allowlist secret
   MainStackName:
     Description: The name of the Main AIS stack
     Type: String
@@ -165,6 +173,86 @@ Resources:
       Dimensions:
         - Name: QueueName
           Value: !Ref TxMAEgressDLQName
+      MetricName: ApproximateNumberOfMessagesVisible
+      Namespace: AWS/SQS
+      Period: 60
+      Statistic: Maximum
+      Unit: Count
+
+  AccountInterventionEventsQueueProcessingSlowly:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref AlertingSNSLowAlertNotificationTopicARN
+      AlarmDescription: !Sub "Account Intervention Events queue processing slowly. ${RunBookURL}"
+      ComparisonOperator: GreaterThanThreshold
+      Threshold: 60  # Adjust threshold as needed
+      EvaluationPeriods: 1
+      TreatMissingData: notBreaching
+      Dimensions:
+        - Name: QueueName
+          Value: !Ref AccountInterventionEventsQueueName
+      MetricName: ApproximateAgeOfOldestMessage
+      Namespace: AWS/SQS
+      Period: 60
+      Statistic: Maximum
+      Unit: Count
+
+  AccountInterventionEventsQueueTooManyMessages:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref AlertingSNSLowAlertNotificationTopicARN
+      AlarmDescription: !Sub "Account Intervention Events queue has too many messages. ${RunBookURL}"
+      ComparisonOperator: GreaterThanThreshold
+      Threshold: 50  # Adjust threshold as needed
+      EvaluationPeriods: 1
+      TreatMissingData: notBreaching
+      Dimensions:
+        - Name: QueueName
+          Value: !Ref AccountInterventionEventsQueueName
+      MetricName: ApproximateNumberOfMessagesVisible
+      Namespace: AWS/SQS
+      Period: 60
+      Statistic: Maximum
+      Unit: Count
+
+  AccountInterventionEventsDLQHasMessages:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref AlertingSNSLowAlertNotificationTopicARN
+      AlarmDescription: !Sub "Account Intervention Events DLQ has messages. ${RunBookURL}"
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Threshold: 1
+      EvaluationPeriods: 1
+      TreatMissingData: notBreaching
+      Dimensions:
+        - Name: QueueName
+          Value: !Ref AccountInterventionEventsDLQName
+      MetricName: ApproximateNumberOfMessagesVisible
+      Namespace: AWS/SQS
+      Period: 60
+      Statistic: Maximum
+      Unit: Count
+
+  AccountInterventionEventsDLQTooManyMessages:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref AlertingSNSLowAlertNotificationTopicARN
+      AlarmDescription: !Sub "Account Intervention Events DLQ has too many messages. ${RunBookURL}"
+      ComparisonOperator: GreaterThanThreshold
+      Threshold: 10  # Adjust threshold as needed
+      EvaluationPeriods: 1
+      TreatMissingData: notBreaching
+      Dimensions:
+        - Name: QueueName
+          Value: !Ref AccountInterventionEventsDLQName
       MetricName: ApproximateNumberOfMessagesVisible
       Namespace: AWS/SQS
       Period: 60

--- a/src/infra/main/template.yaml
+++ b/src/infra/main/template.yaml
@@ -1165,6 +1165,34 @@ Resources:
         - Key: Source
           Value: !Ref SourceTagValue
 
+  AccountInterventionEventsQueueNameSSM:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: The Name of the Account Intervention Events Queue
+      Name: !Sub "/${AWS::StackName}/SQS/AccountInterventionEventsQueue/Name"
+      Type: String
+      Value: !GetAtt AccountInterventionEventsQueue.QueueName
+      Tags:
+        Environment: !Ref Environment
+        Product: !Ref ProductTagValue
+        System: !Ref SystemTagValue
+        Owner: !Ref OwnerTagValue
+        Source: !Ref SourceTagValue
+
+  AccountInterventionEventsDLQNameSSM:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: The Name of the Account Intervention Events DLQ
+      Name: !Sub "/${AWS::StackName}/SQS/AccountInterventionEventsDLQ/Name"
+      Type: String
+      Value: !GetAtt AccountInterventionEventsDLQ.QueueName
+      Tags:
+        Environment: !Ref Environment
+        Product: !Ref ProductTagValue
+        System: !Ref SystemTagValue
+        Owner: !Ref OwnerTagValue
+        Source: !Ref SourceTagValue
+
 ### Encryption Key SQS & SNS ###
 
   AccountDeletionProcessorSNSKmsKey:

--- a/yarn.lock
+++ b/yarn.lock
@@ -5894,10 +5894,10 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonpath-plus@7.1.0, jsonpath-plus@^10.0.0, jsonpath-plus@^6.0.1:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.0.0.tgz#7a747d47e20a27867dbbc80b57fd554788b91474"
-  integrity sha512-v7j76HGp/ibKlXYeZ7UrfCLSNDaBWuJMA0GaMjA4sZJtCtY89qgPyToDDcl2zdeHh4B5q/B3g2pQdW76fOg/dA==
+jsonpath-plus@7.1.0, jsonpath-plus@^10.0.7, jsonpath-plus@^6.0.1:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.1.0.tgz#e8724c721ac60ff2db667066131b1a2c992ffcf0"
+  integrity sha512-gHfV1IYqH8uJHYVTs8BJX1XKy2/rR93+f8QQi0xhx95aCiXn1ettYAd5T+7FU6wfqyDoX/wy0pm/fL3jOKJ9Lg==
   dependencies:
     "@jsep-plugin/assignment" "^1.2.1"
     "@jsep-plugin/regex" "^1.0.3"


### PR DESCRIPTION
## Proposed changes
<!-- Include the Jira ticket number in square brackets as prefix, eg `ATB-XXXX: Description of Change` -->

### What changed

- Create new alarms for the account interventions queue
- Create parameters to share the queue names between the main and alarm stack
- Updated a dev dependency as there was a security notice

### Why did it change

- So that we can monitor the status of account interventions, and be infomred when there is an issue

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
https://govukverify.atlassian.net/browse/OLH-2289

## Testing

Verified that the alarms are created on dev, and that they go into alarm

## Checklists
- [X] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [X] Tested changes and included test evidence in the PR, if appropriate
- [X] Included all required tags and other properties for any new resources in the SAM template
- [X] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [X] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [X] Ensured that no log lines include PII or other sensitive data
- [X] Ensured that all commits in this PR are signed
- [X] Ensured appropriate code coverage is maintained by unit tests
- [X] Checked SonarCube and ensured no code smells were added
