### PR TITLE
FPAD-7754: Update runbook url for TooManyDBQueryNoResponseError alarm

### DIFF
--- a/src/infra/alarm/template.yaml
+++ b/src/infra/alarm/template.yaml
@@ -918,7 +918,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref AlertingSNSHighAlertNotificationTopicARN
-      AlarmDescription: !Sub 'The query to DynamoDB has provided the no response error twice within a minute. ${RunBookURL}'
+      AlarmDescription: !Sub 'The query to DynamoDB has provided the no response error twice within a minute. ${TeamManualPlaybookUrl}'
       ComparisonOperator: GreaterThanOrEqualToThreshold
       DatapointsToAlarm: 1
       Threshold: 2


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What
Update the runbook url for TooManyDBQueryNoResponseError alarm to point to the new Team manual page

## Why
The alarm should have the up to date url for the runbook for TSD to be able to see the correct and up to date information

## Notes
None

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-7754](https://govukverify.atlassian.net/browse/FPAD-7754)


[FPAD-7754]: https://govukverify.atlassian.net/browse/FPAD-7754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ