### PR TITLE
FPAD-7873: Manual fixes to event catalogue schemas

### DIFF
--- a/src/commons/compile-schema.ts
+++ b/src/commons/compile-schema.ts
@@ -13,10 +13,35 @@ import {
 const ajv = new Ajv({ allErrors: true });
 const ajv2019 = new Ajv2019({ allErrors: true });
 
-ajv2019.addSchema(TICF_ACCOUNT_INTERVENTIONSchema);
-ajv2019.addSchema(AUTH_PASSWORD_RESET_SUCCESSFULSchema);
-ajv2019.addSchema(AUTH_PASSWORD_RESET_SUCCESSFUL_FOR_TEST_CLIENTSchema);
-ajv2019.addSchema(IPV_ACCOUNT_INTERVENTION_ENDSchema);
+interface Schema {
+  properties: Record<string, unknown>;
+  required: string[];
+}
+
+const addEventMetadataToSchema = (schema: Schema, eventName: string) => ({
+  ...schema,
+  required: [...schema.required, 'event_id'],
+  properties: {
+    ...schema.properties,
+    event_name: {
+      type: 'string',
+      const: eventName,
+    },
+    event_id: {
+      type: 'string',
+    },
+  },
+});
+
+ajv2019.addSchema(addEventMetadataToSchema(TICF_ACCOUNT_INTERVENTIONSchema, 'TICF_ACCOUNT_INTERVENTION'));
+ajv2019.addSchema(addEventMetadataToSchema(AUTH_PASSWORD_RESET_SUCCESSFULSchema, 'AUTH_PASSWORD_RESET_SUCCESSFUL'));
+ajv2019.addSchema(
+  addEventMetadataToSchema(
+    AUTH_PASSWORD_RESET_SUCCESSFUL_FOR_TEST_CLIENTSchema,
+    'AUTH_PASSWORD_RESET_SUCCESSFUL_FOR_TEST_CLIENT',
+  ),
+);
+ajv2019.addSchema(addEventMetadataToSchema(IPV_ACCOUNT_INTERVENTION_ENDSchema, 'IPV_ACCOUNT_INTERVENTION_END'));
 
 /**
  * Helper function to verify if the schema is valid

--- a/src/data-types/event-catalogue-combined-schema.ts
+++ b/src/data-types/event-catalogue-combined-schema.ts
@@ -7,28 +7,17 @@ import {
 
 export const EventCatalogueCombinedSchema = {
   $schema: 'https://json-schema.org/draft/2019-09/schema',
-  required: ['event_name'],
   type: 'object',
-  allOf: [
+  oneOf: [
+    { $ref: TICF_ACCOUNT_INTERVENTIONSchema.$id },
     {
-      if: { properties: { event_name: { const: 'TICF_ACCOUNT_INTERVENTION' } } },
-      // eslint-disable-next-line unicorn/no-thenable
-      then: { $ref: TICF_ACCOUNT_INTERVENTIONSchema.$id },
+      $ref: AUTH_PASSWORD_RESET_SUCCESSFULSchema.$id,
     },
     {
-      if: { properties: { event_name: { const: 'AUTH_PASSWORD_RESET_SUCCESSFUL' } } },
-      // eslint-disable-next-line unicorn/no-thenable
-      then: { $ref: AUTH_PASSWORD_RESET_SUCCESSFULSchema.$id },
+      $ref: AUTH_PASSWORD_RESET_SUCCESSFUL_FOR_TEST_CLIENTSchema.$id,
     },
     {
-      if: { properties: { event_name: { const: 'AUTH_PASSWORD_RESET_SUCCESSFUL_FOR_TEST_CLIENT' } } },
-      // eslint-disable-next-line unicorn/no-thenable
-      then: { $ref: AUTH_PASSWORD_RESET_SUCCESSFUL_FOR_TEST_CLIENTSchema.$id },
-    },
-    {
-      if: { properties: { event_name: { const: 'IPV_ACCOUNT_INTERVENTION_END' } } },
-      // eslint-disable-next-line unicorn/no-thenable
-      then: { $ref: IPV_ACCOUNT_INTERVENTION_ENDSchema.$id },
+      $ref: IPV_ACCOUNT_INTERVENTION_ENDSchema.$id,
     },
   ],
 };

--- a/src/services/test/validate-event.test.ts
+++ b/src/services/test/validate-event.test.ts
@@ -14,6 +14,7 @@ import { AISInterventionTypes, EventsEnum, MetricNames, TriggerEventsEnum } from
 import { sendAuditEvent } from '../send-audit-events';
 import { getCurrentTimestamp } from '../../commons/get-current-timestamp';
 import { InterventionCodeEnum1 } from '@govuk-one-login/event-catalogue/AIS_EVENT_TRANSITION_APPLIED';
+import { TICF_ACCOUNT_INTERVENTION } from '@govuk-one-login/event-catalogue/TICF_ACCOUNT_INTERVENTION';
 
 vi.mock('../../commons/metrics');
 vi.mock('@aws-lambda-powertools/logger');
@@ -39,12 +40,13 @@ const dynamoDBResult: DynamoDBStateResult = {
   history: [],
   intervention: AISInterventionTypes.AIS_ACCOUNT_UNSUSPENDED,
 };
-describe('event-validation', () => {
+
+describe('validateEventAgainstSchema', () => {
   afterEach(() => {
     vi.clearAllMocks();
   });
 
-  it('should not return anything as event is valid', () => {
+  it('Successfully validate AUTH_PASSWORD_RESET_SUCCESSFUL event', () => {
     const TxMAEvent: TxMAEvent = {
       event_timestamp_ms: timestamp.milliseconds - 5000,
       component_id: 'AUTH',
@@ -54,6 +56,25 @@ describe('event-validation', () => {
       },
       event_name: TriggerEventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL,
       event_id: '123',
+    };
+    expect(() => {
+      validateEventAgainstSchema(TxMAEvent);
+    }).not.toThrow();
+    expect(addMetric).not.toHaveBeenCalledWith('INVALID_EVENT_RECEIVED_EVENT_CATALOGUE', undefined, undefined, {
+      EVENT_NAME: 'AUTH_PASSWORD_RESET_SUCCESSFUL',
+    });
+  });
+
+  it('Successfully validate TICF_ACCOUNT_INTERVENTION event', () => {
+    const TxMAEvent: TICF_ACCOUNT_INTERVENTION & { event_id: string } = {
+      event_timestamp_ms: timestamp.milliseconds - 5000,
+      component_id: 'AUTH',
+      timestamp: timestamp.seconds - 5,
+      user: {
+        user_id: 'abc',
+      },
+      event_name: TriggerEventsEnum.TICF_ACCOUNT_INTERVENTION,
+      event_id: '123',
       extensions: {
         intervention: {
           intervention_code: '01',
@@ -62,11 +83,30 @@ describe('event-validation', () => {
       },
     };
     expect(() => {
-      validateEventAgainstSchema(TxMAEvent);
+      validateEventAgainstSchema(TxMAEvent as TxMAEvent);
     }).not.toThrow();
+    expect(addMetric).not.toHaveBeenCalledWith('INVALID_EVENT_RECEIVED_EVENT_CATALOGUE', undefined, undefined, {
+      EVENT_NAME: 'TICF_ACCOUNT_INTERVENTION',
+    });
+  });
+
+  it('Send metric for event that fails event catalogue validation', () => {
+    const TxMAEvent = {
+      event_timestamp_ms: timestamp.milliseconds - 5000,
+      component_id: 'AUTH',
+      timestamp: timestamp.seconds - 5,
+      user: {
+        user_id: 'abc',
+      },
+      event_name: TriggerEventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL,
+      // event_id: '123',
+    };
     expect(() => {
-      validateInterventionEvent(TxMAEvent);
+      validateEventAgainstSchema(TxMAEvent as TxMAEvent);
     }).not.toThrow();
+    expect(addMetric).toHaveBeenCalledWith('INVALID_EVENT_RECEIVED_EVENT_CATALOGUE', undefined, undefined, {
+      EVENT_NAME: 'AUTH_PASSWORD_RESET_SUCCESSFUL',
+    });
   });
 
   it('should return an error as intervention is invalid', () => {
@@ -135,32 +175,6 @@ describe('event-validation', () => {
     expect(logger.debug).toHaveBeenCalledWith('Sensitive info - Event has failed schema validation.', {
       validationErrors: expect.anything() as unknown,
     });
-    expect(addMetric).toHaveBeenCalledWith('INVALID_EVENT_RECEIVED');
-  });
-
-  it('should return an error as intervention code is NAN', () => {
-    const TxMAEvent: TxMAEvent = {
-      event_timestamp_ms: timestamp.milliseconds - 5000,
-      component_id: 'AUTH',
-      timestamp: timestamp.seconds - 5,
-      user: {
-        user_id: 'abc',
-      },
-      event_name: TriggerEventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL,
-      event_id: '123',
-      extensions: {
-        intervention: {
-          intervention_code: 'nan' as InterventionCodeEnum1,
-          intervention_reason: 'reason',
-        },
-      },
-    };
-    validateEventAgainstSchema(TxMAEvent);
-    expect(() => {
-      validateInterventionEvent(TxMAEvent);
-    }).toThrow(new ValidationError('Invalid intervention event.'));
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(logger.debug).toHaveBeenCalledWith('Invalid intervention request. Intervention code is NAN');
     expect(addMetric).toHaveBeenCalledWith('INVALID_EVENT_RECEIVED');
   });
 
@@ -400,6 +414,55 @@ describe('event-validation', () => {
       validateIfIdentityAcquired(EventsEnum.IPV_ACCOUNT_INTERVENTION_END, idResetEventLowConfidence);
     }).toThrow(new ValidationError('Received event that does not meet criteria to lift intervention.'));
     expect(addMetric).toHaveBeenCalledWith(MetricNames.IDENTITY_NOT_SUFFICIENTLY_PROVED);
+  });
+});
+
+describe('validateInterventionEvent', () => {
+  it('Successfully validate TICF_ACCOUNT_INTERVENTION event', () => {
+    const TxMAEvent: TICF_ACCOUNT_INTERVENTION & { event_id: string } = {
+      event_timestamp_ms: timestamp.milliseconds - 5000,
+      component_id: 'AUTH',
+      timestamp: timestamp.seconds - 5,
+      user: {
+        user_id: 'abc',
+      },
+      event_name: TriggerEventsEnum.TICF_ACCOUNT_INTERVENTION,
+      event_id: '123',
+      extensions: {
+        intervention: {
+          intervention_code: '01',
+          intervention_reason: 'reason',
+        },
+      },
+    };
+    expect(() => {
+      validateInterventionEvent(TxMAEvent as TxMAEvent);
+    }).not.toThrow();
+  });
+
+  it('should return an error as intervention code is NAN', () => {
+    const TxMAEvent: TxMAEvent = {
+      event_timestamp_ms: timestamp.milliseconds - 5000,
+      component_id: 'AUTH',
+      timestamp: timestamp.seconds - 5,
+      user: {
+        user_id: 'abc',
+      },
+      event_name: TriggerEventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL,
+      event_id: '123',
+      extensions: {
+        intervention: {
+          intervention_code: 'nan' as InterventionCodeEnum1,
+          intervention_reason: 'reason',
+        },
+      },
+    };
+    expect(() => {
+      validateInterventionEvent(TxMAEvent);
+    }).toThrow(new ValidationError('Invalid intervention event.'));
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(logger.debug).toHaveBeenCalledWith('Invalid intervention request. Intervention code is NAN');
+    expect(addMetric).toHaveBeenCalledWith('INVALID_EVENT_RECEIVED');
   });
 });
 


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Update compile-schema to manually edit the schemas to apply missing features.

## Why

This way we can simplify our schema validator to use `oneOf`.
This fix should mean that all our events pass this validation and we can then remove the hand-rolled version.
We can then type our events automatically from the JSON schema.

## Notes

Ideally this would be tested in `dev` or similar to see that it actually works.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-7873](https://govukverify.atlassian.net/browse/FPAD-7873)


[FPAD-7873]: https://govukverify.atlassian.net/browse/FPAD-7873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ