### PR TITLE
FPAD-7910: Add handling for AUTH_DELETE_ACCOUNT

### DIFF
--- a/src/contracts/account-delete-message.ts
+++ b/src/contracts/account-delete-message.ts
@@ -1,8 +1,14 @@
 import { z } from 'zod';
 
-export const accountDeleteMessageSchema = z.object({
-  event_name: z.literal('AUTH_DELETE_ACCOUNT'),
-  user_id: z.string().optional(),
-});
+export const accountDeleteMessageSchema = z.union([
+  z.object({
+    event_name: z.literal('AUTH_DELETE_ACCOUNT'),
+    user: z.object({ user_id: z.string().optional() }),
+  }),
+  z.object({
+    event_name: z.literal('AUTH_DELETE_ACCOUNT'),
+    user_id: z.string().optional(),
+  }),
+]);
 
 export type AccountDeleteMessage = z.infer<typeof accountDeleteMessageSchema>;

--- a/src/handlers/account-deletion-processor-handler.ts
+++ b/src/handlers/account-deletion-processor-handler.ts
@@ -73,7 +73,7 @@ function parseMessage(record: SQSRecord): string | undefined {
       `The SQS message can not be parsed. ${prettifyError(result.error)}`,
     );
 
-  return result.data.user_id;
+  return 'user' in result.data ? result.data.user.user_id : result.data.user_id;
 }
 
 /**

--- a/src/handlers/tests/account-deletion-processor-handler.test.ts
+++ b/src/handlers/tests/account-deletion-processor-handler.test.ts
@@ -110,9 +110,7 @@ describe('Account Deletion Processor', () => {
     mockRecord = { ...mockRecord, body: mockBody };
     mockEvent = { Records: [mockRecord] };
     await handler(mockEvent, mockContext);
-    expect(loggerErrorSpy).toHaveBeenCalledWith(
-      'The SQS message can not be parsed. ✖ Invalid input: expected "AUTH_DELETE_ACCOUNT"\n  → at event_name',
-    );
+    expect(loggerErrorSpy).toHaveBeenCalledWith('The SQS message can not be parsed. ✖ Invalid input');
   });
 
   it("does not process the SQS Record when the message doesn't contain user id", async () => {
@@ -144,9 +142,7 @@ describe('Account Deletion Processor', () => {
     mockRecord = { ...mockRecord, body: mockBody };
     mockEvent = { Records: [mockRecord] };
     await handler(mockEvent, mockContext);
-    expect(loggerErrorSpy).toHaveBeenCalledWith(
-      `The SQS message can not be parsed. ✖ Invalid input: expected string, received number\n  → at user_id`,
-    );
+    expect(loggerErrorSpy).toHaveBeenCalledWith(`The SQS message can not be parsed. ✖ Invalid input`);
   });
 
   it('successfully processes the message when the user id passed contains trailing spaces', async () => {
@@ -178,6 +174,21 @@ describe('Account Deletion Processor', () => {
   });
 
   it('successfully process the message when it contains a single record', async () => {
+    mockDynamoDBServiceUpdateDeleteStatus.mockResolvedValue('');
+    await handler(mockEvent, mockContext);
+    expect(mockPublishStoredMetric).toHaveBeenCalledTimes(1);
+    expect(mockDynamoDBServiceUpdateDeleteStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('successfully process the message when it contains a single record, wrapped user', async () => {
+    mockRecord = {
+      ...mockRecord,
+      body: JSON.stringify({
+        event_name: 'AUTH_DELETE_ACCOUNT',
+        user: { user_id: 'other_user_id' },
+      }),
+    };
+    const mockEvent = { Records: [mockRecord] };
     mockDynamoDBServiceUpdateDeleteStatus.mockResolvedValue('');
     await handler(mockEvent, mockContext);
     expect(mockPublishStoredMetric).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Add handling for AUTH_DELETE_ACCOUNT to the Account Deletion Processor

## Why

The wrapped user_id and name matches the AUTH_DELETE_ACCOUNT event.  As `zod` is permissive this will pass for the full event.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-7910](https://govukverify.atlassian.net/browse/FPAD-7910)


[FPAD-7910]: https://govukverify.atlassian.net/browse/FPAD-7910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ