### PR TITLE
FPAD-7887: Increase txma-handler memory

### DIFF
--- a/src/infra/main/template.yaml
+++ b/src/infra/main/template.yaml
@@ -419,7 +419,7 @@ Resources:
         Role: !GetAtt CodeDeployServiceRole.Arn
       Timeout: 5
       Handler: txma-handler.handler
-      MemorySize: 128
+      MemorySize: 256
       Role: !GetAtt TxmaEventHandlerFunctionRole.Arn
       CodeSigningConfigArn: !If [UseCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
       Environment:


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Double txma-handler memory to `256Mb`

## Why

The Max Memory Used is typically close to 100% and this may be the cause of the txma-handler taking substantially longer than the intervention-processor.

## Notes

We should evaluate whether this change has made an improvement by checking the response time and memory usage in AWS after this change is merged.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-7887](https://govukverify.atlassian.net/browse/FPAD-7887)


[FPAD-7887]: https://govukverify.atlassian.net/browse/FPAD-7887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ