### PR TITLE
Fix codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-- @govuk-one-login/fraud-neptune-team @govuk-one-login/fraud-platform-team
-  /.github/CODEOWNERS @govuk-one-login/fraud-platform-leads
+* @govuk-one-login/fraud-neptune-team
+/.github/CODEOWNERS @govuk-one-login/fraud-platform-leads


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Fixes the codeowners file and removes `@govuk-one-login/fraud-platform-team` from it.

## Why

Codeowners isn't adding reviewers to pull requests automatically at the moment because it's broken. I've removed the platform team from the owners list because we're doing infrastructure work within the team.

## Notes

I used this reference for the new changes: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file