### PR TITLE
FPAD-7757: Update StatusRetrieverThrottledOver10Mins runbook url

### DIFF
--- a/src/infra/alarm/template.yaml
+++ b/src/infra/alarm/template.yaml
@@ -1252,7 +1252,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref AlertingSNSHighAlertNotificationTopicARN
-      AlarmDescription: !Sub 'Status Retriever Function Lambda throttled over 10 minutes. ${RunBookURL}'
+      AlarmDescription: !Sub 'Status Retriever Function Lambda throttled over 10 minutes. ${TeamManualPlaybookUrl}'
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Threshold: 1
       EvaluationPeriods: 10


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What
- Update StatusRetrieverThrottledOver10Mins runbook url 

## Why
- The alarm should have the updated runbook url

## Notes

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-7757](https://govukverify.atlassian.net/browse/FPAD-7757)


[FPAD-7757]: https://govukverify.atlassian.net/browse/FPAD-7757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ