### PR TITLE
BAU: Upgrade sonarqube action version

### DIFF
--- a/.github/workflows/acceptance-checks.yaml
+++ b/.github/workflows/acceptance-checks.yaml
@@ -77,7 +77,7 @@ jobs:
         run: npm run test:unit
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # pin@v7.0.0
+        uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432 # pin@v8.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Upgrade sonarqube action version

## Why

The new version uses node24

## Notes

node20 is out of support and GitHub are going to start forcing actions to node24