### PR TITLE
BAU: Switch to vitest stubEnv

### DIFF
--- a/src/handlers/tests/txma-handler.test.ts
+++ b/src/handlers/tests/txma-handler.test.ts
@@ -46,7 +46,6 @@ beforeEach(() => {
 });
 
 describe('TxMA Handler', () => {
-  const OLD_ENV = process.env;
   let mockEvent: SQSEvent;
   let mockRecord: SQSRecord;
   const mockContext = {
@@ -70,12 +69,8 @@ describe('TxMA Handler', () => {
     },
   };
 
-  beforeEach(() => {
-    process.env = { ...OLD_ENV };
-  });
-
   afterEach(() => {
-    process.env = OLD_ENV;
+    vi.unstubAllEnvs();
     vi.clearAllMocks();
   });
 
@@ -88,8 +83,8 @@ describe('TxMA Handler', () => {
     mockRecord = createMockRecord(deleteEvent);
     mockEvent = { Records: [mockRecord] };
 
-    process.env['ACCOUNT_DELETION_SQS_QUEUE'] = 'delete_queue';
-    process.env['ACCOUNT_INTERVENTION_SQS_QUEUE'] = 'intervention_queue';
+    vi.stubEnv('ACCOUNT_DELETION_SQS_QUEUE', 'delete_queue');
+    vi.stubEnv('ACCOUNT_INTERVENTION_SQS_QUEUE', 'intervention_queue');
     await handler(mockEvent, mockContext);
     expect(mockSendBatchSqsMessage).toHaveBeenCalledWith(
       [
@@ -109,8 +104,8 @@ describe('TxMA Handler', () => {
     };
     mockRecord = createMockRecord(otherInterventionEvent);
     mockEvent = { Records: [mockRecord] };
-    process.env['ACCOUNT_DELETION_SQS_QUEUE'] = 'delete_queue';
-    process.env['ACCOUNT_INTERVENTION_SQS_QUEUE'] = 'intervention_queue';
+    vi.stubEnv('ACCOUNT_DELETION_SQS_QUEUE', 'delete_queue');
+    vi.stubEnv('ACCOUNT_INTERVENTION_SQS_QUEUE', 'intervention_queue');
     await handler(mockEvent, mockContext);
     expect(mockSendBatchSqsMessage).toHaveBeenCalledWith(
       [
@@ -124,7 +119,7 @@ describe('TxMA Handler', () => {
   });
 
   it('Sends throw an error if delete queue not configured', async () => {
-    process.env['ACCOUNT_INTERVENTION_SQS_QUEUE'] = 'intervention_queue';
+    vi.stubEnv('ACCOUNT_INTERVENTION_SQS_QUEUE', 'intervention_queue');
     try {
       await handler(mockEvent, mockContext);
     } catch (error) {
@@ -134,7 +129,7 @@ describe('TxMA Handler', () => {
   });
 
   it('Sends throw an error if intervention queue not configured', async () => {
-    process.env['ACCOUNT_DELETION_SQS_QUEUE'] = 'queue';
+    vi.stubEnv('ACCOUNT_DELETION_SQS_QUEUE', 'queue');
     try {
       await handler(mockEvent, mockContext);
     } catch (error) {

--- a/src/services/test/app-config-service.test.ts
+++ b/src/services/test/app-config-service.test.ts
@@ -6,21 +6,17 @@ import { LOGS_PREFIX_INVALID_CONFIG } from '../../data-types/constants';
 vi.mock('@aws-lambda-powertools/logger');
 
 describe('AppConfigService', () => {
-  const OLD_ENV = process.env;
-
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
-    process.env = { ...OLD_ENV };
-    delete process.env['NODE_ENV'];
   });
 
   afterEach(() => {
-    process.env = OLD_ENV;
+    vi.unstubAllEnvs();
   });
 
   it('should throw an error if the environment variable AWS_REGION is undefined', () => {
-    process.env['AWS_REGION'] = undefined;
+    vi.stubEnv('AWS_REGION', '');
     const appConfig = AppConfigService.getInstance();
     const expectedMessage = 'Invalid configuration - Environment variable AWS_REGION is not defined.';
     expect(() => appConfig.awsRegion).toThrow(new InvalidEnvironmentVariableError(expectedMessage));
@@ -31,7 +27,7 @@ describe('AppConfigService', () => {
   });
 
   it('should throw an error if the environment variable TABLE_NAME is equal to an empty string', () => {
-    process.env['TABLE_NAME'] = '';
+    vi.stubEnv('TABLE_NAME', '');
     const appConfig = AppConfigService.getInstance();
     const expectedMessage = 'Invalid configuration - Environment variable TABLE_NAME is not defined.';
     expect(() => appConfig.tableName).toThrow(new InvalidEnvironmentVariableError(expectedMessage));
@@ -42,7 +38,7 @@ describe('AppConfigService', () => {
   });
 
   it('should throw an error if the environment variable DELETED_ACCOUNT_RETENTION_SECONDS is equal to an empty string', () => {
-    process.env['DELETED_ACCOUNT_RETENTION_SECONDS'] = '';
+    vi.stubEnv('DELETED_ACCOUNT_RETENTION_SECONDS', '');
     const appConfig = AppConfigService.getInstance();
     const expectedMessage =
       'Invalid configuration - Environment variable DELETED_ACCOUNT_RETENTION_SECONDS is not defined.';
@@ -54,7 +50,7 @@ describe('AppConfigService', () => {
   });
 
   it('should throw an error if the environment variable CLOUDWATCH_METRICS_NAMESPACE is equal to an empty string', () => {
-    process.env['CLOUDWATCH_METRICS_NAMESPACE'] = '';
+    vi.stubEnv('CLOUDWATCH_METRICS_NAMESPACE', '');
     const appConfig = AppConfigService.getInstance();
     const expectedMessage = 'Invalid configuration - Environment variable CLOUDWATCH_METRICS_NAMESPACE is not defined.';
     expect(() => appConfig.cloudWatchMetricsWorkSpace).toThrow(new InvalidEnvironmentVariableError(expectedMessage));
@@ -65,7 +61,7 @@ describe('AppConfigService', () => {
   });
 
   it('should throw an error if the environment variable TXMA_QUEUE_URL is not a url', () => {
-    process.env['TXMA_QUEUE_URL'] = 'notAURL';
+    vi.stubEnv('TXMA_QUEUE_URL', 'notAURL');
     const appConfig = AppConfigService.getInstance();
     const expectedMessage = `${LOGS_PREFIX_INVALID_CONFIG} Environment variable TXMA_QUEUE_URL is not a valid HTTPS URL (notAURL).`;
     expect(() => appConfig.txmaEgressQueueUrl).toThrow(new InvalidEnvironmentVariableError(expectedMessage));
@@ -87,7 +83,7 @@ describe('AppConfigService', () => {
   });
 
   it('should throw an error if the environmental variable is not a number', () => {
-    process.env['DELETED_ACCOUNT_RETENTION_SECONDS'] = 'string';
+    vi.stubEnv('DELETED_ACCOUNT_RETENTION_SECONDS', 'string');
     const expectedMessage =
       'Invalid configuration - Environment variable DELETED_ACCOUNT_RETENTION_SECONDS is not a number.';
     const appConfig = AppConfigService.getInstance();

--- a/src/services/test/send-sqs-message.test.ts
+++ b/src/services/test/send-sqs-message.test.ts
@@ -29,14 +29,14 @@ describe('sendSqsMessage', () => {
   });
 
   it('throws an error if AWS_REGION environment variable is not set', async () => {
-    delete process.env['AWS_REGION'];
+    vi.stubEnv('AWS_REGION', '');
     await expect(sendSqsMessage(messageBody, queueUrl)).rejects.toThrow('AWS_REGION environment variable not set');
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(vi.mocked(logger.error)).toHaveBeenCalledWith('AWS_REGION environment variable is not set');
   });
 
   it('sends a message successfully when AWS_REGION and parameters are set', async () => {
-    process.env['AWS_REGION'] = 'eu-west-2';
+    vi.stubEnv('AWS_REGION', 'eu-west-2');
 
     await sendSqsMessage(messageBody, queueUrl);
 
@@ -45,7 +45,7 @@ describe('sendSqsMessage', () => {
   });
 
   it('throws an error if sending the message fails', async () => {
-    process.env['AWS_REGION'] = 'eu-west-2';
+    vi.stubEnv('AWS_REGION', 'eu-west-2');
     sendFn.mockImplementation(() => {
       throw new Error('Failed to send message');
     });
@@ -67,14 +67,14 @@ describe('sendBatchSqsMessage', () => {
   });
 
   it('throws an error if AWS_REGION environment variable is not set', async () => {
-    delete process.env['AWS_REGION'];
+    vi.stubEnv('AWS_REGION', '');
     await expect(sendBatchSqsMessage(entries, queueUrl)).rejects.toThrow('AWS_REGION environment variable not set');
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(vi.mocked(logger.error)).toHaveBeenCalledWith('AWS_REGION environment variable is not set');
   });
 
   it('sends a message successfully when AWS_REGION and parameters are set', async () => {
-    process.env['AWS_REGION'] = 'eu-west-2';
+    vi.stubEnv('AWS_REGION', 'eu-west-2');
 
     await sendBatchSqsMessage(entries, queueUrl);
 
@@ -83,7 +83,7 @@ describe('sendBatchSqsMessage', () => {
   });
 
   it('throws an error if sending the message fails', async () => {
-    process.env['AWS_REGION'] = 'eu-west-2';
+    vi.stubEnv('AWS_REGION', 'eu-west-2');
     sendFn.mockImplementation(() => {
       throw new Error('Failed to send message');
     });


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Switch to using Vitest `stubEnv`

## Why

Removes requirement to reset environment variables after tests and reduces risks of one test influencing another.