### PR TITLE
FPAD-7872: Change notification topic and remove runbook url for less useful alarms

### DIFF
--- a/src/infra/alarm/template.yaml
+++ b/src/infra/alarm/template.yaml
@@ -959,7 +959,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref AlertingSNSLowAlertNotificationTopicARN
-      AlarmDescription: !Sub DynamoDB query too many items error once within a minute.
+      AlarmDescription: DynamoDB query too many items error once within a minute.
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Threshold: 1
       EvaluationPeriods: 1
@@ -1020,7 +1020,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref AlertingSNSLowAlertNotificationTopicARN
-      AlarmDescription: !Sub Schema is invalid.
+      AlarmDescription: Schema is invalid.
       Namespace: !Ref SystemTagValue
       MetricName: INVALID_SCHEMA
       ComparisonOperator: GreaterThanOrEqualToThreshold

--- a/src/infra/alarm/template.yaml
+++ b/src/infra/alarm/template.yaml
@@ -958,8 +958,8 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Ref AlertingSNSHighAlertNotificationTopicARN
-      AlarmDescription: !Sub 'DynamoDB query too many items error once within a minute. ${TeamManualPlaybookUrl}'
+        - !Ref AlertingSNSLowAlertNotificationTopicARN
+      AlarmDescription: !Sub DynamoDB query too many items error once within a minute.
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Threshold: 1
       EvaluationPeriods: 1
@@ -1019,8 +1019,8 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Ref AlertingSNSHighAlertNotificationTopicARN
-      AlarmDescription: !Sub 'Schema is invalid. ${TeamManualPlaybookUrl}'
+        - !Ref AlertingSNSLowAlertNotificationTopicARN
+      AlarmDescription: !Sub Schema is invalid.
       Namespace: !Ref SystemTagValue
       MetricName: INVALID_SCHEMA
       ComparisonOperator: GreaterThanOrEqualToThreshold


### PR DESCRIPTION

<!-- https://jml.io/posts/what-why-notes/ -->

## What
Downgrade less useful alarms by changing the notification topic they are sent to and removing the runbook url from their description

## Why
Any alarms that page TSD should have useful steps for TSD to follow, if they cannot remediate the alarm then they should not be notified

## Notes

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-7827](https://govukverify.atlassian.net/browse/FPAD-7872)


[FPAD-7827]: https://govukverify.atlassian.net/browse/FPAD-7827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ