### PR TITLE
OLH-2291 update alarm

### DIFF
--- a/src/infra/alarm/template.yaml
+++ b/src/infra/alarm/template.yaml
@@ -1053,7 +1053,7 @@ Resources:
       TreatMissingData: notBreaching
       Dimensions:
         - Name: service
-          Value: InterventionsProcessorFunction
+          Value: TxmaEventHandlerFunction
 
   AverageTxMALatencyOver5Sec:
     Type: AWS::CloudWatch::Alarm
@@ -1073,7 +1073,7 @@ Resources:
       TreatMissingData: notBreaching
       Dimensions:
         - Name: service
-          Value: InterventionsProcessorFunction
+          Value: TxmaEventHandlerFunction
 
   MaxTxMALatencyOver10Sec:
     Type: AWS::CloudWatch::Alarm
@@ -1093,7 +1093,7 @@ Resources:
       TreatMissingData: notBreaching
       Dimensions:
         - Name: service
-          Value: InterventionsProcessorFunction
+          Value: TxmaEventHandlerFunction
 
 #
 # CloudWatch alarms for Status Retriever


### PR DESCRIPTION
## Proposed changes
<!-- Include the Jira ticket number in square brackets as prefix, eg `ATB-XXXX: Description of Change` -->

### What changed

- Change the TxMA latency alarm to the new TxMA Handler

### Why did it change

The metric was checking the time for the InterventionHandler, we now use the TxMA handler, so we should change it. There were a lot of 2 second execution time alarms, which were triggering as a result.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- List any related PRs -->
https://govukverify.atlassian.net/browse/OLH-2291

## Testing
<!-- Please give an overview of how the changes were tested -->
<!-- Please specify if changes were tested locally and how, include evidence where relevant -->
<!-- Please specify if changes were deployed and tested in the AWS Account and how, include evidence where relevant -->

## Checklists
- [ ] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [ ] Tested changes and included test evidence in the PR, if appropriate
- [ ] Included all required tags and other properties for any new resources in the SAM template
- [ ] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [ ] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [ ] Ensured that no log lines include PII or other sensitive data
- [ ] Implemented unit testing for any new logic implemented, if appropriate
- [ ] Ensured that all commits in this PR are signed
- [ ] Ensured appropriate code coverage is maintained by unit tests
- [ ] Checked SonarCube and ensured no code smells were added
