### PR TITLE
FPAD-7756: Update runbook url for InvalidSchema alarm

### DIFF
--- a/src/infra/alarm/template.yaml
+++ b/src/infra/alarm/template.yaml
@@ -1020,7 +1020,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref AlertingSNSHighAlertNotificationTopicARN
-      AlarmDescription: !Sub 'Schema is invalid. ${RunBookURL}'
+      AlarmDescription: !Sub 'Schema is invalid. ${TeamManualPlaybookUrl}'
       Namespace: !Ref SystemTagValue
       MetricName: INVALID_SCHEMA
       ComparisonOperator: GreaterThanOrEqualToThreshold


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What
Update the runbook url for the InvalidSchema alarm

## Why
The runbook url should be up to date when an alarm is triggered

## Notes
None

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-7756](https://govukverify.atlassian.net/browse/FPAD-7756)


[FPAD-7756]: https://govukverify.atlassian.net/browse/FPAD-7756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ