### PR TITLE
FPAD-7737: Remove AccountDeletionProcessorQueue

### DIFF
--- a/src/infra/alarm/template.yaml
+++ b/src/infra/alarm/template.yaml
@@ -29,10 +29,6 @@ Parameters:
     Description: 'The name of the Private API Gateway'
     Type: AWS::SSM::Parameter::Value<String>
     Default: '/ais-main/PrivateRestApi/Name'
-  AccountDeletionProcessorQueueName:
-    Description: 'The name of the Account Deletion Processor queue'
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: '/ais-main/SQS/AccountDeletionProcessorQueue/Name' #pragma: allowlist secret
   AccountDeletionEventQueueName:
     Description: 'The name of the Account Deletion Event queue'
     Type: AWS::SSM::Parameter::Value<String>
@@ -262,46 +258,6 @@ Resources:
         - Name: QueueName
           Value: !Ref AccountInterventionEventsDLQName
       MetricName: ApproximateNumberOfMessagesVisible
-      Namespace: AWS/SQS
-      Period: 60
-      Statistic: Maximum
-      Unit: Count
-
-  AccountDeletionProcessorQueueProcessingSlowly:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      ActionsEnabled: true
-      AlarmActions:
-        - !Ref AlertingSNSLowAlertNotificationTopicARN
-      AlarmDescription: !Sub 'Account Deletion Processor Queue processing slowly. ${RunBookURL}'
-      ComparisonOperator: GreaterThanThreshold
-      Threshold: 60
-      EvaluationPeriods: 1
-      TreatMissingData: notBreaching
-      Dimensions:
-        - Name: QueueName
-          Value: !Ref AccountDeletionProcessorQueueName
-      MetricName: ApproximateAgeOfOldestMessage
-      Namespace: AWS/SQS
-      Period: 60
-      Statistic: Maximum
-      Unit: Count
-
-  AccountDeletionProcessorQueueProcessingTooSlow:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      ActionsEnabled: true
-      AlarmActions:
-        - !Ref AlertingSNSLowAlertNotificationTopicARN
-      AlarmDescription: !Sub 'Account Deletion Processor Queue processing too slow. ${RunBookURL}'
-      ComparisonOperator: GreaterThanThreshold
-      Threshold: 600
-      EvaluationPeriods: 1
-      TreatMissingData: notBreaching
-      Dimensions:
-        - Name: QueueName
-          Value: !Ref AccountDeletionProcessorQueueName
-      MetricName: ApproximateAgeOfOldestMessage
       Namespace: AWS/SQS
       Period: 60
       Statistic: Maximum

--- a/src/infra/main/template.yaml
+++ b/src/infra/main/template.yaml
@@ -716,12 +716,6 @@ Resources:
               - 'sqs:ReceiveMessage'
               - 'sqs:DeleteMessage'
               - 'sqs:GetQueueAttributes'
-            Resource: !GetAtt AccountDeletionProcessorQueue.Arn
-          - Effect: Allow
-            Action:
-              - 'sqs:ReceiveMessage'
-              - 'sqs:DeleteMessage'
-              - 'sqs:GetQueueAttributes'
             Resource: !GetAtt AccountDeletionEventQueue.Arn
       Roles:
         - !Ref AccountDeletionProcessorFunctionRole
@@ -786,30 +780,6 @@ Resources:
       LogGroupName: !Ref AccountDeletionProcessorFunctionLogGroup
       FilterPattern: '{$.message != "Sensitive info*"}'
 
-  AccountDeletionProcessorQueue:
-    Type: AWS::SQS::Queue
-    Properties:
-      QueueName: !Sub '${AWS::StackName}-AccountDeletionProcessorQueue'
-      MessageRetentionPeriod: 1209600
-      KmsMasterKeyId: !GetAtt SQSEncryptionKey.Arn
-      RedriveAllowPolicy:
-        redrivePermission: denyAll
-      RedrivePolicy:
-        deadLetterTargetArn: !GetAtt AccountDeletionProcessorDLQ.Arn
-        maxReceiveCount: 60
-      VisibilityTimeout: 10
-      Tags:
-        - Key: Product
-          Value: !Ref ProductTagValue
-        - Key: System
-          Value: !Ref SystemTagValue
-        - Key: Environment
-          Value: !Ref Environment
-        - Key: Owner
-          Value: !Ref OwnerTagValue
-        - Key: Source
-          Value: !Ref SourceTagValue
-
   AccountDeletionEventQueue:
     Type: AWS::SQS::Queue
     Properties:
@@ -844,7 +814,6 @@ Resources:
       RedriveAllowPolicy:
         redrivePermission: byQueue
         sourceQueueArns:
-          - !Sub 'arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${AWS::StackName}-AccountDeletionProcessorQueue'
           - !Sub 'arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${AWS::StackName}-AccountDeletionEventQueue'
       Tags:
         - Key: Product
@@ -857,20 +826,6 @@ Resources:
           Value: !Ref OwnerTagValue
         - Key: Source
           Value: !Ref SourceTagValue
-
-  AccountDeletionProcessorQueueNameSSM:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Description: The Name of the Account Deletion Processor Queue
-      Name: !Sub '/${AWS::StackName}/SQS/AccountDeletionProcessorQueue/Name'
-      Type: String
-      Value: !GetAtt AccountDeletionProcessorQueue.QueueName
-      Tags:
-        Environment: !Ref Environment
-        Product: !Ref ProductTagValue
-        System: !Ref SystemTagValue
-        Owner: !Ref OwnerTagValue
-        Source: !Ref SourceTagValue
 
   AccountDeletionEventQueueNameSSM:
     Type: AWS::SSM::Parameter


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Remove AccountDeletionProcessorQueue.

## Why

Unused queue, which is a hold over from a previous implementation of Account Deletion.

## Notes

This has been confirmed with Saral.

I have manually deployed to the `dev` environment and checked feature tests pass.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-7737](https://govukverify.atlassian.net/browse/FPAD-7737)


[FPAD-7737]: https://govukverify.atlassian.net/browse/FPAD-7737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ