### PR TITLE
FPAD-7858: Update `ApiHttp5xxCriticalErrors` runbook link

### DIFF
--- a/src/infra/alarm/template.yaml
+++ b/src/infra/alarm/template.yaml
@@ -1375,7 +1375,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref AlertingSNSHighAlertNotificationTopicARN
-      AlarmDescription: !Sub 'Significant proportion of 5XX errors on the API Gateway. ${RunBookURL}'
+      AlarmDescription: !Sub 'Significant proportion of 5XX errors on the API Gateway. ${TeamManualPlaybookUrl}'
       Threshold: 80
       EvaluationPeriods: 5
       DatapointsToAlarm: 2


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Updates the `ApiHttp5xxCriticalErrors` runbook link to the new team-manual page

## Why

So everyone who needs to (support rota, TSD, etc) has access to the runbook.

## Notes

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-7858](https://govukverify.atlassian.net/browse/FPAD-7858)


[FPAD-7858]: https://govukverify.atlassian.net/browse/FPAD-7858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ