### PR TITLE
Fix for TEST_ENVIRONMENT being set in vitest.config.ts

### DIFF
--- a/feature-tests/vitest.config.ts
+++ b/feature-tests/vitest.config.ts
@@ -14,7 +14,6 @@ export default defineConfig({
     hideSkippedTests: true,
     testTimeout: 60_000,
     env: {
-      TEST_ENVIRONMENT: 'dev',
       SAM_STACK_NAME: 'ais-main',
       AWS_REGION: 'eu-west-2',
       tagFilter: '@regression',


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Don't set `TEST_ENVIRONMENT` environment variable in `vitest.config.ts` as this is causing issue when running feature tests in `build`.
