### PR TITLE
BAU: Update github actions to latest versions

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -26,12 +26,12 @@ jobs:
       packages: read
     steps:
       - name: Pull repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
           fetch-depth: '0'
 
       - name: Set up Node
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # pin@v6.3.0
         with:
           node-version-file: '.node-version'
           registry-url: 'https://npm.pkg.github.com/'

--- a/.github/workflows/ensure-sha-pinned-actions.yaml
+++ b/.github/workflows/ensure-sha-pinned-actions.yaml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # pin@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
       - name: Ensure SHA Pinned Actions
         uses: zgosalvez/github-actions-ensure-sha-pinned-actions@70c4af2ed5282c51ba40566d026d6647852ffa3e # pin@v5.0.1

--- a/.github/workflows/manual-publish-feature-tests-to-dev.yaml
+++ b/.github/workflows/manual-publish-feature-tests-to-dev.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # pin@v2.0.1
+        uses: aws-actions/amazon-ecr-login@376925c9d111252e87ae59691e5a442dd100ef6a # pin@v2.1.3
 
       - name: Build & Publish Docker Image as latest
         working-directory: feature-tests/

--- a/.github/workflows/merge-feature-tests-to-main.yaml
+++ b/.github/workflows/merge-feature-tests-to-main.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # pin@v2.0.1
+        uses: aws-actions/amazon-ecr-login@376925c9d111252e87ae59691e5a442dd100ef6a # pin@v2.1.3
 
       - name: Build & Publish Docker Image as latest
         working-directory: feature-tests/

--- a/.github/workflows/validate-alarm-sam-template.yaml
+++ b/.github/workflows/validate-alarm-sam-template.yaml
@@ -31,7 +31,7 @@ jobs:
       SAM_CLI_TELEMETRY: 0
     steps:
       - name: Checkout
-        uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # pin@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
           ref: ${{ inputs.gitRef || github.ref }}
       - name: SAM Validate

--- a/.github/workflows/validate-core-sam-template.yaml
+++ b/.github/workflows/validate-core-sam-template.yaml
@@ -31,7 +31,7 @@ jobs:
       SAM_CLI_TELEMETRY: 0
     steps:
       - name: Checkout
-        uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # pin@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
           ref: ${{ inputs.gitRef || github.ref }}
       - name: SAM Validate

--- a/.github/workflows/validate-main-sam-template.yaml
+++ b/.github/workflows/validate-main-sam-template.yaml
@@ -32,7 +32,7 @@ jobs:
       SAM_CLI_TELEMETRY: 0
     steps:
       - name: Checkout
-        uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # pin@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
           ref: ${{ inputs.gitRef || github.ref }}
       - name: SAM Validate


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Update to latest versions of some GitHub actions.

## Why

GitHub is complaining that we are using actions which use node version 20.