### PR TITLE
FPAD-7912: Remove handling for unwrapped deletion messages

### DIFF
--- a/src/contracts/account-delete-message.ts
+++ b/src/contracts/account-delete-message.ts
@@ -1,14 +1,12 @@
 import { z } from 'zod';
 
-export const accountDeleteMessageSchema = z.union([
-  z.object({
-    event_name: z.literal('AUTH_DELETE_ACCOUNT'),
-    user: z.object({ user_id: z.string().optional() }),
+export const accountDeleteMessageSchema = z.object({
+  event_name: z.literal('AUTH_DELETE_ACCOUNT'),
+  user: z.object({
+    user_id: z.string().trim().min(1, {
+      message: 'String cannot be empty or just spaces',
+    }),
   }),
-  z.object({
-    event_name: z.literal('AUTH_DELETE_ACCOUNT'),
-    user_id: z.string().optional(),
-  }),
-]);
+});
 
 export type AccountDeleteMessage = z.infer<typeof accountDeleteMessageSchema>;

--- a/src/handlers/account-deletion-processor-handler.ts
+++ b/src/handlers/account-deletion-processor-handler.ts
@@ -8,11 +8,6 @@ import { accountDeleteMessageSchema } from '../contracts/account-delete-message'
 import { prettifyError } from 'zod';
 import jsonSafeParse from '../commons/json-safe-parse';
 
-enum ErrorSeverity {
-  error = 'error',
-  warn = 'warn',
-}
-
 enum ParserErrorType {
   BODY_JSON_PARSER_ERROR = 'BODY_JSON_PARSER_ERROR',
   BODY_FORMAT_PARSER_ERROR = 'BODY_FORMAT_PARSER_ERROR',
@@ -24,7 +19,6 @@ class ParserError extends Error {
   constructor(
     public readonly errorType: ParserErrorType,
     message?: string,
-    public readonly severity: ErrorSeverity = ErrorSeverity.error,
   ) {
     super(message ?? 'The SQS message can not be parsed.');
     this.name = 'ParserError';
@@ -60,7 +54,7 @@ export async function handler(event: SQSEvent, context: Context): Promise<void> 
  * @param record - The record passed in from the event.
  * @returns - User ID or undefined
  */
-function parseMessage(record: SQSRecord): string | undefined {
+function parseMessage(record: SQSRecord): string {
   // JSON parse record.body
   const recordBodyResult = jsonSafeParse(record.body);
   if (!recordBodyResult.success) throw new ParserError(ParserErrorType.BODY_JSON_PARSER_ERROR);
@@ -73,11 +67,7 @@ function parseMessage(record: SQSRecord): string | undefined {
       `The SQS message can not be parsed. ${prettifyError(result.error)}`,
     );
 
-  if ('user' in result.data) return result.data.user.user_id;
-
-  addMetric(MetricNames.DELETE_EVENT_UNWRAPPED);
-
-  return result.data.user_id;
+  return result.data.user.user_id;
 }
 
 /**
@@ -87,17 +77,10 @@ function parseMessage(record: SQSRecord): string | undefined {
  */
 function getUserId(record: SQSRecord) {
   try {
-    const userId = parseMessage(record);
-
-    if (userId === undefined)
-      throw new ParserError(ParserErrorType.MISSING_USER_ID, 'Attribute missing: user_id.', ErrorSeverity.warn);
-    if (userId.trim() === '')
-      throw new ParserError(ParserErrorType.EMPTY_USER_ID, 'Attribute invalid: user_id is empty.', ErrorSeverity.warn);
-
-    return userId.trim();
+    return parseMessage(record);
   } catch (error) {
     if (error instanceof ParserError) {
-      logger[error.severity](error.message);
+      logger.error(error.message);
       addMetric(MetricNames.DELETE_EVENT_PARSER_ERROR, undefined, undefined, {
         ERROR: error.errorType,
       });

--- a/src/handlers/tests/account-deletion-processor-handler.test.ts
+++ b/src/handlers/tests/account-deletion-processor-handler.test.ts
@@ -24,7 +24,6 @@ const mockAddDimensions = Metrics.prototype.addDimensions as Mock;
 const mockSerializeMetrics = Metrics.prototype.serializeMetrics as Mock;
 
 const loggerErrorSpy = vi.spyOn(logger, 'error');
-const loggerWarnSpy = vi.spyOn(logger, 'warn');
 
 describe('Account Deletion Processor', () => {
   let mockEvent: SQSEvent;
@@ -110,7 +109,11 @@ describe('Account Deletion Processor', () => {
     mockRecord = { ...mockRecord, body: mockBody };
     mockEvent = { Records: [mockRecord] };
     await handler(mockEvent, mockContext);
-    expect(loggerErrorSpy).toHaveBeenCalledWith('The SQS message can not be parsed. ✖ Invalid input');
+    expect(loggerErrorSpy)
+      .toHaveBeenCalledWith(`The SQS message can not be parsed. ✖ Invalid input: expected "AUTH_DELETE_ACCOUNT"
+  → at event_name
+✖ Invalid input: expected object, received undefined
+  → at user`);
   });
 
   it("does not process the SQS Record when the message doesn't contain user id", async () => {
@@ -118,38 +121,46 @@ describe('Account Deletion Processor', () => {
     mockRecord = { ...mockRecord, body: mockBody };
     mockEvent = { Records: [mockRecord] };
     await handler(mockEvent, mockContext);
-    expect(loggerWarnSpy).toHaveBeenCalledWith('Attribute missing: user_id.');
+    expect(loggerErrorSpy)
+      .toHaveBeenCalledWith(`The SQS message can not be parsed. ✖ Invalid input: expected object, received undefined
+  → at user`);
   });
 
   it('does not process the SQS Record when user_id is an empty string in the SNS Event', async () => {
-    const mockBody = JSON.stringify({ event_name: 'AUTH_DELETE_ACCOUNT', user_id: '' });
+    const mockBody = JSON.stringify({ event_name: 'AUTH_DELETE_ACCOUNT', user: { user_id: '' } });
     mockRecord = { ...mockRecord, body: mockBody };
     mockEvent = { Records: [mockRecord] };
     await handler(mockEvent, mockContext);
-    expect(loggerWarnSpy).toHaveBeenCalledWith('Attribute invalid: user_id is empty.');
+    expect(loggerErrorSpy)
+      .toHaveBeenCalledWith(`The SQS message can not be parsed. ✖ String cannot be empty or just spaces
+  → at user.user_id`);
   });
 
   it('does not process the SQS Record when user_id is a string with whitespaces in the SNS Event and tests the trim function', async () => {
-    const mockBody = JSON.stringify({ event_name: 'AUTH_DELETE_ACCOUNT', user_id: '   ' });
+    const mockBody = JSON.stringify({ event_name: 'AUTH_DELETE_ACCOUNT', user: { user_id: '   ' } });
     mockRecord = { ...mockRecord, body: mockBody };
     mockEvent = { Records: [mockRecord] };
     await handler(mockEvent, mockContext);
-    expect(loggerWarnSpy).toHaveBeenCalledWith('Attribute invalid: user_id is empty.');
+    expect(loggerErrorSpy)
+      .toHaveBeenCalledWith(`The SQS message can not be parsed. ✖ String cannot be empty or just spaces
+  → at user.user_id`);
   });
 
   it('does not process the SQS Record when user_id is not a string', async () => {
-    const mockBody = JSON.stringify({ event_name: 'AUTH_DELETE_ACCOUNT', user_id: 123 });
+    const mockBody = JSON.stringify({ event_name: 'AUTH_DELETE_ACCOUNT', user: { user_id: 123 } });
     mockRecord = { ...mockRecord, body: mockBody };
     mockEvent = { Records: [mockRecord] };
     await handler(mockEvent, mockContext);
-    expect(loggerErrorSpy).toHaveBeenCalledWith(`The SQS message can not be parsed. ✖ Invalid input`);
+    expect(loggerErrorSpy)
+      .toHaveBeenCalledWith(`The SQS message can not be parsed. ✖ Invalid input: expected string, received number
+  → at user.user_id`);
   });
 
   it('successfully processes the message when the user id passed contains trailing spaces', async () => {
     mockDynamoDBServiceUpdateDeleteStatus.mockReturnValueOnce(['1']);
     const mockBody = JSON.stringify({
       event_name: 'AUTH_DELETE_ACCOUNT',
-      user_id: 'abcdef ',
+      user: { user_id: 'abcdef ' },
     });
     mockRecord = { ...mockRecord, body: mockBody };
     mockEvent = { Records: [mockRecord] };
@@ -241,7 +252,9 @@ describe('Account Deletion Processor', () => {
       ...mockRecord,
       body: JSON.stringify({
         event_name: 'AUTH_DELETE_ACCOUNT',
-        user_id: 'other_user_id',
+        user: {
+          user_id: 'other_user_id',
+        },
       }),
     };
     const mockEvent = { Records: [mockRecord, mockRecord2] };


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Remove handling for unwrapped deletion messages

## Why

We are no longer sending events with unwrapped `user_id`.

## Notes

This keeps using Zod validation.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-7912](https://govukverify.atlassian.net/browse/FPAD-7912)

[FPAD-7912]: https://govukverify.atlassian.net/browse/FPAD-7912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ