### PR TITLE
FPAD-8033: txma handler to send complete events

### DIFF
--- a/src/handlers/tests/account-deletion-processor-handler.test.ts
+++ b/src/handlers/tests/account-deletion-processor-handler.test.ts
@@ -197,6 +197,44 @@ describe('Account Deletion Processor', () => {
     expect(mockDynamoDBServiceUpdateDeleteStatus).toHaveBeenCalledTimes(1);
   });
 
+  it('successfully process the message when it contains a single txma message', async () => {
+    mockRecord = {
+      ...mockRecord,
+      body: JSON.stringify({
+        client_id: 'client_id',
+        event_name: 'AUTH_DELETE_ACCOUNT',
+        component_id: 'AUTH',
+        // eslint-disable-next-line unicorn/numeric-separators-style
+        event_timestamp_ms: 1722953808667,
+        extensions: {
+          account_deletion_reason: 'USER_INITIATED',
+          phone_number_country_code: '44',
+        },
+        restricted: {
+          device_information: {
+            encoded: 'encoded_data',
+          },
+        },
+        // eslint-disable-next-line unicorn/numeric-separators-style
+        timestamp: 1722953808,
+        user: {
+          user_id: 'other_user_id',
+          email: 'email',
+          govuk_signin_journey_id: 'govuk_signin_journey_id',
+          ip_address: '0.0.0.0',
+          persistent_session_id: 'persistent_session_id',
+          phone: 'phone',
+          session_id: 'session_id',
+        },
+      }),
+    };
+    const mockEvent = { Records: [mockRecord] };
+    mockDynamoDBServiceUpdateDeleteStatus.mockResolvedValue('');
+    await handler(mockEvent, mockContext);
+    expect(mockPublishStoredMetric).toHaveBeenCalledTimes(1);
+    expect(mockDynamoDBServiceUpdateDeleteStatus).toHaveBeenCalledTimes(1);
+  });
+
   it('successfully process the message when it contains multiple records', async () => {
     mockDynamoDBServiceUpdateDeleteStatus.mockResolvedValue('');
     const mockRecord2 = {

--- a/src/handlers/tests/txma-handler.test.ts
+++ b/src/handlers/tests/txma-handler.test.ts
@@ -1,20 +1,12 @@
 import { Mock } from 'vitest';
 import { SQSEvent, SQSRecord } from 'aws-lambda';
-import { getUserId, handler } from '../txma-handler';
+import { handler } from '../txma-handler';
 import { sendBatchSqsMessage } from '../../services/send-sqs-message';
-import { TxMAEgressEvent } from '../../data-types/interfaces';
 import { Metrics } from '@aws-lambda-powertools/metrics';
-import { MetricNames } from '../../data-types/constants';
 
 vi.mock('../../services/send-sqs-message');
 vi.mock('@aws-lambda-powertools/metrics');
 
-// eslint-disable-next-line @typescript-eslint/unbound-method
-const mockPublishStoredMetric = Metrics.prototype.publishStoredMetrics as Mock;
-// eslint-disable-next-line @typescript-eslint/unbound-method
-const mockAddMetric = Metrics.prototype.addMetric as Mock;
-// eslint-disable-next-line @typescript-eslint/unbound-method
-const mockAddDimensions = Metrics.prototype.addDimensions as Mock;
 // eslint-disable-next-line @typescript-eslint/unbound-method
 const mockSerializeMetrics = Metrics.prototype.serializeMetrics as Mock;
 
@@ -90,7 +82,8 @@ describe('TxMA Handler', () => {
       [
         {
           Id: '0',
-          MessageBody: '{"event_name":"AUTH_DELETE_ACCOUNT","user":{"user_id":"urn:fdc:gov.uk:2022:USER_ONE"}}',
+          MessageBody:
+            '{"event_name":"AUTH_DELETE_ACCOUNT","user":{"user_id":"urn:fdc:gov.uk:2022:USER_ONE"},"txma":{"configVersion":"1.0.4"}}',
         },
       ],
       'delete_queue',
@@ -138,39 +131,5 @@ describe('TxMA Handler', () => {
       expect((error as Error).message).toEqual('ACCOUNT_INTERVENTION_SQS_QUEUE env variable is not set');
     }
     expect(mockSendBatchSqsMessage).not.toHaveBeenCalled();
-  });
-});
-
-describe('getUserId', () => {
-  const baseEvent = {
-    event_name: 'AUTH_DELETE_ACCOUNT',
-    component_id: 'ANY',
-    timestamp: 1234,
-    event_timestamp_ms: 1234,
-  };
-
-  it('correct', () => {
-    expect(
-      getUserId({
-        ...baseEvent,
-        user: {
-          user_id: '1234',
-        },
-      }),
-    ).toBe('1234');
-  });
-
-  it('missing', () => {
-    expect(
-      getUserId({
-        event_name: 'AUTH_DELETE_ACCOUNT',
-      } as TxMAEgressEvent),
-    ).toBe(undefined);
-
-    expect(mockAddMetric).toHaveBeenCalledTimes(1);
-    expect(mockAddMetric).toHaveBeenCalledWith(MetricNames.DELETE_EVENT_USER_ID_ISSUE, 'Count', 1);
-    expect(mockAddDimensions).toHaveBeenCalledTimes(1);
-    expect(mockAddDimensions).toHaveBeenCalledWith({ ISSUE: 'NO_USER_ID' });
-    expect(mockPublishStoredMetric).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/handlers/txma-handler.ts
+++ b/src/handlers/txma-handler.ts
@@ -4,7 +4,6 @@ import { TxMAEgressEvent } from '../data-types/interfaces';
 import { createSqsClient, sendBatchSqsMessage } from '../services/send-sqs-message';
 import { addMetric, metric } from '../commons/metrics';
 import { MetricNames } from '../data-types/constants';
-import { AccountDeleteMessage } from '../contracts/account-delete-message';
 
 export async function handler(event: SQSEvent, context: Context): Promise<void> {
   logger.addContext(context);
@@ -34,14 +33,9 @@ export async function handler(event: SQSEvent, context: Context): Promise<void> 
 
     if (body.event_name === 'AUTH_DELETE_ACCOUNT') {
       addMetric(MetricNames.RECIEVED_TXMA_ACCOUNT_DELETE);
-
-      const deletionEvent: AccountDeleteMessage = {
-        event_name: 'AUTH_DELETE_ACCOUNT',
-        user: { user_id: getUserId(body) },
-      };
       deletionMessages.push({
         Id: String(id),
-        MessageBody: JSON.stringify(deletionEvent),
+        MessageBody: record.body,
       });
     } else {
       addMetric(MetricNames.RECIEVED_TXMA_ACCOUNT_INTERVENTION);
@@ -64,14 +58,4 @@ export async function handler(event: SQSEvent, context: Context): Promise<void> 
   await Promise.all(promiseList);
 
   metric.publishStoredMetrics();
-}
-
-export function getUserId(event: TxMAEgressEvent): string | undefined {
-  if (event.user) return event.user.user_id;
-
-  addMetric(MetricNames.DELETE_EVENT_USER_ID_ISSUE, undefined, undefined, {
-    ISSUE: 'NO_USER_ID',
-  });
-
-  return undefined;
 }


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Update txma handler to send complete AUTH_DELETE_ACCOUNT events.

## Why

This is simpler, so should save us processing time.

There is currently full validation in the account deletion processor.

This would allow us to send TxMA messages straight into the account deletion processor in future.

## Notes

Currently sticking with `zod` validation, but could switch to `ajv` against a full JSON schema from the event catalogue in future.

https://govukverify.atlassian.net/browse/FPAD-7912 is still outstanding.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-8033](https://govukverify.atlassian.net/browse/FPAD-8033r)

[FPAD-8033]: https://govukverify.atlassian.net/browse/FPAD-8033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ