### PR TITLE
FPAD-7874: Remove handling of user_id at top level

### DIFF
--- a/feature-tests/utils/send-sqs-message.ts
+++ b/feature-tests/utils/send-sqs-message.ts
@@ -30,7 +30,7 @@ export async function sendSQSEvent(testUserId: string, aisEventType: keyof typeo
 export async function sendDeleteEvent(testUserId: string) {
   const body = {
     event_name: 'AUTH_DELETE_ACCOUNT',
-    user_id: testUserId,
+    user: { user_id: testUserId },
     txma: { configVersion: '1.0.4' },
   };
 

--- a/pacts/AccountInterventionsServiceConsumer-TxMAProvider.json
+++ b/pacts/AccountInterventionsServiceConsumer-TxMAProvider.json
@@ -210,7 +210,7 @@
       "description": "a valid intervention event",
       "matchingRules": {
         "body": {
-          "$.user_id": {
+          "$.user.user_id": {
             "combine": "AND",
             "matchers": [
               {

--- a/src/contract-testing/consumer/txma-ais-consumer.pact.test.ts
+++ b/src/contract-testing/consumer/txma-ais-consumer.pact.test.ts
@@ -71,7 +71,7 @@ describe('TxMA & AIS - Contract Testing - Consumer', () => {
         .given('AIS is healthy')
         .expectsToReceive('a valid intervention event')
         .withContent({
-          user_id: string('urn:fdc:gov.uk:2022:USER_ONE'),
+          user: { user_id: string('urn:fdc:gov.uk:2022:USER_ONE') },
         })
         .verify(synchronousBodyHandler(deleteAccountEventValidator)));
   });
@@ -83,7 +83,7 @@ function interventionMessageValidator(event: AnyJson | Buffer) {
 }
 
 function deleteAccountEventValidator(event: AnyJson | Buffer) {
-  const userId = (event as unknown as { user_id?: string }).user_id;
+  const userId = (event as unknown as { user?: { user_id?: string } }).user?.user_id;
   if (!userId || typeof userId !== 'string' || userId.trim() === '') {
     throw new Error('Invalid Message');
   }

--- a/src/data-types/interfaces.ts
+++ b/src/data-types/interfaces.ts
@@ -61,13 +61,7 @@ export type TxMAEgressEvent =
   | AIS_EVENT_TRANSITION_APPLIED
   | AIS_EVENT_TRANSITION_IGNORED
   | AIS_EVENT_IGNORED_STALE
-  | AUTH_DELETE_ACCOUNT
-  | TxMAEgressDeletionEvent; // Custom type with user_id at top level;
-
-export interface TxMAEgressDeletionEvent {
-  event_name: 'AUTH_DELETE_ACCOUNT';
-  user_id: string;
-}
+  | AUTH_DELETE_ACCOUNT;
 
 export interface TxMAIngressEvent {
   event_name: TriggerEventsEnum;

--- a/src/handlers/account-deletion-processor-handler.ts
+++ b/src/handlers/account-deletion-processor-handler.ts
@@ -61,11 +61,11 @@ export async function handler(event: SQSEvent, context: Context): Promise<void> 
  * @returns - User ID or undefined
  */
 function parseMessage(record: SQSRecord): string | undefined {
-  // Parse record.body
+  // JSON parse record.body
   const recordBodyResult = jsonSafeParse(record.body);
   if (!recordBodyResult.success) throw new ParserError(ParserErrorType.BODY_JSON_PARSER_ERROR);
 
-  // Check if unwrapped
+  // Validate against zod schema
   const result = accountDeleteMessageSchema.safeParse(recordBodyResult.data);
   if (!result.success)
     throw new ParserError(

--- a/src/handlers/tests/txma-handler.test.ts
+++ b/src/handlers/tests/txma-handler.test.ts
@@ -77,7 +77,7 @@ describe('TxMA Handler', () => {
   it('Sends an SQS message to the delete queue', async () => {
     const deleteEvent = {
       event_name: 'AUTH_DELETE_ACCOUNT',
-      user_id: 'urn:fdc:gov.uk:2022:USER_ONE',
+      user: { user_id: 'urn:fdc:gov.uk:2022:USER_ONE' },
       txma: { configVersion: '1.0.4' },
     };
     mockRecord = createMockRecord(deleteEvent);
@@ -156,21 +156,6 @@ describe('getUserId', () => {
         },
       }),
     ).toBe('1234');
-  });
-
-  it('top level', () => {
-    expect(
-      getUserId({
-        event_name: 'AUTH_DELETE_ACCOUNT',
-        user_id: '1234',
-      }),
-    ).toBe('1234');
-
-    expect(mockAddMetric).toHaveBeenCalledTimes(1);
-    expect(mockAddMetric).toHaveBeenCalledWith(MetricNames.DELETE_EVENT_USER_ID_ISSUE, 'Count', 1);
-    expect(mockAddDimensions).toHaveBeenCalledTimes(1);
-    expect(mockAddDimensions).toHaveBeenCalledWith({ ISSUE: 'USER_ID_ON_TOP_LEVEL' });
-    expect(mockPublishStoredMetric).toHaveBeenCalledTimes(1);
   });
 
   it('missing', () => {

--- a/src/handlers/txma-handler.ts
+++ b/src/handlers/txma-handler.ts
@@ -63,15 +63,7 @@ export async function handler(event: SQSEvent, context: Context): Promise<void> 
 }
 
 export function getUserId(event: TxMAEgressEvent): string | undefined {
-  if ('user' in event) return event.user.user_id;
-
-  if ('user_id' in event) {
-    addMetric(MetricNames.DELETE_EVENT_USER_ID_ISSUE, undefined, undefined, {
-      ISSUE: 'USER_ID_ON_TOP_LEVEL',
-    });
-
-    return event.user_id;
-  }
+  if (event.user) return event.user.user_id;
 
   addMetric(MetricNames.DELETE_EVENT_USER_ID_ISSUE, undefined, undefined, {
     ISSUE: 'NO_USER_ID',


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Remove handling of user_id at top level in the txma-handler

## Why

No longer required after we switched the txma self serve to supply user_id nested under user

## Notes

I have confirmed in AWS that the `DELETE_EVENT_USER_ID_ISSUE` metric is no longer being raised.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-7874](https://govukverify.atlassian.net/browse/FPAD-7874)

[FPAD-7874]: https://govukverify.atlassian.net/browse/FPAD-7874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ