### PR TITLE
Update link for `InterventionsProcessorErrorsOver10Mins` alarm

### DIFF
--- a/src/infra/alarm/template.yaml
+++ b/src/infra/alarm/template.yaml
@@ -54,9 +54,13 @@ Parameters:
     Type: String
     Default: ais-main
   RunBookURL:
-    Description: 'A Link to the AIS Runbook'
+    Description: 'A Link to the partially deprecated Confluence AIS Runbook'
     Type: String
     Default: 'https://govukverify.atlassian.net/wiki/spaces/AIS/pages/4579595211/AIS+-+Alarms+Metrics+Monitoring'
+  TeamManualPlaybookUrl:
+    Description: 'A link to the AIS playbook in the team manual'
+    Type: String
+    Default: 'https://team-manual.account.gov.uk/teams/fraud-platforms-and-delivery-team/fraud-neptune-team/ais/account-interventions-service-playbook'
 
 Resources:
   #
@@ -718,7 +722,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref AlertingSNSHighAlertNotificationTopicARN
-      AlarmDescription: !Sub 'Interventions Processor Function Lambda errors over 10 minutes. ${RunBookURL}'
+      AlarmDescription: !Sub 'Interventions Processor Function Lambda errors over 10 minutes. ${TeamManualPlaybookUrl}'
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Threshold: 1
       EvaluationPeriods: 10


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

This updates the link for the `InterventionsProcessorErrorsOver10Mins` alarm, to point to the new team manual playbook page

## Why

So if anyone gets paged they can find up-to-date instructions

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-7735](https://govukverify.atlassian.net/browse/FPAD-7735)


[FPAD-7735]: https://govukverify.atlassian.net/browse/FPAD-7735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ