### PR TITLE
FPAD-8078: Intervention processor Zod validation

### DIFF
--- a/src/commons/build-partial-update-state-command.ts
+++ b/src/commons/build-partial-update-state-command.ts
@@ -1,9 +1,10 @@
-import { StateDetails, TxMAIngressEvent } from '../data-types/interfaces';
+import { StateDetails } from '../data-types/interfaces';
 import { UpdateItemCommandInput } from '@aws-sdk/client-dynamodb';
 import { AISInterventionTypes, EventsEnum, MetricNames } from '../data-types/constants';
 import { addMetric } from './metrics';
 import { HistoryStringBuilder } from './history-string-builder';
 import { AppConfigService } from '../services/app-config-service';
+import { InterventionEventMessage } from '../contracts/intervention-events';
 
 type DeepRequiredKey<T, K extends keyof T> = Omit<T, K> & {
   [P in K]-?: Exclude<T[P], undefined>;
@@ -20,13 +21,12 @@ type DeepRequiredKey<T, K extends keyof T> = Omit<T, K> & {
  */
 export function buildPartialUpdateAccountStateCommand(
   finalState: StateDetails,
-  eventName: EventsEnum,
   currentTimestamp: number,
-  interventionEvent: TxMAIngressEvent,
+  interventionEvent: InterventionEventMessage,
   historyList: string[],
   interventionName?: AISInterventionTypes,
 ): Partial<UpdateItemCommandInput> {
-  const eventTimestamp = interventionEvent.event_timestamp_ms ?? interventionEvent.timestamp * 1000;
+  const eventTimestamp = interventionEvent.event_timestamp_ms;
 
   const baseUpdateItemCommandInput: DeepRequiredKey<
     Partial<UpdateItemCommandInput>,
@@ -49,7 +49,7 @@ export function buildPartialUpdateAccountStateCommand(
     UpdateExpression: 'SET #B = :b, #S = :s, #RP = :rp, #RI = :ri, #UA = :ua',
   };
 
-  if (eventName === EventsEnum.IPV_ACCOUNT_INTERVENTION_END) {
+  if (interventionEvent.event_name === EventsEnum.IPV_ACCOUNT_INTERVENTION_END) {
     baseUpdateItemCommandInput.ExpressionAttributeNames['#RIdA'] = 'reprovedIdentityAt';
     baseUpdateItemCommandInput.ExpressionAttributeValues[':rida'] = { N: eventTimestamp.toString() };
     baseUpdateItemCommandInput.ExpressionAttributeNames['#H'] = 'history';
@@ -61,8 +61,8 @@ export function buildPartialUpdateAccountStateCommand(
   }
 
   if (
-    eventName === EventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL ||
-    eventName === EventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL_FOR_TEST_CLIENT
+    interventionEvent.event_name === EventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL ||
+    interventionEvent.event_name === EventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL_FOR_TEST_CLIENT
   ) {
     baseUpdateItemCommandInput.ExpressionAttributeNames['#RPswdA'] = 'resetPasswordAt';
     baseUpdateItemCommandInput.ExpressionAttributeValues[':rpswda'] = { N: eventTimestamp.toString() };
@@ -78,6 +78,7 @@ export function buildPartialUpdateAccountStateCommand(
     addMetric(MetricNames.INTERVENTION_DID_NOT_HAVE_NAME_IN_CURRENT_CONFIG);
     throw new Error('The intervention received did not have an interventionName field.');
   }
+
   baseUpdateItemCommandInput.ExpressionAttributeNames['#INT'] = 'intervention';
   baseUpdateItemCommandInput.ExpressionAttributeValues[':int'] = { S: interventionName };
   baseUpdateItemCommandInput.ExpressionAttributeNames['#AA'] = 'appliedAt';

--- a/src/commons/history-string-builder.ts
+++ b/src/commons/history-string-builder.ts
@@ -1,5 +1,6 @@
+import { TicfAccountIntervention } from '../contracts/intervention-events';
 import { HistoryStringParts, expectedHistoryStringLength } from '../data-types/constants';
-import { HistoryObject, TxMAIngressEvent } from '../data-types/interfaces';
+import { HistoryObject } from '../data-types/interfaces';
 import { AccountStateEngine } from '../services/account-states/account-state-engine';
 
 /**
@@ -38,9 +39,9 @@ export class HistoryStringBuilder {
    * @returns - the history string that has been built with the buildHistoryString method with the
    * information of each part, updated.
    */
-  public getHistoryString(event: TxMAIngressEvent, timeStamp: number) {
-    const interventionInformation = event.extensions?.intervention;
-    if (!interventionInformation) throw new Error('No intervention information found in event.');
+  public getHistoryString(event: TicfAccountIntervention, timeStamp: number) {
+    const interventionInformation = event.extensions.intervention;
+
     return this.buildHistoryString(
       String(timeStamp),
       event.component_id,

--- a/src/commons/test/build-partial-update-state-command.test.ts
+++ b/src/commons/test/build-partial-update-state-command.test.ts
@@ -1,7 +1,12 @@
-import { StateDetails, TxMAIngressEvent } from '../../data-types/interfaces';
+import { StateDetails } from '../../data-types/interfaces';
 import { AISInterventionTypes, EventsEnum, MetricNames, TriggerEventsEnum } from '../../data-types/constants';
 import { buildPartialUpdateAccountStateCommand } from '../build-partial-update-state-command';
 import { addMetric } from '../metrics';
+import {
+  AuthPasswordResetSuccessful,
+  IpvAccountInterventionEnd,
+  TicfAccountIntervention,
+} from '../../contracts/intervention-events';
 
 vi.mock('@aws-lambda-powertools/logger');
 vi.mock('../../commons/metrics');
@@ -12,7 +17,8 @@ vi.mock('../../commons/get-current-timestamp', () => ({
     seconds: 1_706_544_555,
   })),
 }));
-const interventionEventBody: TxMAIngressEvent = {
+
+const interventionEventBody: TicfAccountIntervention = {
   timestamp: 1000,
   event_timestamp_ms: 123_456,
   user: {
@@ -31,22 +37,28 @@ const interventionEventBody: TxMAIngressEvent = {
     },
   },
 };
-const resetPasswordEventBody = {
-  event_name: TriggerEventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL,
+
+const resetPasswordEventBody: AuthPasswordResetSuccessful = {
+  event_name: EventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL,
   event_id: '123',
   timestamp: 10_000,
   event_timestamp_ms: 10_000_000,
-  client_id: 'UNKNOWN',
   component_id: 'UNKNOWN',
   user: {
     user_id: 'abc',
-    email: '',
-    phone: 'UNKNOWN',
-    ip_address: '',
-    session_id: '',
-    persistent_session_id: '',
-    govuk_signin_journey_id: '',
   },
+};
+
+const ipvAccountInterventionEventBody: IpvAccountInterventionEnd = {
+  event_name: EventsEnum.IPV_ACCOUNT_INTERVENTION_END,
+  event_id: '123',
+  timestamp: 10_000,
+  event_timestamp_ms: 10_000_000,
+  component_id: 'UNKNOWN',
+  user: {
+    user_id: 'abc',
+  },
+  extensions: {},
 };
 
 describe('build-partial-update-state-command', () => {
@@ -57,7 +69,6 @@ describe('build-partial-update-state-command', () => {
       resetPassword: true,
       reproveIdentity: true,
     };
-    const userAction = EventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL;
     const expectedOutput = {
       ExpressionAttributeNames: {
         '#B': 'blocked',
@@ -79,7 +90,7 @@ describe('build-partial-update-state-command', () => {
       },
       UpdateExpression: 'SET #B = :b, #S = :s, #RP = :rp, #RI = :ri, #UA = :ua, #RPswdA = :rpswda, #H = :h',
     };
-    const command = buildPartialUpdateAccountStateCommand(state, userAction, 4444, resetPasswordEventBody, []);
+    const command = buildPartialUpdateAccountStateCommand(state, 4444, resetPasswordEventBody, []);
     expect(command).toEqual(expectedOutput);
   });
 
@@ -90,8 +101,8 @@ describe('build-partial-update-state-command', () => {
       resetPassword: true,
       reproveIdentity: true,
     };
-    const userAction = EventsEnum.IPV_ACCOUNT_INTERVENTION_END;
-    const expectedOutput = {
+    const command = buildPartialUpdateAccountStateCommand(state, 4444, ipvAccountInterventionEventBody, []);
+    expect(command).toEqual({
       ExpressionAttributeNames: {
         '#B': 'blocked',
         '#H': 'history',
@@ -111,9 +122,7 @@ describe('build-partial-update-state-command', () => {
         ':rida': { N: '10000000' },
       },
       UpdateExpression: 'SET #B = :b, #S = :s, #RP = :rp, #RI = :ri, #UA = :ua, #RIdA = :rida, #H = :h',
-    };
-    const command = buildPartialUpdateAccountStateCommand(state, userAction, 4444, resetPasswordEventBody, []);
-    expect(command).toEqual(expectedOutput);
+    });
   });
 
   it('should return a partial update command given an intervention is applied', () => {
@@ -123,7 +132,6 @@ describe('build-partial-update-state-command', () => {
       resetPassword: true,
       reproveIdentity: false,
     };
-    const intervention = EventsEnum.FRAUD_FORCED_USER_PASSWORD_RESET;
     const expectedOutput = {
       ExpressionAttributeNames: {
         '#B': 'blocked',
@@ -152,7 +160,6 @@ describe('build-partial-update-state-command', () => {
     };
     const command = buildPartialUpdateAccountStateCommand(
       state,
-      intervention,
       4444,
       interventionEventBody,
       [],
@@ -167,7 +174,6 @@ describe('build-partial-update-state-command', () => {
       resetPassword: false,
       reproveIdentity: false,
     };
-    const intervention = EventsEnum.FRAUD_UNSUSPEND_ACCOUNT;
     const expectedOutput = {
       ExpressionAttributeNames: {
         '#B': 'blocked',
@@ -196,7 +202,6 @@ describe('build-partial-update-state-command', () => {
     };
     const command = buildPartialUpdateAccountStateCommand(
       state,
-      intervention,
       4444,
       interventionEventBody,
       [],
@@ -212,7 +217,6 @@ describe('build-partial-update-state-command', () => {
       resetPassword: false,
       reproveIdentity: true,
     };
-    const intervention = EventsEnum.FRAUD_FORCED_USER_IDENTITY_REVERIFICATION;
     const expectedOutput = {
       ExpressionAttributeNames: {
         '#B': 'blocked',
@@ -241,7 +245,6 @@ describe('build-partial-update-state-command', () => {
     };
     const command = buildPartialUpdateAccountStateCommand(
       state,
-      intervention,
       4444,
       interventionEventBody,
       [],
@@ -249,6 +252,7 @@ describe('build-partial-update-state-command', () => {
     );
     expect(command).toEqual(expectedOutput);
   });
+
   it('should return a partial update command given an intervention is applied and id reset and psw reset user actions are needed', () => {
     const state: StateDetails = {
       blocked: false,
@@ -256,7 +260,6 @@ describe('build-partial-update-state-command', () => {
       resetPassword: true,
       reproveIdentity: true,
     };
-    const intervention = EventsEnum.FRAUD_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_REVERIFICATION;
     const expectedOutput = {
       ExpressionAttributeNames: {
         '#B': 'blocked',
@@ -275,7 +278,7 @@ describe('build-partial-update-state-command', () => {
         ':rp': { BOOL: true },
         ':ri': { BOOL: true },
         ':ua': { N: '4444' },
-        ':sa': { N: '1000000' },
+        ':sa': { N: '123456' },
         ':aa': { N: '4444' },
         ':h': {
           L: [{ S: '1000000|TICF_CRI|01|reason|originating_component_id|originator_reference_id|requester_id' }],
@@ -285,22 +288,18 @@ describe('build-partial-update-state-command', () => {
       UpdateExpression:
         'SET #B = :b, #S = :s, #RP = :rp, #RI = :ri, #UA = :ua, #INT = :int, #SA = :sa, #AA = :aa, #H = :h REMOVE resetPasswordAt, reprovedIdentityAt',
     };
-    const interventionEventBodyNoMsTimestamp = {
-      ...interventionEventBody,
-      event_timestamp_ms: undefined,
-    };
+
     const command = buildPartialUpdateAccountStateCommand(
       state,
-      intervention,
       4444,
-      interventionEventBodyNoMsTimestamp as unknown as TxMAIngressEvent,
+      interventionEventBody,
       ['1706544554234|TICF_CRI|02|reason|originating_component_id|originator_reference_id|requester_id'],
       AISInterventionTypes.AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY,
     );
     expectedOutput.ExpressionAttributeValues[':h'] = {
       L: [
         { S: '1706544554234|TICF_CRI|02|reason|originating_component_id|originator_reference_id|requester_id' },
-        { S: '1000000|TICF_CRI|01|reason|originating_component_id|originator_reference_id|requester_id' },
+        { S: '123456|TICF_CRI|01|reason|originating_component_id|originator_reference_id|requester_id' },
       ],
     };
     expect(command).toEqual(expectedOutput);
@@ -313,8 +312,7 @@ describe('build-partial-update-state-command', () => {
       resetPassword: true,
       reproveIdentity: true,
     };
-    const intervention = EventsEnum.FRAUD_BLOCK_ACCOUNT;
-    expect(() => buildPartialUpdateAccountStateCommand(state, intervention, 4444, interventionEventBody, [])).toThrow(
+    expect(() => buildPartialUpdateAccountStateCommand(state, 4444, interventionEventBody, [])).toThrow(
       new Error('The intervention received did not have an interventionName field.'),
     );
     expect(addMetric).toHaveBeenLastCalledWith(MetricNames.INTERVENTION_DID_NOT_HAVE_NAME_IN_CURRENT_CONFIG);

--- a/src/commons/test/history-string-builder.test.ts
+++ b/src/commons/test/history-string-builder.test.ts
@@ -1,8 +1,8 @@
-import { TxMAIngressEvent } from '../../data-types/interfaces';
 import { HistoryStringBuilder } from '../history-string-builder';
 import { TriggerEventsEnum } from '../../data-types/constants';
+import { TicfAccountIntervention } from '../../contracts/intervention-events';
 
-const interventionEventBody: TxMAIngressEvent = {
+const interventionEventBody: TicfAccountIntervention = {
   timestamp: 1000,
   event_timestamp_ms: 123_456,
   user: {
@@ -21,16 +21,7 @@ const interventionEventBody: TxMAIngressEvent = {
     },
   },
 };
-const resetPasswordEventBody: TxMAIngressEvent = {
-  event_name: TriggerEventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL,
-  event_id: '123',
-  timestamp: 10_000,
-  event_timestamp_ms: 10_000_000,
-  component_id: 'UNKNOWN',
-  user: {
-    user_id: 'abc',
-  },
-};
+
 describe('history-string-builder', () => {
   const stringBuilder = new HistoryStringBuilder();
   it('should return a history string formatted correctly', () => {
@@ -76,12 +67,6 @@ describe('history-string-builder', () => {
     const historyString = '123456||01||originating_component_id|intervention_predecessor_id|requester_i';
     expect(() => stringBuilder.getHistoryObject(historyString)).toThrow(
       new Error('One of the required property was not found in the history string.'),
-    );
-  });
-
-  it('should throw if the event passed has no intervention information', () => {
-    expect(() => stringBuilder.getHistoryString(resetPasswordEventBody, 1_234_567)).toThrow(
-      new Error('No intervention information found in event.'),
     );
   });
 });

--- a/src/contract-testing/consumer/txma-ais-consumer.pact.test.ts
+++ b/src/contract-testing/consumer/txma-ais-consumer.pact.test.ts
@@ -4,7 +4,6 @@ import { boolean, number, string } from '@pact-foundation/pact/src/v3/matchers';
 import { validateEventAgainstSchema } from '../../services/validate-event';
 import path from 'node:path';
 import { AnyJson } from '@pact-foundation/pact/src/common/jsonTypes';
-import { TxMAIngressEvent } from '../../data-types/interfaces';
 const { like } = Matchers;
 
 describe('TxMA & AIS - Contract Testing - Consumer', () => {
@@ -78,8 +77,7 @@ describe('TxMA & AIS - Contract Testing - Consumer', () => {
 });
 
 function interventionMessageValidator(event: AnyJson | Buffer) {
-  validateEventAgainstSchema(event as unknown as TxMAIngressEvent);
-  return;
+  validateEventAgainstSchema(event);
 }
 
 function deleteAccountEventValidator(event: AnyJson | Buffer) {
@@ -87,5 +85,4 @@ function deleteAccountEventValidator(event: AnyJson | Buffer) {
   if (!userId || typeof userId !== 'string' || userId.trim() === '') {
     throw new Error('Invalid Message');
   }
-  return;
 }

--- a/src/contract-testing/consumer/txma-ais-consumer.pact.test.ts
+++ b/src/contract-testing/consumer/txma-ais-consumer.pact.test.ts
@@ -21,7 +21,9 @@ describe('TxMA & AIS - Contract Testing - Consumer', () => {
         .given('AIS is healthy')
         .expectsToReceive('a valid intervention event')
         .withContent({
+          component_id: '',
           timestamp: like(1_705_318_190),
+          event_timestamp_ms: number(1_705_318_190_000),
           event_name: 'TICF_ACCOUNT_INTERVENTION',
           user: {
             user_id: string('urn:fdc:gov.uk:2022:USER_ONE'),
@@ -39,7 +41,9 @@ describe('TxMA & AIS - Contract Testing - Consumer', () => {
         .given('AIS is healthy')
         .expectsToReceive('a valid user action event - reset password')
         .withContent({
+          component_id: '',
           timestamp: number(1_705_318_190),
+          event_timestamp_ms: number(1_705_318_190_000),
           event_name: like('AUTH_PASSWORD_RESET_SUCCESSFUL'),
           user: {
             user_id: string('urn:fdc:gov.uk:2022:USER_ONE'),
@@ -51,7 +55,9 @@ describe('TxMA & AIS - Contract Testing - Consumer', () => {
         .given('AIS is healthy')
         .expectsToReceive('a valid user action event - reset password')
         .withContent({
+          component_id: '',
           timestamp: number(1_705_318_190),
+          event_timestamp_ms: number(1_705_318_190_000),
           event_name: like('IPV_ACCOUNT_INTERVENTION_END'),
           user: {
             user_id: string('urn:fdc:gov.uk:2022:USER_ONE'),

--- a/src/contracts/intervention-events.ts
+++ b/src/contracts/intervention-events.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+import { EventsEnum, TriggerEventsEnum } from '../data-types/constants';
+
+const baseInterventionMessageSchema = z.object({
+  component_id: z.string(),
+  event_id: z.string().optional(),
+  event_name: z.string(),
+  timestamp: z.number(),
+  event_timestamp_ms: z.number(),
+  user: z.object({
+    user_id: z.string().trim().min(1, {
+      message: 'String cannot be empty or just spaces',
+    }),
+  }),
+});
+
+const ticfAccountInterventionSchema = baseInterventionMessageSchema.safeExtend({
+  event_name: z.literal(TriggerEventsEnum.TICF_ACCOUNT_INTERVENTION),
+  extensions: z.object({
+    intervention: z.object({
+      intervention_code: z.string(),
+      intervention_reason: z.string(),
+      originating_component_id: z.string().optional(),
+      originator_reference_id: z.string().optional(),
+      requester_id: z.string().optional(),
+    }),
+  }),
+});
+
+export type TicfAccountIntervention = z.infer<typeof ticfAccountInterventionSchema>;
+
+const authPasswordResetSuccessfulSchema = baseInterventionMessageSchema.safeExtend({
+  event_name: z.literal(EventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL),
+});
+
+export type AuthPasswordResetSuccessful = z.infer<typeof authPasswordResetSuccessfulSchema>;
+
+const authPasswordResetSuccessfulForTestClientSchema = baseInterventionMessageSchema.safeExtend({
+  event_name: z.literal(EventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL_FOR_TEST_CLIENT),
+});
+
+const ipvAccountInterventionEndSchema = baseInterventionMessageSchema.safeExtend({
+  event_name: z.literal(EventsEnum.IPV_ACCOUNT_INTERVENTION_END),
+  extensions: z.object({
+    type: z.string().optional(),
+    success: z.boolean().optional(),
+  }),
+});
+
+export type IpvAccountInterventionEnd = z.infer<typeof ipvAccountInterventionEndSchema>;
+
+export const interventionMessageSchema = z.union([
+  ticfAccountInterventionSchema,
+  ipvAccountInterventionEndSchema,
+  authPasswordResetSuccessfulSchema,
+  authPasswordResetSuccessfulForTestClientSchema,
+]);
+
+export type InterventionEventMessage = z.infer<typeof interventionMessageSchema>;

--- a/src/data-types/interfaces.ts
+++ b/src/data-types/interfaces.ts
@@ -1,8 +1,5 @@
-import {
-  AIS_EVENT_TRANSITION_APPLIED,
-  InterventionCodeEnum1,
-} from '@govuk-one-login/event-catalogue/AIS_EVENT_TRANSITION_APPLIED';
-import { EventsEnum, AISInterventionTypes, TriggerEventsEnum, PossibleAccountStatus, Codes } from './constants';
+import { AIS_EVENT_TRANSITION_APPLIED } from '@govuk-one-login/event-catalogue/AIS_EVENT_TRANSITION_APPLIED';
+import { EventsEnum, AISInterventionTypes, PossibleAccountStatus, Codes } from './constants';
 import { AIS_EVENT_IGNORED_STALE } from '../events/ais-event-ignored-stale';
 import { AIS_EVENT_TRANSITION_IGNORED } from '@govuk-one-login/event-catalogue/AIS_EVENT_TRANSITION_IGNORED';
 import { AUTH_DELETE_ACCOUNT } from '@govuk-one-login/event-catalogue/AUTH_DELETE_ACCOUNT';
@@ -63,34 +60,8 @@ export type TxMAEgressEvent =
   | AIS_EVENT_IGNORED_STALE
   | AUTH_DELETE_ACCOUNT;
 
-export interface TxMAIngressEvent {
-  event_name: TriggerEventsEnum;
-  event_id: string | undefined;
-  timestamp: number;
-  event_timestamp_ms?: number;
-  component_id: string;
-  user: TxmaUser;
-  extensions?: IngressEventExtension;
-}
-
 export interface TxmaUser {
   user_id: string;
-}
-
-interface IngressEventExtension {
-  intervention?: Intervention;
-  type?: string;
-  success?: boolean;
-}
-
-interface Intervention {
-  intervention_code: InterventionCodeEnum1;
-  intervention_reason: string;
-  requester_id?: string;
-  originating_component_id?: string;
-  originator_reference_id?: string;
-  audit_level?: string;
-  [key: string | number]: unknown;
 }
 
 export interface DeleteStatusUpdateSNSMessage {

--- a/src/events/ais-event-ignored-stale.ts
+++ b/src/events/ais-event-ignored-stale.ts
@@ -39,9 +39,9 @@ export interface AisEventIgnoredStaleExtensions extends AisEventIgnoredStaleBasi
   action?: string;
 }
 export interface AisEventIgnoredStaleBasicExtensions {
-  trigger_event_id: string;
+  trigger_event_id: string | undefined;
   trigger_event: string;
-  intervention_code?: InterventionCodeEnum;
+  intervention_code?: string;
 }
 /**
  * This interface was referenced by `AIS_EVENT_TRANSITION_APPLIED`'s JSON-Schema

--- a/src/handlers/interventions-processor-handler.ts
+++ b/src/handlers/interventions-processor-handler.ts
@@ -9,14 +9,13 @@ import {
   noMetadata,
   TriggerEventsEnum,
 } from '../data-types/constants';
-import { DynamoDBStateResult, StateDetails, TxMAIngressEvent } from '../data-types/interfaces';
+import { DynamoDBStateResult, StateDetails } from '../data-types/interfaces';
 import { RetryEventError, StateTransitionError, TooManyRecordsError, ValidationError } from '../data-types/errors';
 import {
   attemptToParseJson,
   validateEventAgainstSchema,
   validateEventIsNotInFuture,
   validateEventIsNotStale,
-  validateInterventionEvent,
   validateIfIdentityAcquired,
 } from '../services/validate-event';
 import { AppConfigService } from '../services/app-config-service';
@@ -26,6 +25,7 @@ import { getCurrentTimestamp } from '../commons/get-current-timestamp';
 import { sendAuditEvent } from '../services/send-audit-events';
 import { buildPartialUpdateAccountStateCommand } from '../commons/build-partial-update-state-command';
 import { publishTimeToResolveMetrics, updateAccountStateCountMetric } from '../commons/metrics-helper';
+import { InterventionEventMessage } from '../contracts/intervention-events';
 
 const appConfig = AppConfigService.getInstance();
 const service = new DynamoDatabaseService(appConfig.tableName);
@@ -74,36 +74,33 @@ export async function handler(event: SQSEvent, context: Context): Promise<SQSBat
  */
 async function processSQSRecord(record: SQSRecord) {
   const currentTimestamp = getCurrentTimestamp();
-  const recordBody = attemptToParseJson(record.body) as TxMAIngressEvent;
-  validateEventAgainstSchema(recordBody);
-  const eventName = getEventName(recordBody);
-  logger.debug('Intervention received.', { intervention: eventName });
-  validateIfIdentityAcquired(eventName, recordBody);
-  await validateEventIsNotInFuture(eventName, recordBody);
 
-  const userId = recordBody.user.user_id;
-  const eventTimestampInMs = recordBody.event_timestamp_ms ?? recordBody.timestamp * 1000;
+  const recordBody = attemptToParseJson(record.body);
 
-  addMetric(MetricNames.EVENT_DELIVERY_LATENCY, noMetadata, currentTimestamp.milliseconds - eventTimestampInMs);
+  const { result, eventName } = await validateRecord(recordBody);
+
+  const userId = result.user.user_id;
+
+  addMetric(MetricNames.EVENT_DELIVERY_LATENCY, noMetadata, currentTimestamp.milliseconds - result.event_timestamp_ms);
 
   const itemFromDB = await service.getAccountStateInformation(userId);
 
   const currentAccountState = formCurrentAccountStateObject(itemFromDB);
 
   if (itemFromDB) {
-    await validateAccountIsNotDeleted(eventName, userId, recordBody, currentAccountState, itemFromDB);
-    await validateEventIsNotStale(eventName, recordBody, currentAccountState, itemFromDB);
+    await validateAccountIsNotDeleted(eventName, userId, result, currentAccountState, itemFromDB);
+    await validateEventIsNotStale(eventName, result, currentAccountState, itemFromDB);
   }
 
-  const statusResult = await applyEventTransition(eventName, currentAccountState, itemFromDB?.intervention, recordBody);
+  const statusResult = await applyEventTransition(eventName, currentAccountState, itemFromDB?.intervention, result);
   const partialCommandInput = buildPartialUpdateAccountStateCommand(
     statusResult.stateResult,
-    eventName,
     currentTimestamp.milliseconds,
-    recordBody,
+    result,
     itemFromDB?.history ?? [],
     statusResult.interventionName,
   );
+
   logger.debug(`${LOGS_PREFIX_SENSITIVE_INFO} Updating user status`, { userId, partialCommandInput });
   await service.updateUserStatus(userId, partialCommandInput);
   publishTimeToResolveMetrics(
@@ -116,20 +113,33 @@ async function processSQSRecord(record: SQSRecord) {
 
   updateAccountStateCountMetric(currentAccountState, statusResult.stateResult);
   addMetric(MetricNames.INTERVENTION_EVENT_APPLIED, [], 1, { eventName: eventName.toString() });
-  await sendAuditEvent('AIS_EVENT_TRANSITION_APPLIED', eventName, recordBody, statusResult);
+  await sendAuditEvent('AIS_EVENT_TRANSITION_APPLIED', eventName, result, statusResult);
+}
+
+async function validateRecord(recordBody: unknown) {
+  const result = validateEventAgainstSchema(recordBody);
+  const eventName = getEventName(result);
+  logger.debug('Intervention received.', { intervention: eventName });
+  validateIfIdentityAcquired(result);
+  await validateEventIsNotInFuture(eventName, result);
+
+  return {
+    result,
+    eventName,
+  };
 }
 
 async function applyEventTransition(
   event: EventsEnum,
   initialState: StateDetails,
   interventionName: string | undefined,
-  ingressTxMAEvent: TxMAIngressEvent,
+  result: InterventionEventMessage,
 ) {
   try {
     return accountStateEngine.applyEventTransition(event, initialState, interventionName);
   } catch (error) {
     if (error instanceof StateTransitionError)
-      await sendAuditEvent('AIS_EVENT_TRANSITION_IGNORED', error.transition, ingressTxMAEvent, error.output);
+      await sendAuditEvent('AIS_EVENT_TRANSITION_IGNORED', error.transition, result, error.output);
 
     throw error;
   }
@@ -165,15 +175,13 @@ function handleError(error: unknown, record: SQSRecord) {
  * @param recordBody - the record body from the SQS message
  * @returns - the Enum representation of the intervention
  */
-function getEventName(recordBody: TxMAIngressEvent): EventsEnum {
+function getEventName(recordBody: InterventionEventMessage): EventsEnum {
   logger.debug('event is valid, starting processing');
   if (recordBody.event_name === TriggerEventsEnum.TICF_ACCOUNT_INTERVENTION) {
-    validateInterventionEvent(recordBody);
-    const interventionCode = recordBody.extensions?.intervention?.intervention_code;
-    if (!interventionCode) throw new Error('Missing intervention code from TxMAIngressEvent');
+    const interventionCode = recordBody.extensions.intervention.intervention_code;
     return accountStateEngine.getInterventionEnumFromCode(interventionCode);
   }
-  return recordBody.event_name as unknown as EventsEnum;
+  return recordBody.event_name;
 }
 
 /**
@@ -187,7 +195,7 @@ function getEventName(recordBody: TxMAIngressEvent): EventsEnum {
 async function validateAccountIsNotDeleted(
   intervention: EventsEnum,
   userId: string,
-  record: TxMAIngressEvent,
+  record: InterventionEventMessage,
   initialState: StateDetails,
   itemFromDB: DynamoDBStateResult,
 ) {

--- a/src/handlers/tests/interventions-processor-lambda.test.ts
+++ b/src/handlers/tests/interventions-processor-lambda.test.ts
@@ -10,8 +10,8 @@ import { getCurrentTimestamp } from '../../commons/get-current-timestamp';
 import { StateTransitionError, TooManyRecordsError, ValidationError } from '../../data-types/errors';
 import { AISInterventionTypes, EventsEnum, MetricNames, TriggerEventsEnum } from '../../data-types/constants';
 import { sendAuditEvent } from '../../services/send-audit-events';
-import { TxMAIngressEvent } from '../../data-types/interfaces';
 import { publishTimeToResolveMetrics } from '../../commons/metrics-helper';
+import { InterventionEventMessage, TicfAccountIntervention } from '../../contracts/intervention-events';
 
 vi.mock('@aws-lambda-powertools/logger');
 vi.mock('../../commons/metrics');
@@ -32,7 +32,7 @@ const now = getCurrentTimestamp();
 const t0ms = now.milliseconds;
 const t0s = now.seconds;
 
-const interventionEventBody: TxMAIngressEvent = {
+const interventionEventBody: InterventionEventMessage = {
   component_id: '',
   timestamp: t0s - 5,
   event_timestamp_ms: t0ms - 5000,
@@ -49,7 +49,7 @@ const interventionEventBody: TxMAIngressEvent = {
   },
 };
 
-const interventionEventBodyInTheFuture = {
+const interventionEventBodyInTheFuture: TicfAccountIntervention = {
   component_id: '',
   timestamp: getCurrentTimestamp().seconds + 5,
   event_timestamp_ms: getCurrentTimestamp().milliseconds + 5000,
@@ -305,7 +305,18 @@ describe('intervention processor handler', () => {
       expect(sendAuditEvent).toHaveBeenLastCalledWith(
         'AIS_EVENT_TRANSITION_APPLIED',
         EventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL,
-        resetPasswordEventBody,
+        {
+          component_id: 'UNKNOWN',
+          event_id: '123',
+          event_name: 'AUTH_PASSWORD_RESET_SUCCESSFUL',
+          // eslint-disable-next-line unicorn/numeric-separators-style
+          event_timestamp_ms: 1234562890,
+          // eslint-disable-next-line unicorn/numeric-separators-style
+          timestamp: 1234562,
+          user: {
+            user_id: 'abc',
+          },
+        },
         {
           stateResult: {
             blocked: false,
@@ -362,6 +373,8 @@ describe('intervention processor handler', () => {
     });
 
     it('should return message id to be retried if event is in the future', async () => {
+      mockValidateEventAgainstSchema.mockReturnValueOnce(interventionEventBodyInTheFuture);
+
       mockRecord.body = JSON.stringify(interventionEventBodyInTheFuture);
       expect(await handler({ Records: [mockRecord] }, mockContext)).toEqual({
         batchItemFailures: [
@@ -446,6 +459,7 @@ describe('intervention processor handler', () => {
     });
 
     it('should successfully process valid event from fraud', async () => {
+      mockValidateEventAgainstSchema.mockReturnValueOnce(interventionEventBody);
       mockRetrieveRecords.mockReturnValue({
         blocked: false,
         reproveIdentity: false,
@@ -515,7 +529,10 @@ describe('intervention processor handler', () => {
         messageId: '123',
         receiptHandle: '',
         body: JSON.stringify({
+          component_id: 'UNKNOWN',
+          event_id: '123',
           timestamp: getCurrentTimestamp().milliseconds + 500_000,
+          event_timestamp_ms: getCurrentTimestamp().milliseconds + 500_000,
           user: {
             user_id: 'abc',
           },

--- a/src/services/send-audit-events.ts
+++ b/src/services/send-audit-events.ts
@@ -2,12 +2,7 @@ import { AppConfigService } from './app-config-service';
 import tracer from '../commons/tracer';
 import { NodeHttpHandler } from '@smithy/node-http-handler';
 import { SendMessageCommand, SendMessageCommandOutput, SQSClient } from '@aws-sdk/client-sqs';
-import {
-  AccountStateEngineOutput,
-  TxMAEgressEvent,
-  TxMAEgressInterventionEventName,
-  TxMAIngressEvent,
-} from '../data-types/interfaces';
+import { AccountStateEngineOutput, TxMAEgressEvent, TxMAEgressInterventionEventName } from '../data-types/interfaces';
 import logger from '../commons/logger';
 import { getCurrentTimestamp } from '../commons/get-current-timestamp';
 import {
@@ -16,11 +11,13 @@ import {
   EventsEnum,
   MetricNames,
   State,
+  TriggerEventsEnum,
   userLedActionList,
 } from '../data-types/constants';
 import { addMetric } from '../commons/metrics';
 import { transitionConfiguration } from './account-states/config';
 import { AisEventIgnoredStaleBasicExtensions, AisEventIgnoredStaleExtensions } from '../events/ais-event-ignored-stale';
+import { InterventionEventMessage } from '../contracts/intervention-events';
 
 const appConfig = AppConfigService.getInstance();
 
@@ -43,7 +40,7 @@ const sqsClient = tracer.captureAWSv3Client(
 export async function sendAuditEvent(
   egressEventName: TxMAEgressInterventionEventName,
   ingressEventName: EventsEnum,
-  ingressTxMAEvent: TxMAIngressEvent,
+  ingressTxMAEvent: InterventionEventMessage,
   accountStateEngineOutput?: AccountStateEngineOutput,
 ): Promise<SendMessageCommandOutput | undefined> {
   logger.debug('sendAuditEvent function.');
@@ -57,7 +54,9 @@ export async function sendAuditEvent(
     event_timestamp_ms: timestamp.milliseconds,
     component_id: COMPONENT_ID,
     event_name: egressEventName,
-    user: { user_id: ingressTxMAEvent.user.user_id },
+    user: {
+      user_id: ingressTxMAEvent.user.user_id,
+    },
     extensions: buildExtensions(ingressTxMAEvent, ingressEventName, egressEventName, accountStateEngineOutput),
   };
 
@@ -83,7 +82,7 @@ export async function sendAuditEvent(
  * @returns - TxMAEgressExtensions object
  */
 function buildExtensions(
-  txMAIngressEvent: TxMAIngressEvent,
+  txMAIngressEvent: InterventionEventMessage,
   ingressEventName: EventsEnum,
   egressEventName: TxMAEgressInterventionEventName,
   stateEngineOutput: AccountStateEngineOutput | undefined,
@@ -91,8 +90,9 @@ function buildExtensions(
   if (stateEngineOutput) {
     return {
       trigger_event: txMAIngressEvent.event_name,
-      trigger_event_id: txMAIngressEvent.event_id ?? 'UNKNOWN',
-      ...txMAIngressEvent.extensions?.intervention,
+      trigger_event_id: txMAIngressEvent.event_id,
+      ...(txMAIngressEvent.event_name === TriggerEventsEnum.TICF_ACCOUNT_INTERVENTION &&
+        txMAIngressEvent.extensions.intervention),
       description: userLedActionList.includes(ingressEventName)
         ? 'USER_LED_ACTION'
         : stateEngineOutput.interventionName,
@@ -104,8 +104,9 @@ function buildExtensions(
   }
   return {
     trigger_event: txMAIngressEvent.event_name,
-    trigger_event_id: txMAIngressEvent.event_id ?? 'UNKNOWN',
-    ...txMAIngressEvent.extensions?.intervention,
+    trigger_event_id: txMAIngressEvent.event_id,
+    ...(txMAIngressEvent.event_name === TriggerEventsEnum.TICF_ACCOUNT_INTERVENTION &&
+      txMAIngressEvent.extensions.intervention),
   };
 }
 

--- a/src/services/test/send-audit-events.test.ts
+++ b/src/services/test/send-audit-events.test.ts
@@ -15,7 +15,6 @@ import logger from '../../commons/logger';
 import { AppConfigService } from '../app-config-service';
 import { getCurrentTimestamp } from '../../commons/get-current-timestamp';
 import 'aws-sdk-client-mock-vitest/extend';
-import { TxMAIngressEvent } from '../../data-types/interfaces';
 
 vi.mock('@aws-lambda-powertools/logger');
 vi.mock('../../commons/metrics');
@@ -27,14 +26,14 @@ vi.mock('../../commons/get-current-timestamp', () => ({
   })),
 }));
 
-const ingressInterventionEvent: TxMAIngressEvent = {
+const ingressInterventionEvent = {
   component_id: '',
   timestamp: 5,
   event_timestamp_ms: 5000,
   user: {
     user_id: 'testUserId',
   },
-  event_name: TriggerEventsEnum.TICF_ACCOUNT_INTERVENTION,
+  event_name: TriggerEventsEnum.TICF_ACCOUNT_INTERVENTION as const,
   event_id: '123',
   extensions: {
     intervention: {
@@ -44,14 +43,14 @@ const ingressInterventionEvent: TxMAIngressEvent = {
   },
 };
 
-const ingressEventWithExtraInterventionData: TxMAIngressEvent = {
+const ingressEventWithExtraInterventionData = {
   component_id: '',
   timestamp: 5,
   event_timestamp_ms: 5000,
   user: {
     user_id: 'testUserId',
   },
-  event_name: TriggerEventsEnum.TICF_ACCOUNT_INTERVENTION,
+  event_name: TriggerEventsEnum.TICF_ACCOUNT_INTERVENTION as const,
   event_id: '123',
   extensions: {
     intervention: {
@@ -64,7 +63,7 @@ const ingressEventWithExtraInterventionData: TxMAIngressEvent = {
 };
 
 const ingressUserActionEvent = {
-  event_name: TriggerEventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL,
+  event_name: EventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL as const,
   event_id: '123',
   timestamp: 5,
   event_timestamp_ms: 5000,

--- a/src/services/test/validate-event.test.ts
+++ b/src/services/test/validate-event.test.ts
@@ -1,9 +1,8 @@
-import { DynamoDBStateResult, TxMAIngressEvent as TxMAEvent } from '../../data-types/interfaces';
+import { DynamoDBStateResult } from '../../data-types/interfaces';
 import {
   validateEventAgainstSchema,
   validateEventIsNotInFuture,
   validateEventIsNotStale,
-  validateInterventionEvent,
   validateIfIdentityAcquired,
   attemptToParseJson,
 } from '../validate-event';
@@ -13,7 +12,6 @@ import { ValidationError } from '../../data-types/errors';
 import { AISInterventionTypes, EventsEnum, MetricNames, TriggerEventsEnum } from '../../data-types/constants';
 import { sendAuditEvent } from '../send-audit-events';
 import { getCurrentTimestamp } from '../../commons/get-current-timestamp';
-import { InterventionCodeEnum1 } from '@govuk-one-login/event-catalogue/AIS_EVENT_TRANSITION_APPLIED';
 import { TICF_ACCOUNT_INTERVENTION } from '@govuk-one-login/event-catalogue/TICF_ACCOUNT_INTERVENTION';
 
 vi.mock('../../commons/metrics');
@@ -47,7 +45,7 @@ describe('validateEventAgainstSchema', () => {
   });
 
   it('Successfully validate AUTH_PASSWORD_RESET_SUCCESSFUL event', () => {
-    const TxMAEvent: TxMAEvent = {
+    const TxMAEvent = {
       event_timestamp_ms: timestamp.milliseconds - 5000,
       component_id: 'AUTH',
       timestamp: timestamp.seconds - 5,
@@ -83,7 +81,7 @@ describe('validateEventAgainstSchema', () => {
       },
     };
     expect(() => {
-      validateEventAgainstSchema(TxMAEvent as TxMAEvent);
+      validateEventAgainstSchema(TxMAEvent);
     }).not.toThrow();
     expect(addMetric).not.toHaveBeenCalledWith('INVALID_EVENT_RECEIVED_EVENT_CATALOGUE', undefined, undefined, {
       EVENT_NAME: 'TICF_ACCOUNT_INTERVENTION',
@@ -99,10 +97,11 @@ describe('validateEventAgainstSchema', () => {
         user_id: 'abc',
       },
       event_name: TriggerEventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL,
-      // event_id: '123',
+      event_id: '123',
+      blah: 'value',
     };
     expect(() => {
-      validateEventAgainstSchema(TxMAEvent as TxMAEvent);
+      validateEventAgainstSchema(TxMAEvent);
     }).not.toThrow();
     expect(addMetric).toHaveBeenCalledWith('INVALID_EVENT_RECEIVED_EVENT_CATALOGUE', undefined, undefined, {
       EVENT_NAME: 'AUTH_PASSWORD_RESET_SUCCESSFUL',
@@ -117,16 +116,17 @@ describe('validateEventAgainstSchema', () => {
       user: {
         user_id: 'abc',
       },
-      event_name: TriggerEventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL,
+      event_name: TriggerEventsEnum.TICF_ACCOUNT_INTERVENTION,
       event_id: '123',
       extensions: {
         intervention: {
           intervention_reason: 'reason',
+          // Missing required intervention_code
         },
       },
     };
     expect(() => {
-      validateEventAgainstSchema(TxMAEvent as TxMAEvent);
+      validateEventAgainstSchema(TxMAEvent);
     }).toThrow(new ValidationError('Invalid intervention event.'));
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(logger.debug).toHaveBeenCalledWith('Sensitive info - Event has failed schema validation.', {
@@ -148,18 +148,12 @@ describe('validateEventAgainstSchema', () => {
       },
     };
     expect(() => {
-      validateEventAgainstSchema(TxMAEvent as TxMAEvent);
+      validateEventAgainstSchema(TxMAEvent);
     }).toThrow(new ValidationError('Invalid intervention event.'));
-    validateInterventionEvent(TxMAEvent as TxMAEvent);
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(logger.debug).toHaveBeenCalledWith('Sensitive info - Event has failed schema validation.', {
-      validationErrors: expect.anything() as unknown,
-    });
-    expect(addMetric).toHaveBeenCalledWith('INVALID_EVENT_RECEIVED');
   });
 
   it('should return an error as extensions do not contain required fields', () => {
-    const TxMAEvent: TxMAEvent = {
+    const TxMAEvent = {
       event_timestamp_ms: timestamp.milliseconds - 5000,
       component_id: 'AUTH',
       timestamp: timestamp.seconds - 5,
@@ -182,13 +176,13 @@ describe('validateEventAgainstSchema', () => {
     const staleEvent = {
       timestamp: timestamp.seconds - 10,
       event_timestamp_ms: timestamp.milliseconds - 10_000,
-      event_name: TriggerEventsEnum.TICF_ACCOUNT_INTERVENTION,
+      event_name: TriggerEventsEnum.TICF_ACCOUNT_INTERVENTION as const,
       event_id: '123',
       component_id: 'TICF_CRI',
       user: { user_id: 'urn:fdc:gov.uk:2022:USER_ONE' },
       extensions: {
         intervention: {
-          intervention_code: '01' as InterventionCodeEnum1,
+          intervention_code: '01',
           intervention_reason: 'something',
           originating_component_id: 'CMS',
           originator_reference_id: '1234567',
@@ -222,13 +216,13 @@ describe('validateEventAgainstSchema', () => {
     const staleEvent = {
       timestamp: timestamp.seconds - 5000,
       event_timestamp_ms: timestamp.milliseconds - 5000,
-      event_name: TriggerEventsEnum.TICF_ACCOUNT_INTERVENTION,
+      event_name: TriggerEventsEnum.TICF_ACCOUNT_INTERVENTION as const,
       event_id: '123',
       component_id: 'TICF_CRI',
       user: { user_id: 'urn:fdc:gov.uk:2022:USER_ONE' },
       extensions: {
         intervention: {
-          intervention_code: '01' as InterventionCodeEnum1,
+          intervention_code: '01',
           intervention_reason: 'something',
           originating_component_id: 'CMS',
           originator_reference_id: '1234567',
@@ -261,13 +255,14 @@ describe('validateEventAgainstSchema', () => {
   it('should not throw if event is not stale', async () => {
     const nonStaleEvent = {
       timestamp: timestamp.seconds,
-      event_name: TriggerEventsEnum.TICF_ACCOUNT_INTERVENTION,
+      event_timestamp_ms: timestamp.milliseconds,
+      event_name: TriggerEventsEnum.TICF_ACCOUNT_INTERVENTION as const,
       event_id: '123',
       component_id: 'TICF_CRI',
       user: { user_id: 'urn:fdc:gov.uk:2022:USER_ONE' },
       extensions: {
         intervention: {
-          intervention_code: '01' as InterventionCodeEnum1,
+          intervention_code: '01',
           intervention_reason: 'something',
           originating_component_id: 'CMS',
           originator_reference_id: '1234567',
@@ -296,13 +291,14 @@ describe('validateEventAgainstSchema', () => {
   it('should throw an error if event timestamp is in the future', async () => {
     const eventInTheFuture = {
       timestamp: timestamp.seconds + 10,
-      event_name: TriggerEventsEnum.TICF_ACCOUNT_INTERVENTION,
+      event_timestamp_ms: (timestamp.seconds + 10) * 1000,
+      event_name: TriggerEventsEnum.TICF_ACCOUNT_INTERVENTION as const,
       event_id: '123',
       component_id: 'TICF_CRI',
       user: { user_id: 'urn:fdc:gov.uk:2022:USER_ONE' },
       extensions: {
         intervention: {
-          intervention_code: '01' as InterventionCodeEnum1,
+          intervention_code: '01',
           intervention_reason: 'something',
           originating_component_id: 'CMS',
           originator_reference_id: '1234567',
@@ -325,13 +321,13 @@ describe('validateEventAgainstSchema', () => {
     const eventNotInTheFuture = {
       timestamp: timestamp.seconds - 10,
       event_timestamp_ms: timestamp.milliseconds - 10_000,
-      event_name: TriggerEventsEnum.TICF_ACCOUNT_INTERVENTION,
+      event_name: TriggerEventsEnum.TICF_ACCOUNT_INTERVENTION as const,
       event_id: '123',
       component_id: 'TICF_CRI',
       user: { user_id: 'urn:fdc:gov.uk:2022:USER_ONE' },
       extensions: {
         intervention: {
-          intervention_code: '01' as InterventionCodeEnum1,
+          intervention_code: '01',
           intervention_reason: 'something',
           originating_component_id: 'CMS',
           originator_reference_id: '1234567',
@@ -348,8 +344,9 @@ describe('validateEventAgainstSchema', () => {
 
   it('should throw if success is false for a ID Reset event', () => {
     const idResetEventWithoutSuccess = {
-      event_name: TriggerEventsEnum.IPV_ACCOUNT_INTERVENTION_END,
+      event_name: EventsEnum.IPV_ACCOUNT_INTERVENTION_END as const,
       event_id: '123',
+      event_timestamp_ms: 1_234_567_000,
       timestamp: 1_234_567,
       component_id: 'https://identity.account.gov.uk',
       user: {
@@ -364,16 +361,17 @@ describe('validateEventAgainstSchema', () => {
       },
     };
     expect(() => {
-      validateIfIdentityAcquired(EventsEnum.IPV_ACCOUNT_INTERVENTION_END, idResetEventWithoutSuccess);
+      validateIfIdentityAcquired(idResetEventWithoutSuccess);
     }).toThrow(new ValidationError('Received event that does not meet criteria to lift intervention.'));
     expect(addMetric).toHaveBeenCalledWith(MetricNames.IDENTITY_NOT_SUFFICIENTLY_PROVED);
   });
 
   it('should not throw if success is true for a ID Reset event', () => {
     const idResetEvent = {
-      event_name: TriggerEventsEnum.IPV_ACCOUNT_INTERVENTION_END,
+      event_name: EventsEnum.IPV_ACCOUNT_INTERVENTION_END as const,
       event_id: '123',
       timestamp: 1_234_567,
+      event_timestamp_ms: 1_234_567_000,
       client_id: 'UNKNOWN',
       component_id: 'https://identity.account.gov.uk',
       user: {
@@ -388,16 +386,17 @@ describe('validateEventAgainstSchema', () => {
       },
     };
     expect(() => {
-      validateIfIdentityAcquired(EventsEnum.IPV_ACCOUNT_INTERVENTION_END, idResetEvent);
+      validateIfIdentityAcquired(idResetEvent);
     }).not.toThrow();
     expect(addMetric).not.toHaveBeenCalled();
   });
 
   it('should throw if success field is not present in an ID Reset event', () => {
     const idResetEventLowConfidence = {
-      event_name: TriggerEventsEnum.IPV_ACCOUNT_INTERVENTION_END,
+      event_name: EventsEnum.IPV_ACCOUNT_INTERVENTION_END as const,
       event_id: '123',
       timestamp: 1_234_567,
+      event_timestamp_ms: 1_234_567_000,
       client_id: 'UNKNOWN',
       component_id: 'https://identity.account.gov.uk',
       user: {
@@ -411,58 +410,9 @@ describe('validateEventAgainstSchema', () => {
       },
     };
     expect(() => {
-      validateIfIdentityAcquired(EventsEnum.IPV_ACCOUNT_INTERVENTION_END, idResetEventLowConfidence);
+      validateIfIdentityAcquired(idResetEventLowConfidence);
     }).toThrow(new ValidationError('Received event that does not meet criteria to lift intervention.'));
     expect(addMetric).toHaveBeenCalledWith(MetricNames.IDENTITY_NOT_SUFFICIENTLY_PROVED);
-  });
-});
-
-describe('validateInterventionEvent', () => {
-  it('Successfully validate TICF_ACCOUNT_INTERVENTION event', () => {
-    const TxMAEvent: TICF_ACCOUNT_INTERVENTION & { event_id: string } = {
-      event_timestamp_ms: timestamp.milliseconds - 5000,
-      component_id: 'AUTH',
-      timestamp: timestamp.seconds - 5,
-      user: {
-        user_id: 'abc',
-      },
-      event_name: TriggerEventsEnum.TICF_ACCOUNT_INTERVENTION,
-      event_id: '123',
-      extensions: {
-        intervention: {
-          intervention_code: '01',
-          intervention_reason: 'reason',
-        },
-      },
-    };
-    expect(() => {
-      validateInterventionEvent(TxMAEvent as TxMAEvent);
-    }).not.toThrow();
-  });
-
-  it('should return an error as intervention code is NAN', () => {
-    const TxMAEvent: TxMAEvent = {
-      event_timestamp_ms: timestamp.milliseconds - 5000,
-      component_id: 'AUTH',
-      timestamp: timestamp.seconds - 5,
-      user: {
-        user_id: 'abc',
-      },
-      event_name: TriggerEventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL,
-      event_id: '123',
-      extensions: {
-        intervention: {
-          intervention_code: 'nan' as InterventionCodeEnum1,
-          intervention_reason: 'reason',
-        },
-      },
-    };
-    expect(() => {
-      validateInterventionEvent(TxMAEvent);
-    }).toThrow(new ValidationError('Invalid intervention event.'));
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(logger.debug).toHaveBeenCalledWith('Invalid intervention request. Intervention code is NAN');
-    expect(addMetric).toHaveBeenCalledWith('INVALID_EVENT_RECEIVED');
   });
 });
 

--- a/src/services/validate-event.ts
+++ b/src/services/validate-event.ts
@@ -1,17 +1,16 @@
-import { DynamoDBStateResult, StateDetails, TxMAIngressEvent } from '../data-types/interfaces';
+import { DynamoDBStateResult, StateDetails } from '../data-types/interfaces';
 import logger from '../commons/logger';
 import { addMetric } from '../commons/metrics';
 import { AISInterventionTypes, EventsEnum, LOGS_PREFIX_SENSITIVE_INFO, MetricNames } from '../data-types/constants';
 import { RetryEventError, ValidationError } from '../data-types/errors';
-import { compileSchema, compileSchema2019 } from '../commons/compile-schema';
-import { TxMAIngress } from '../data-types/schemas';
+import { compileSchema2019 } from '../commons/compile-schema';
 import { EventCatalogueCombinedSchema } from '../data-types/event-catalogue-combined-schema';
 import { getCurrentTimestamp } from '../commons/get-current-timestamp';
 import { sendAuditEvent } from './send-audit-events';
 import { AccountStateEngine } from './account-states/account-state-engine';
 import jsonSafeParse from '../commons/json-safe-parse';
+import { InterventionEventMessage, interventionMessageSchema } from '../contracts/intervention-events';
 
-const validateInterventionDataInput = compileSchema(TxMAIngress);
 const validateEventCatalogue = compileSchema2019(EventCatalogueCombinedSchema);
 
 /**
@@ -19,38 +18,28 @@ const validateEventCatalogue = compileSchema2019(EventCatalogueCombinedSchema);
  *
  * @param interventionRequest - the TxMA request
  */
-export function validateEventAgainstSchema(interventionRequest: TxMAIngressEvent): void {
-  if (!validateInterventionDataInput({ event: interventionRequest })) {
+export function validateEventAgainstSchema(interventionRequest: unknown) {
+  // Validate with Zod
+  const result = interventionMessageSchema.safeParse(interventionRequest);
+  if (!result.success) {
     logger.debug(`${LOGS_PREFIX_SENSITIVE_INFO} Event has failed schema validation.`, {
-      validationErrors: validateInterventionDataInput.errors,
+      validationErrors: result.error,
     });
     addMetric(MetricNames.INVALID_EVENT_RECEIVED);
     throw new ValidationError('Invalid intervention event.');
   }
 
-  const eventName = interventionRequest.event_name;
-
+  // Validate against event catalogue JSON schema
   if (!validateEventCatalogue(interventionRequest)) {
     logger.info(`${LOGS_PREFIX_SENSITIVE_INFO} Event has failed event catalogue schema validation.`, {
       validationErrors: validateEventCatalogue.errors,
     });
     addMetric(MetricNames.INVALID_EVENT_RECEIVED_EVENT_CATALOGUE, undefined, undefined, {
-      EVENT_NAME: eventName,
+      EVENT_NAME: result.data.event_name,
     });
   }
-}
 
-/**
- * A function to perform validation on intervention code
- *
- * @param interventionRequest - the TxMA event
- */
-export function validateInterventionEvent(interventionRequest: TxMAIngressEvent): void {
-  if (Number.isNaN(Number.parseInt(interventionRequest.extensions?.intervention?.intervention_code ?? ''))) {
-    logger.debug('Invalid intervention request. Intervention code is NAN');
-    addMetric(MetricNames.INVALID_EVENT_RECEIVED);
-    throw new ValidationError('Invalid intervention event.');
-  }
+  return result.data;
 }
 
 /**
@@ -59,11 +48,11 @@ export function validateInterventionEvent(interventionRequest: TxMAIngressEvent)
  * @param event - the event received
  * @throws ValidationError - if the status is undefined or not as expected
  */
-export function validateIfIdentityAcquired(intervention: EventsEnum, event: TxMAIngressEvent) {
-  if (intervention === EventsEnum.IPV_ACCOUNT_INTERVENTION_END && event.extensions?.success !== true) {
+export function validateIfIdentityAcquired(event: InterventionEventMessage) {
+  if (event.event_name === EventsEnum.IPV_ACCOUNT_INTERVENTION_END && event.extensions.success !== true) {
     logger.warn('Received event that does not meet criteria to lift intervention.', {
-      success: event.extensions?.success,
-      type: event.extensions?.type,
+      success: event.extensions.success,
+      type: event.extensions.type,
     });
     addMetric(MetricNames.IDENTITY_NOT_SUFFICIENTLY_PROVED);
     throw new ValidationError('Received event that does not meet criteria to lift intervention.');
@@ -76,8 +65,8 @@ export function validateIfIdentityAcquired(intervention: EventsEnum, event: TxMA
  * @param event - the event received
  * @throws RetryEventError - if the timestamp of the event is in the future
  */
-export async function validateEventIsNotInFuture(eventEnum: EventsEnum, event: TxMAIngressEvent) {
-  const eventTimestampInMs = event.event_timestamp_ms ?? event.timestamp * 1000;
+export async function validateEventIsNotInFuture(eventEnum: EventsEnum, event: InterventionEventMessage) {
+  const eventTimestampInMs = event.event_timestamp_ms;
   const now = getCurrentTimestamp().milliseconds;
   if (now < eventTimestampInMs) {
     logger.warn('Event with timestamp in the future.', {
@@ -103,11 +92,11 @@ export async function validateEventIsNotInFuture(eventEnum: EventsEnum, event: T
  */
 export async function validateEventIsNotStale(
   intervention: EventsEnum,
-  event: TxMAIngressEvent,
+  event: InterventionEventMessage,
   initialState: StateDetails,
   itemFromDB: DynamoDBStateResult,
 ) {
-  const eventTimestampInMs = event.event_timestamp_ms ?? event.timestamp * 1000;
+  const eventTimestampInMs = event.event_timestamp_ms;
   if (!isEventAfterLastEvent(eventTimestampInMs, itemFromDB.sentAt, itemFromDB.appliedAt)) {
     logger.warn('Event received predates last applied event for this user.');
     addMetric(MetricNames.INTERVENTION_EVENT_STALE);


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Switch intervention processor to Zod validation

## Why

Follows our ADR.

Easily gives good typescript types

## Notes

Relies on refactors in https://github.com/govuk-one-login/account-interventions-service/pull/949

I have updated the contract tests to provide some required fields, these are marked as required in the event catalogue.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-8078](https://govukverify.atlassian.net/browse/FPAD-8078)

[FPAD-8078]: https://govukverify.atlassian.net/browse/FPAD-8078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ