### PR TITLE
FPAD-7860: Update runbook urls for alarms

### DIFF
--- a/src/infra/alarm/template.yaml
+++ b/src/infra/alarm/template.yaml
@@ -959,7 +959,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref AlertingSNSHighAlertNotificationTopicARN
-      AlarmDescription: !Sub 'DynamoDB query too many items error once within a minute. ${RunBookURL}'
+      AlarmDescription: !Sub 'DynamoDB query too many items error once within a minute. ${TeamManualPlaybookUrl}'
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Threshold: 1
       EvaluationPeriods: 1
@@ -1148,7 +1148,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref AlertingSNSHighAlertNotificationTopicARN
-      AlarmDescription: !Sub 'Status Retriever Function Lambda errors over 10 minutes. ${RunBookURL}'
+      AlarmDescription: !Sub 'Status Retriever Function Lambda errors over 10 minutes. ${TeamManualPlaybookUrl}'
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Threshold: 1
       EvaluationPeriods: 10


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What
Update the runbook urls to the new team manual runbook
(this includes a url I forgot to update on a previous ticket)

## Why
When triggered, alarms will link to the correct runbook

## Notes

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-7860](https://govukverify.atlassian.net/browse/FPAD-FPAD-7860)


[FPAD-7860]: https://govukverify.atlassian.net/browse/FPAD-7860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ