### PR TITLE
Set log level to info for INVALID_EVENT_RECEIVED_EVENT_CATALOGUE

### DIFF
--- a/src/handlers/account-deletion-processor-handler.ts
+++ b/src/handlers/account-deletion-processor-handler.ts
@@ -74,7 +74,7 @@ function parseMessage(record: SQSRecord): string {
     );
 
   if (!validateEventCatalogue(recordBodyResult.data)) {
-    logger.debug(`${LOGS_PREFIX_SENSITIVE_INFO} Event has failed event catalogue schema validation.`, {
+    logger.info(`${LOGS_PREFIX_SENSITIVE_INFO} Event has failed event catalogue schema validation.`, {
       validationErrors: validateEventCatalogue.errors,
     });
     addMetric(MetricNames.INVALID_EVENT_RECEIVED_EVENT_CATALOGUE, undefined, undefined, {

--- a/src/services/validate-event.ts
+++ b/src/services/validate-event.ts
@@ -30,7 +30,7 @@ export function validateEventAgainstSchema(interventionRequest: TxMAIngressEvent
   const eventName = interventionRequest.event_name;
 
   if (!validateEventCatalogue(interventionRequest)) {
-    logger.debug(`${LOGS_PREFIX_SENSITIVE_INFO} Event has failed event catalogue schema validation.`, {
+    logger.info(`${LOGS_PREFIX_SENSITIVE_INFO} Event has failed event catalogue schema validation.`, {
       validationErrors: validateEventCatalogue.errors,
     });
     addMetric(MetricNames.INVALID_EVENT_RECEIVED_EVENT_CATALOGUE, undefined, undefined, {


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Set log level to info for INVALID_EVENT_RECEIVED_EVENT_CATALOGUE

## Why

So they show in the production environment

## Notes

Can probably put back later
