### PR TITLE
FPAD-8044: Add non-blocking event catalogue schema validation

### DIFF
--- a/src/handlers/account-deletion-processor-handler.ts
+++ b/src/handlers/account-deletion-processor-handler.ts
@@ -1,4 +1,5 @@
 import logger from '../commons/logger';
+import Ajv2019 from 'ajv/dist/2019';
 import { DynamoDatabaseService } from '../services/dynamo-database-service';
 import { LOGS_PREFIX_SENSITIVE_INFO, MetricNames } from '../data-types/constants';
 import { AppConfigService } from '../services/app-config-service';
@@ -7,6 +8,11 @@ import { addMetric, metric } from '../commons/metrics';
 import { accountDeleteMessageSchema } from '../contracts/account-delete-message';
 import { prettifyError } from 'zod';
 import jsonSafeParse from '../commons/json-safe-parse';
+import { AUTH_DELETE_ACCOUNTSchema } from '@govuk-one-login/event-catalogue-schemas';
+
+const ajv2019 = new Ajv2019({ allErrors: true });
+
+const validateEventCatalogue = ajv2019.compile(AUTH_DELETE_ACCOUNTSchema);
 
 enum ParserErrorType {
   BODY_JSON_PARSER_ERROR = 'BODY_JSON_PARSER_ERROR',
@@ -66,6 +72,15 @@ function parseMessage(record: SQSRecord): string {
       ParserErrorType.BODY_FORMAT_PARSER_ERROR,
       `The SQS message can not be parsed. ${prettifyError(result.error)}`,
     );
+
+  if (!validateEventCatalogue(recordBodyResult.data)) {
+    logger.debug(`${LOGS_PREFIX_SENSITIVE_INFO} Event has failed event catalogue schema validation.`, {
+      validationErrors: validateEventCatalogue.errors,
+    });
+    addMetric(MetricNames.INVALID_EVENT_RECEIVED_EVENT_CATALOGUE, undefined, undefined, {
+      EVENT_NAME: result.data.event_name,
+    });
+  }
 
   return result.data.user.user_id;
 }

--- a/src/handlers/tests/account-deletion-processor-handler.test.ts
+++ b/src/handlers/tests/account-deletion-processor-handler.test.ts
@@ -165,7 +165,7 @@ describe('Account Deletion Processor', () => {
     mockRecord = { ...mockRecord, body: mockBody };
     mockEvent = { Records: [mockRecord] };
     await handler(mockEvent, mockContext);
-    expect(mockPublishStoredMetric).toHaveBeenCalledTimes(1);
+    expect(mockPublishStoredMetric).toHaveBeenCalled();
     expect(mockDynamoDBServiceUpdateDeleteStatus).toHaveBeenCalledWith('abcdef');
   });
 
@@ -180,16 +180,16 @@ describe('Account Deletion Processor', () => {
     mockRecord = { ...mockRecord, body: mockBody };
     mockEvent = { Records: [mockRecord] };
     await expect(handler(mockEvent, mockContext)).rejects.toThrow('Failed to update the account status.');
-    expect(mockPublishStoredMetric).toHaveBeenCalledTimes(1);
+    expect(mockPublishStoredMetric).toHaveBeenCalled();
     expect(loggerErrorSpy).toHaveBeenCalledWith(`Sensitive info - Error updating account hello`, { error: 'Error' });
-    expect(mockAddMetric).toHaveBeenCalledTimes(1);
+    expect(mockAddMetric).toHaveBeenCalled();
     expect(mockAddMetric).toHaveBeenCalledWith(MetricNames.MARK_AS_DELETED_FAILED, 'Count', 1);
   });
 
   it('successfully process the message when it contains a single record', async () => {
     mockDynamoDBServiceUpdateDeleteStatus.mockResolvedValue('');
     await handler(mockEvent, mockContext);
-    expect(mockPublishStoredMetric).toHaveBeenCalledTimes(1);
+    expect(mockPublishStoredMetric).toHaveBeenCalled();
     expect(mockDynamoDBServiceUpdateDeleteStatus).toHaveBeenCalledTimes(1);
   });
 
@@ -204,7 +204,7 @@ describe('Account Deletion Processor', () => {
     const mockEvent = { Records: [mockRecord] };
     mockDynamoDBServiceUpdateDeleteStatus.mockResolvedValue('');
     await handler(mockEvent, mockContext);
-    expect(mockPublishStoredMetric).toHaveBeenCalledTimes(1);
+    expect(mockPublishStoredMetric).toHaveBeenCalled();
     expect(mockDynamoDBServiceUpdateDeleteStatus).toHaveBeenCalledTimes(1);
   });
 
@@ -243,6 +243,7 @@ describe('Account Deletion Processor', () => {
     mockDynamoDBServiceUpdateDeleteStatus.mockResolvedValue('');
     await handler(mockEvent, mockContext);
     expect(mockPublishStoredMetric).toHaveBeenCalledTimes(1);
+    expect(mockAddMetric).not.toHaveBeenCalledWith('INVALID_EVENT_RECEIVED_EVENT_CATALOGUE', 'Count', 1);
     expect(mockDynamoDBServiceUpdateDeleteStatus).toHaveBeenCalledTimes(1);
   });
 
@@ -259,7 +260,7 @@ describe('Account Deletion Processor', () => {
     };
     const mockEvent = { Records: [mockRecord, mockRecord2] };
     await handler(mockEvent, mockContext);
-    expect(mockPublishStoredMetric).toHaveBeenCalledTimes(1);
+    expect(mockPublishStoredMetric).toHaveBeenCalled();
     expect(mockDynamoDBServiceUpdateDeleteStatus).toHaveBeenCalledTimes(2);
   });
 
@@ -277,8 +278,7 @@ describe('Account Deletion Processor', () => {
     };
     const mockEvent = { Records: [mockRecord, mockRecord2] };
     await expect(handler(mockEvent, mockContext)).rejects.toThrow('Failed to update the account status.');
-    expect(mockPublishStoredMetric).toHaveBeenCalledTimes(1);
-    expect(mockAddMetric).toHaveBeenCalledTimes(1);
+    expect(mockPublishStoredMetric).toHaveBeenCalled();
     expect(mockAddMetric).toHaveBeenCalledWith(MetricNames.MARK_AS_DELETED_FAILED, 'Count', 1);
   });
 });


### PR DESCRIPTION


<!-- https://jml.io/posts/what-why-notes/ -->

## What

Add non-blocking event catalogue schema validation to account deletion processor.

Will raise the existing `INVALID_EVENT_RECEIVED_EVENT_CATALOGUE` metric with `EVENT_NAME`.

## Why

Give us a record of how many deletion events we are receiving are invalid.

First step towards tightening our validation to only accept events that follow the event catalogue schema.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-8044](https://govukverify.atlassian.net/browse/FPAD-8044)

[FPAD-8044]: https://govukverify.atlassian.net/browse/FPAD-8044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ