### PR TITLE
FPAD-6038: State transition error messages

### DIFF
--- a/src/data-types/interfaces.ts
+++ b/src/data-types/interfaces.ts
@@ -19,6 +19,7 @@ export interface DynamoDBStateResult extends StateDetails {
   appliedAt?: number;
   isAccountDeleted?: boolean;
   history: string[];
+  intervention: string;
 }
 
 export interface FullAccountInformation {

--- a/src/handlers/interventions-processor-handler.ts
+++ b/src/handlers/interventions-processor-handler.ts
@@ -202,11 +202,19 @@ async function validateAccountIsNotDeleted(
  * @param itemFromDB - query result from database
  * @returns - Object representing the account state
  */
-function formCurrentAccountStateObject(itemFromDB?: DynamoDBStateResult) {
+function formCurrentAccountStateObject(itemFromDB?: DynamoDBStateResult): StateDetails {
+  if (!itemFromDB)
+    return {
+      blocked: false,
+      suspended: false,
+      resetPassword: false,
+      reproveIdentity: false,
+    };
+
   return {
-    blocked: itemFromDB ? itemFromDB.blocked : false,
-    suspended: itemFromDB ? itemFromDB.suspended : false,
-    resetPassword: itemFromDB ? itemFromDB.resetPassword : false,
-    reproveIdentity: itemFromDB ? itemFromDB.reproveIdentity : false,
+    blocked: itemFromDB.blocked,
+    suspended: itemFromDB.suspended,
+    resetPassword: itemFromDB.resetPassword,
+    reproveIdentity: itemFromDB.reproveIdentity,
   };
 }

--- a/src/handlers/interventions-processor-handler.ts
+++ b/src/handlers/interventions-processor-handler.ts
@@ -88,14 +88,18 @@ async function processSQSRecord(record: SQSRecord) {
 
   const itemFromDB = await service.getAccountStateInformation(userId);
 
-  const currentAccountState: StateDetails = formCurrentAccountStateObject(itemFromDB);
+  const currentAccountState = formCurrentAccountStateObject(itemFromDB);
 
   if (itemFromDB) {
     await validateAccountIsNotDeleted(eventName, userId, recordBody, currentAccountState, itemFromDB);
     await validateEventIsNotStale(eventName, recordBody, currentAccountState, itemFromDB);
   }
 
-  const statusResult = accountStateEngine.applyEventTransition(eventName, currentAccountState);
+  const statusResult = accountStateEngine.applyEventTransition(
+    eventName,
+    currentAccountState,
+    itemFromDB?.intervention,
+  );
   const partialCommandInput = buildPartialUpdateAccountStateCommand(
     statusResult.stateResult,
     eventName,

--- a/src/services/account-states/account-state-engine.ts
+++ b/src/services/account-states/account-state-engine.ts
@@ -71,14 +71,18 @@ export class AccountStateEngine {
    * @param event - EventEnum representation of event received
    * @param initialState - optional state object representation the current state of the account, it defaults to account unsuspended if nothing is passed
    */
-  applyEventTransition(event: EventsEnum, initialState: StateDetails): AccountStateEngineOutput {
+  applyEventTransition(
+    event: EventsEnum,
+    initialState: StateDetails,
+    interventionName: string | undefined,
+  ): AccountStateEngineOutput {
     const allowedTransitions = this.determineNextAllowableInterventions(initialState);
-    const transition = this.getTransition(allowedTransitions, event, initialState);
+    const transition = this.getTransition(allowedTransitions, event, initialState, interventionName);
     const newStateObject = this.getNewStateObject(transition);
     if (areAccountStatesTheSame(newStateObject, initialState))
       throw buildConfigurationError(
         MetricNames.TRANSITION_SAME_AS_CURRENT_STATE,
-        'Computed new state is the same as the current state.',
+        `Computed new state is the same as the current state. Current state: ${interventionName ?? '(empty)'}; Event: ${event}`,
       );
     return {
       stateResult: newStateObject,
@@ -135,13 +139,18 @@ export class AccountStateEngine {
    * @param transition - EventsEnum representation of the proposed transition
    * @param initialState - initial state of the account
    */
-  private getTransition(allowedTransition: Codes[], transition: EventsEnum, initialState: StateDetails) {
+  private getTransition(
+    allowedTransition: Codes[],
+    transition: EventsEnum,
+    initialState: StateDetails,
+    interventionName: string | undefined,
+  ) {
     for (const edge of allowedTransition) {
       if (AccountStateEngine.configuration.edges[edge].name.toString() === transition.toString()) return edge;
     }
     throw buildStateTransitionError(
       MetricNames.STATE_TRANSITION_NOT_ALLOWED_OR_IGNORED,
-      `${transition} is not allowed from current state`,
+      `${transition} is not allowed from current state. Current state: ${interventionName ?? '(empty)'}`,
       transition,
       initialState,
     );

--- a/src/services/dynamo-database-service.ts
+++ b/src/services/dynamo-database-service.ts
@@ -43,7 +43,7 @@ export class DynamoDatabaseService {
   public async getAccountStateInformation(userId: string): Promise<DynamoDBStateResult | undefined> {
     const parameters = this.getInputParameterForDatabaseQuery(userId);
     parameters.ProjectionExpression =
-      'blocked, suspended, resetPassword, reproveIdentity, sentAt, appliedAt, isAccountDeleted, history';
+      'blocked, suspended, resetPassword, reproveIdentity, sentAt, appliedAt, isAccountDeleted, history, intervention';
     const response: QueryCommandOutput = await this.dynamoClient.send(new QueryCommand(parameters));
     return this.validateQueryResponse<DynamoDBStateResult>(response);
   }

--- a/src/services/test/account-state-engine.test.ts
+++ b/src/services/test/account-state-engine.test.ts
@@ -155,6 +155,8 @@ const idResetSuccessfulUpdateSuspended = {
   nextAllowableInterventions: ['01', '02', '03', '05', '06', '90', '94'],
 };
 
+const interventionName: string | undefined = undefined;
+
 vi.mock('@aws-lambda-powertools/logger');
 vi.mock('../../commons/metrics');
 vi.mock('../../commons/get-current-timestamp', () => ({
@@ -178,7 +180,11 @@ describe('account-state-service', () => {
           pswAndIdResetRequiredUpdate,
         ],
       ])('%p', (intervention, retrievedAccountState, command) => {
-        const partialCommand = accountStateEngine.applyEventTransition(intervention, retrievedAccountState);
+        const partialCommand = accountStateEngine.applyEventTransition(
+          intervention,
+          retrievedAccountState,
+          interventionName,
+        );
         expect(partialCommand).toEqual(command);
       });
     });
@@ -195,7 +201,11 @@ describe('account-state-service', () => {
           pswAndIdResetRequiredUpdate,
         ],
       ])('%p', (intervention, retrievedAccountState, command) => {
-        const partialCommand = accountStateEngine.applyEventTransition(intervention, retrievedAccountState);
+        const partialCommand = accountStateEngine.applyEventTransition(
+          intervention,
+          retrievedAccountState,
+          interventionName,
+        );
         expect(partialCommand).toEqual(command);
       });
     });
@@ -212,7 +222,11 @@ describe('account-state-service', () => {
         ],
         [EventsEnum.FRAUD_BLOCK_ACCOUNT, accountIsSuspended, blockAccountUpdate],
       ])('%p', (intervention, retrievedAccountState, command) => {
-        const partialCommand = accountStateEngine.applyEventTransition(intervention, retrievedAccountState);
+        const partialCommand = accountStateEngine.applyEventTransition(
+          intervention,
+          retrievedAccountState,
+          interventionName,
+        );
         expect(addMetric).not.toHaveBeenCalled();
         expect(partialCommand).toEqual(command);
       });
@@ -236,7 +250,11 @@ describe('account-state-service', () => {
           pswAndIdResetRequiredUpdate,
         ],
       ])('%p', (intervention, retrievedAccountState, command) => {
-        const partialCommand = accountStateEngine.applyEventTransition(intervention, retrievedAccountState);
+        const partialCommand = accountStateEngine.applyEventTransition(
+          intervention,
+          retrievedAccountState,
+          interventionName,
+        );
         expect(partialCommand).toEqual(command);
       });
     });
@@ -254,7 +272,11 @@ describe('account-state-service', () => {
         [EventsEnum.IPV_ACCOUNT_INTERVENTION_END, accountNeedsIDReset, idResetSuccessfulUpdateUnsuspended],
         [EventsEnum.FRAUD_BLOCK_ACCOUNT, accountNeedsIDReset, blockAccountUpdate],
       ])('%p', (intervention, retrievedAccountState, command) => {
-        const partialCommand = accountStateEngine.applyEventTransition(intervention, retrievedAccountState);
+        const partialCommand = accountStateEngine.applyEventTransition(
+          intervention,
+          retrievedAccountState,
+          interventionName,
+        );
         expect(partialCommand).toEqual(command);
       });
     });
@@ -274,7 +296,11 @@ describe('account-state-service', () => {
         [EventsEnum.FRAUD_UNSUSPEND_ACCOUNT, accountNeedsIDResetAdnPswReset, unsuspendAccountUpdate],
         [EventsEnum.FRAUD_SUSPEND_ACCOUNT, accountNeedsIDResetAdnPswReset, suspendAccountUpdate],
       ])('%p', (intervention, retrievedAccountState, command) => {
-        const partialCommand = accountStateEngine.applyEventTransition(intervention, retrievedAccountState);
+        const partialCommand = accountStateEngine.applyEventTransition(
+          intervention,
+          retrievedAccountState,
+          interventionName,
+        );
         expect(partialCommand).toEqual(command);
       });
     });
@@ -283,7 +309,11 @@ describe('account-state-service', () => {
       it.each([[EventsEnum.FRAUD_UNBLOCK_ACCOUNT, accountIsBlocked, unblockAccountUpdate]])(
         '%p',
         (intervention, retrievedAccountState, command) => {
-          const partialCommand = accountStateEngine.applyEventTransition(intervention, retrievedAccountState);
+          const partialCommand = accountStateEngine.applyEventTransition(
+            intervention,
+            retrievedAccountState,
+            interventionName,
+          );
           expect(partialCommand).toEqual(command);
         },
       );
@@ -314,12 +344,18 @@ describe('account-state-service', () => {
       ])(
         'when is %p applied on account state: %p it should throw a StateTransitionError',
         (intervention, retrievedAccountState) => {
-          expect(() => accountStateEngine.applyEventTransition(intervention, retrievedAccountState)).toThrow(
-            new StateTransitionError(`${intervention} is not allowed from current state`, intervention, {
-              nextAllowableInterventions: [Codes.C01, Codes.C03, Codes.C04, Codes.C05, Codes.C06],
-              stateResult: retrievedAccountState,
-              interventionName: AISInterventionTypes.AIS_NO_INTERVENTION,
-            }),
+          expect(() =>
+            accountStateEngine.applyEventTransition(intervention, retrievedAccountState, interventionName),
+          ).toThrow(
+            new StateTransitionError(
+              `${intervention} is not allowed from current state. Current state: (empty)`,
+              intervention,
+              {
+                nextAllowableInterventions: [Codes.C01, Codes.C03, Codes.C04, Codes.C05, Codes.C06],
+                stateResult: retrievedAccountState,
+                interventionName: AISInterventionTypes.AIS_NO_INTERVENTION,
+              },
+            ),
           );
           // eslint-disable-next-line @typescript-eslint/unbound-method
           expect(logger.error).not.toHaveBeenCalled();
@@ -391,15 +427,23 @@ describe('account-state-service', () => {
       ])(
         'when is %p applied on account state: %p it should throw StateTransitionError and add a STATE_TRANSITION_NOT_ALLOWED_OR_IGNORED metric',
         (intervention, retrievedAccountState, expectedAllowable) => {
-          expect(() => accountStateEngine.applyEventTransition(intervention, retrievedAccountState)).toThrow(
-            new StateTransitionError(`${intervention} is not allowed from current state`, intervention, {
-              nextAllowableInterventions: expectedAllowable,
-              stateResult: retrievedAccountState,
-              interventionName: AISInterventionTypes.AIS_NO_INTERVENTION,
-            }),
+          expect(() =>
+            accountStateEngine.applyEventTransition(intervention, retrievedAccountState, interventionName),
+          ).toThrow(
+            new StateTransitionError(
+              `${intervention} is not allowed from current state. Current state: (empty)`,
+              intervention,
+              {
+                nextAllowableInterventions: expectedAllowable,
+                stateResult: retrievedAccountState,
+                interventionName: AISInterventionTypes.AIS_NO_INTERVENTION,
+              },
+            ),
           );
           // eslint-disable-next-line @typescript-eslint/unbound-method
-          expect(logger.error).toHaveBeenCalledWith({ message: `${intervention} is not allowed from current state` });
+          expect(logger.error).toHaveBeenCalledWith({
+            message: `${intervention} is not allowed from current state. Current state: (empty)`,
+          });
           expect(addMetric).toHaveBeenLastCalledWith(MetricNames.STATE_TRANSITION_NOT_ALLOWED_OR_IGNORED);
         },
       );
@@ -413,7 +457,11 @@ describe('account-state-service', () => {
           resetPassword: true,
         };
         expect(() =>
-          accountStateEngine.applyEventTransition(EventsEnum.FRAUD_BLOCK_ACCOUNT, unexpectedAccountState),
+          accountStateEngine.applyEventTransition(
+            EventsEnum.FRAUD_BLOCK_ACCOUNT,
+            unexpectedAccountState,
+            interventionName,
+          ),
         ).toThrow(new StateEngineConfigurationError('Account state does not exists in current configuration.'));
         expect(addMetric).toHaveBeenLastCalledWith(MetricNames.STATE_NOT_FOUND_IN_CURRENT_CONFIG);
       });
@@ -466,11 +514,13 @@ describe('account-state-service', () => {
         value: invalidConfig,
       });
 
-      const expectedError = new StateEngineConfigurationError('Computed new state is the same as the current state.');
-
-      expect(() => accountStateEngine.applyEventTransition(EventsEnum.FRAUD_BLOCK_ACCOUNT, accountIsOkay)).toThrow(
-        expectedError,
+      const expectedError = new StateEngineConfigurationError(
+        'Computed new state is the same as the current state. Current state: (empty); Event: FRAUD_BLOCK_ACCOUNT',
       );
+
+      expect(() =>
+        accountStateEngine.applyEventTransition(EventsEnum.FRAUD_BLOCK_ACCOUNT, accountIsOkay, interventionName),
+      ).toThrow(expectedError);
       expect(addMetric).toHaveBeenLastCalledWith(MetricNames.TRANSITION_SAME_AS_CURRENT_STATE);
     });
 
@@ -513,7 +563,9 @@ describe('account-state-service', () => {
         value: invalidConfig,
       });
 
-      expect(() => accountStateEngine.applyEventTransition(EventsEnum.FRAUD_UNBLOCK_ACCOUNT, accountIsBlocked)).toThrow(
+      expect(() =>
+        accountStateEngine.applyEventTransition(EventsEnum.FRAUD_UNBLOCK_ACCOUNT, accountIsBlocked, interventionName),
+      ).toThrow(
         new StateEngineConfigurationError(
           'There are no allowed transitions from state AccountIsBlocked in current configurations',
         ),

--- a/src/services/test/dynamo-database-service.test.ts
+++ b/src/services/test/dynamo-database-service.test.ts
@@ -97,7 +97,7 @@ describe('Dynamo DB Service', () => {
       ExpressionAttributeNames: { '#pk': 'pk' },
       ExpressionAttributeValues: { ':id_value': { S: 'abc' } },
       ProjectionExpression:
-        'blocked, suspended, resetPassword, reproveIdentity, sentAt, appliedAt, isAccountDeleted, history',
+        'blocked, suspended, resetPassword, reproveIdentity, sentAt, appliedAt, isAccountDeleted, history, intervention',
     };
     queryCommandMock.resolvesOnce({ Items: items });
     await new DynamoDatabaseService('abc').getAccountStateInformation('abc');

--- a/src/services/test/validate-event.test.ts
+++ b/src/services/test/validate-event.test.ts
@@ -9,7 +9,7 @@ import {
 import logger from '../../commons/logger';
 import { addMetric } from '../../commons/metrics';
 import { ValidationError } from '../../data-types/errors';
-import { EventsEnum, MetricNames, TriggerEventsEnum } from '../../data-types/constants';
+import { AISInterventionTypes, EventsEnum, MetricNames, TriggerEventsEnum } from '../../data-types/constants';
 import { sendAuditEvent } from '../send-audit-events';
 import { getCurrentTimestamp } from '../../commons/get-current-timestamp';
 import { InterventionCodeEnum1 } from '@govuk-one-login/event-catalogue/AIS_EVENT_TRANSITION_APPLIED';
@@ -36,6 +36,7 @@ const dynamoDBResult: DynamoDBStateResult = {
   appliedAt: timestamp.milliseconds - 5000,
   isAccountDeleted: false,
   history: [],
+  intervention: AISInterventionTypes.AIS_ACCOUNT_UNSUSPENDED,
 };
 describe('event-validation', () => {
   afterEach(() => {


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Include the current state from the database in state transition error messages.

## Why

Make it easier to debug.

## Notes

This change requires fetching an additional `intervention` field from the database.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-6038](https://govukverify.atlassian.net/browse/FPAD-6038)


[FPAD-6038]: https://govukverify.atlassian.net/browse/FPAD-6038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ