### PR TITLE
OLH-2619: Restrict actions workflows to repo read permissions

### DIFF
--- a/.github/workflows/acceptance-checks.yaml
+++ b/.github/workflows/acceptance-checks.yaml
@@ -1,5 +1,7 @@
 ---
 name: 'Build & Test'
+permissions:
+  contents: read
 
 # Triggered when:
 #   - a file, listed below, is pushed to any branch other than `main`, i.e. a feature branch.

--- a/.github/workflows/ensure-sha-pinned-actions.yaml
+++ b/.github/workflows/ensure-sha-pinned-actions.yaml
@@ -1,9 +1,11 @@
-name: "Ensure SHA Pinned Actions"
+name: 'Ensure SHA Pinned Actions'
+permissions:
+  contents: read
 
 on:
   push:
     paths:
-      - ".github/workflows/*"
+      - '.github/workflows/*'
 
 jobs:
   harden_security:


### PR DESCRIPTION
## Proposed changes
<!-- Include the Jira ticket number in square brackets as prefix, eg `ATB-XXXX: Description of Change` -->

### What changed
Set the GITHUB_TOKEN permissions to read only for the workflows which run the tests and check for pinned action versions.

### Why did it change

If a workflow doesn't have any permissions defined it inherits from the repo permissions. Since this repo was created before Feb 2023, the default permissions are read/write.

These workflows don't need any write permissions so we can restrict them to the minimum for safety.

This PR fixes security alerts [1](https://github.com/govuk-one-login/account-interventions-service/security/code-scanning/1) & [2](https://github.com/govuk-one-login/account-interventions-service/security/code-scanning/2). 

### Testing

If these two workflows still run and pass on this PR then this change is working.

## Checklists
- [x] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [ ] Tested changes and included test evidence in the PR, if appropriate
- [ ] Included all required tags and other properties for any new resources in the SAM template
- [ ] Ensured that any new resources in the SAM Template follow appropriate naming conventions
- [ ] Ensured that naming of new resources is compatible with deploying multiple stacks with custom stack names during development
- [ ] Ensured that no log lines include PII or other sensitive data
- [ ] Implemented unit testing for any new logic implemented, if appropriate
- [x] Ensured that all commits in this PR are signed
- [ ] Ensured appropriate code coverage is maintained by unit tests
- [ ] Checked SonarCube and ensured no code smells were added
