### PR TITLE
FPAD-7829: Stryker config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     rev: v4.4.0
     hooks:
       - id: end-of-file-fixer
-        exclude: 'package.json|package-lock.json'
+        exclude: '\.json$'
       - id: trailing-whitespace
       - id: detect-private-key
       - id: detect-aws-credentials

--- a/.stryker/logger-ignorer.js
+++ b/.stryker/logger-ignorer.js
@@ -1,0 +1,28 @@
+/**
+  This Stryker plugin automatically ignores calls to log functions when mutation testing.
+  It's adapted from an example in the Stryker docs: https://stryker-mutator.io/docs/stryker-js/disable-mutants/#using-an-ignore-plugin
+*/
+
+import { PluginKind, declareValuePlugin } from '@stryker-mutator/api/plugin';
+
+const logFunctionLevels = new Set(['trace', 'debug', 'info', 'warn', 'error'])
+
+export const strykerPlugins = [
+  declareValuePlugin(PluginKind.Ignore, 'logger', {
+    shouldIgnore(path) {
+      // Define the conditions for which you want to ignore mutants
+      if (
+        path.isExpressionStatement() &&
+        path.node.expression.type === 'CallExpression' &&
+        path.node.expression.callee.type === 'MemberExpression' &&
+        path.node.expression.callee.object.type === 'Identifier' &&
+        path.node.expression.callee.object.name === 'logger' &&
+        path.node.expression.callee.property.type === 'Identifier' &&
+        logFunctionLevels.has(path.node.expression.callee.property.name)
+      ) {
+        // Return the ignore reason
+        return "We're not interested in testing log statements, see ADR 002.";
+      }
+    },
+  }),
+];

--- a/adr/002-dont-test-log-statements.md
+++ b/adr/002-dont-test-log-statements.md
@@ -1,0 +1,28 @@
+# Don't test the content of log lines
+
+## What
+
+We will not test the content of log lines in automated tests.
+Calls to logger functions will not be counted in coverage, and will not be mutated during mutation testing.
+The only exception is if the main purpose of the system under test (SUT) is logging.
+An example of this is a function which dynamically logs different data depending on the input.
+
+## Why
+
+Logging is a perfect candidate for testing in production.
+It's a non-functional part of the code for which we (team Neptune) are a first-class user.
+This means we should be closely involved in the use of logs, and able to address any issues with logging.
+
+Adding and changing log lines should be also be made as easy as possible to encourage engineers to rely on observability instead of other things (e.g. manually checking data in production cloud environments).
+
+This decision introduces no additional risk of logging PII because one can easily write a test for a log line which logs PII.
+
+## Consequences
+
+- Test coverage becomes easier to understand.
+- Tests are more focused on functional behaviour.
+- Log lines are untested so need to be checked with care at development-time and review-time, and in use.
+
+## Notes
+
+---

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@pact-foundation/pact": "^16.3.0",
         "@pact-foundation/pact-cli": "^16.1.6",
         "@stoplight/spectral-cli": "^6.15.0",
+        "@stryker-mutator/api": "^9.6.1",
         "@stryker-mutator/core": "^9.6.1",
         "@stryker-mutator/vitest-runner": "^9.6.1",
         "@types/aws-lambda": "^8.10.160",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@pact-foundation/pact": "^16.3.0",
     "@pact-foundation/pact-cli": "^16.1.6",
     "@stoplight/spectral-cli": "^6.15.0",
+    "@stryker-mutator/api": "^9.6.1",
     "@stryker-mutator/core": "^9.6.1",
     "@stryker-mutator/vitest-runner": "^9.6.1",
     "@types/aws-lambda": "^8.10.160",

--- a/src/data-types/errors.ts
+++ b/src/data-types/errors.ts
@@ -1,3 +1,4 @@
+// Stryker disable StringLiteral: Testing against the name of an exception class is just a change-detector test
 import { EventsEnum } from './constants';
 import { AccountStateEngineOutput } from './interfaces';
 

--- a/src/handlers/invoke-private-api.ts
+++ b/src/handlers/invoke-private-api.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore: not production */
+// Stryker disable all: Not used in production
 import getEnvOrThrow from '../commons/get-env-or-throw';
 import logger from '../commons/logger';
 

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -11,6 +11,13 @@
   "testRunner_comment": "Take a look at https://stryker-mutator.io/docs/stryker-js/vitest-runner for information about the vitest plugin.",
   "coverageAnalysis": "perTest",
   "ignorePatterns": [
-    "**/contract-testing/**"
+    "src/contract-testing/**"
+  ],
+  "ignorers": [
+    "logger"
+  ],
+  "plugins": [
+    "@stryker-mutator/*",
+    "./.stryker/logger-ignorer.js"
   ]
 }


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

This updates the Stryker mutation-testing config to exclude a few false-positives, mainly log lines. This branch also contains an ADR for not testing log lines.

## Why

We want to have a fairly clean set of results from Stryker before running it in CI, so we have a good baseline to move up from. See the text of the ADR itself for the reasoning about log lines (if this is contentious I'll move it to a separate PR).

## Notes

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-7829](https://govukverify.atlassian.net/browse/FPAD-7829)


[FPAD-7829]: https://govukverify.atlassian.net/browse/FPAD-7829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ