### PR TITLE
FPAD-8080: Fixes for event catalogue schema validation

### DIFF
--- a/src/commons/compile-schema.ts
+++ b/src/commons/compile-schema.ts
@@ -18,7 +18,7 @@ interface Schema {
   required: string[];
 }
 
-const addEventMetadataToSchema = (schema: Schema, eventName: string) => ({
+export const addEventMetadataToSchema = (schema: Schema, eventName: string) => ({
   ...schema,
   required: [...schema.required, 'event_id'],
   properties: {
@@ -29,6 +29,9 @@ const addEventMetadataToSchema = (schema: Schema, eventName: string) => ({
     },
     event_id: {
       type: 'string',
+    },
+    txma: {
+      type: 'object',
     },
   },
 });

--- a/src/handlers/account-deletion-processor-handler.ts
+++ b/src/handlers/account-deletion-processor-handler.ts
@@ -9,10 +9,13 @@ import { accountDeleteMessageSchema } from '../contracts/account-delete-message'
 import { prettifyError } from 'zod';
 import jsonSafeParse from '../commons/json-safe-parse';
 import { AUTH_DELETE_ACCOUNTSchema } from '@govuk-one-login/event-catalogue-schemas';
+import { addEventMetadataToSchema } from '../commons/compile-schema';
 
 const ajv2019 = new Ajv2019({ allErrors: true });
 
-const validateEventCatalogue = ajv2019.compile(AUTH_DELETE_ACCOUNTSchema);
+const validateEventCatalogue = ajv2019.compile(
+  addEventMetadataToSchema(AUTH_DELETE_ACCOUNTSchema, 'AUTH_DELETE_ACCOUNT'),
+);
 
 enum ParserErrorType {
   BODY_JSON_PARSER_ERROR = 'BODY_JSON_PARSER_ERROR',

--- a/src/handlers/tests/account-deletion-processor-handler.test.ts
+++ b/src/handlers/tests/account-deletion-processor-handler.test.ts
@@ -215,6 +215,7 @@ describe('Account Deletion Processor', () => {
         client_id: 'client_id',
         event_name: 'AUTH_DELETE_ACCOUNT',
         component_id: 'AUTH',
+        event_id: '1234',
         // eslint-disable-next-line unicorn/numeric-separators-style
         event_timestamp_ms: 1722953808667,
         extensions: {


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Fixes for event catalogue schema validation

- Accept txma property
- Update delete schema to include event_id etc.

## Why

This should resolve our validation errors

## Notes

There are changes to TxMA self serve https://github.com/govuk-one-login/txma-event-self-serve/pull/1041 which are required before the deletion processor validation will pass.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-8080](https://govukverify.atlassian.net/browse/FPAD-8080)

[FPAD-8080]: https://govukverify.atlassian.net/browse/FPAD-8080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ