### PR TITLE
FPAD-7911: Update TxMA handler to send valid AUTH_DELETE_ACCOUNT events

### DIFF
--- a/src/handlers/tests/txma-handler.test.ts
+++ b/src/handlers/tests/txma-handler.test.ts
@@ -90,7 +90,7 @@ describe('TxMA Handler', () => {
       [
         {
           Id: '0',
-          MessageBody: '{"event_name":"AUTH_DELETE_ACCOUNT","user_id":"urn:fdc:gov.uk:2022:USER_ONE"}',
+          MessageBody: '{"event_name":"AUTH_DELETE_ACCOUNT","user":{"user_id":"urn:fdc:gov.uk:2022:USER_ONE"}}',
         },
       ],
       'delete_queue',

--- a/src/handlers/txma-handler.ts
+++ b/src/handlers/txma-handler.ts
@@ -37,7 +37,7 @@ export async function handler(event: SQSEvent, context: Context): Promise<void> 
 
       const deletionEvent: AccountDeleteMessage = {
         event_name: 'AUTH_DELETE_ACCOUNT',
-        user_id: getUserId(body),
+        user: { user_id: getUserId(body) },
       };
       deletionMessages.push({
         Id: String(id),


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Update the TxMA handler to send the valid AUTH_DELETE_ACCOUNT events to the deletion processor

## Why
We want what we send from the TxMA handler to the deletion processor to match the AUTH_DELETE_ACCOUNT event in the event catalogue

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-7911](https://govukverify.atlassian.net/browse/FPAD-7911)


[FPAD-7911]: https://govukverify.atlassian.net/browse/FPAD-7911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ