### PR TITLE
FPAD-8138: Typed table service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@aws-lambda-powertools/tracer": "^2.33.1",
         "@aws-sdk/client-dynamodb": "^3.1057.0",
         "@aws-sdk/client-sqs": "^3.1057.0",
+        "@aws-sdk/lib-dynamodb": "^3.1063.0",
         "@aws-sdk/util-dynamodb": "^3.996.0",
         "@babel/helpers": "^7.26.10",
         "@govuk-one-login/event-catalogue-schemas": "^44.0.22",
@@ -280,22 +281,22 @@
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.1057.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1057.0.tgz",
-      "integrity": "sha512-S0feh4mSWsqxQ8SGWIqAX5CQ9w+wBFxpNx4QVNy4rfQVMY6PvPuWT6kolfIHqMoIvuVGd9zD71BvzCK3CHip8Q==",
+      "version": "3.1063.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1063.0.tgz",
+      "integrity": "sha512-RH5PM9lJsGgTDYyIjhPIqwRTuIZdVzRfEdLWB9/p11VVoDjQ+itbzZ7Qi/KMaw6AucAo8uXxnlVp1fZ0cVQjuA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.15",
-        "@aws-sdk/credential-provider-node": "^3.972.47",
-        "@aws-sdk/dynamodb-codec": "^3.973.15",
-        "@aws-sdk/middleware-endpoint-discovery": "^3.972.15",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.5",
-        "@smithy/fetch-http-handler": "^5.4.5",
-        "@smithy/node-http-handler": "^4.7.5",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/credential-provider-node": "^3.972.52",
+        "@aws-sdk/dynamodb-codec": "^3.973.18",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.17",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -564,6 +565,25 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/lib-dynamodb": {
+      "version": "3.1063.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1063.0.tgz",
+      "integrity": "sha512-3vXZzmYUe1k0vswOByKuLNQuB4TBu4L6IajHGFbas4I+z6Kaw875FwJLvoc6oSogvowo84Z/5rmB+5u0DX+DKw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/util-dynamodb": "^3.996.3",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1063.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
       "version": "3.972.17",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.17.tgz",
@@ -662,9 +682,9 @@
       }
     },
     "node_modules/@aws-sdk/util-dynamodb": {
-      "version": "3.996.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.996.2.tgz",
-      "integrity": "sha512-ddpwaZmjBzcApYN7lgtAXjk+u+GO8fiPsxzuc59UqP+zqdxI1gsenPvkyiHiF9LnYnyRGijz6oN2JylnN561qQ==",
+      "version": "3.996.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.996.3.tgz",
+      "integrity": "sha512-vLTbeDu000/6OvdjSL3J549WmRU9R5a/HIR6xhFDK682D74c3cYCYmnvDjGOtHfQL3c8RChFulbK2n3pxNPXyA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -673,7 +693,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-dynamodb": "^3.1003.0"
+        "@aws-sdk/client-dynamodb": "^3.1063.0"
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@aws-lambda-powertools/tracer": "^2.33.1",
     "@aws-sdk/client-dynamodb": "^3.1057.0",
     "@aws-sdk/client-sqs": "^3.1057.0",
+    "@aws-sdk/lib-dynamodb": "^3.1063.0",
     "@aws-sdk/util-dynamodb": "^3.996.0",
     "@babel/helpers": "^7.26.10",
     "@govuk-one-login/event-catalogue-schemas": "^44.0.22",

--- a/src/handlers/interventions-processor-handler.ts
+++ b/src/handlers/interventions-processor-handler.ts
@@ -26,6 +26,7 @@ import { sendAuditEvent } from '../services/send-audit-events';
 import { buildPartialUpdateAccountStateCommand } from '../commons/build-partial-update-state-command';
 import { publishTimeToResolveMetrics, updateAccountStateCountMetric } from '../commons/metrics-helper';
 import { InterventionEventMessage } from '../contracts/intervention-events';
+import { getPersistentInterventionEventsService, InterventionEventsService } from '../tables/intervention-events';
 
 const appConfig = AppConfigService.getInstance();
 const service = new DynamoDatabaseService(appConfig.tableName);
@@ -38,7 +39,11 @@ const accountStateEngine = AccountStateEngine.getInstance();
  * @param context - context object
  * @returns - Promise of SQS Partial Batch Response
  */
-export async function handler(event: SQSEvent, context: Context): Promise<SQSBatchResponse> {
+export async function handler(
+  event: SQSEvent,
+  context: Context,
+  interventionEventsService: InterventionEventsService = getPersistentInterventionEventsService(),
+): Promise<SQSBatchResponse> {
   logger.addContext(context);
 
   if (event.Records.length === 0) {
@@ -53,7 +58,7 @@ export async function handler(event: SQSEvent, context: Context): Promise<SQSBat
   const itemFailures: SQSBatchItemFailure[] = [];
 
   const promiseArray = event.Records.map((record: SQSRecord) =>
-    processSQSRecord(record).catch((error: unknown) => {
+    processSQSRecord(record, interventionEventsService).catch((error: unknown) => {
       const itemIdentifier = handleError(error, record);
       if (itemIdentifier) itemFailures.push({ itemIdentifier });
     }),
@@ -72,7 +77,7 @@ export async function handler(event: SQSEvent, context: Context): Promise<SQSBat
  * it updates the user record in the database, it sends a notification upon completion
  * @param record - SQS Record polled from the queue
  */
-async function processSQSRecord(record: SQSRecord) {
+async function processSQSRecord(record: SQSRecord, interventionEventsService: InterventionEventsService) {
   const currentTimestamp = getCurrentTimestamp();
 
   const recordBody = attemptToParseJson(record.body);
@@ -114,6 +119,11 @@ async function processSQSRecord(record: SQSRecord) {
   updateAccountStateCountMetric(currentAccountState, statusResult.stateResult);
   addMetric(MetricNames.INTERVENTION_EVENT_APPLIED, [], 1, { eventName: eventName.toString() });
   await sendAuditEvent('AIS_EVENT_TRANSITION_APPLIED', eventName, result, statusResult);
+
+  const existingInterventionEvents = await interventionEventsService.fetchEventsForAccount(userId);
+  logger.debug(
+    `${LOGS_PREFIX_SENSITIVE_INFO} Fetched existingInterventionEvents ${JSON.stringify(existingInterventionEvents)}`,
+  );
 }
 
 async function validateRecord(recordBody: unknown) {

--- a/src/handlers/tests/interventions-processor-handler.test.ts
+++ b/src/handlers/tests/interventions-processor-handler.test.ts
@@ -12,6 +12,7 @@ import { AISInterventionTypes, EventsEnum, MetricNames, TriggerEventsEnum } from
 import { sendAuditEvent } from '../../services/send-audit-events';
 import { publishTimeToResolveMetrics } from '../../commons/metrics-helper';
 import { InterventionEventMessage, TicfAccountIntervention } from '../../contracts/intervention-events';
+import { InMemoryInterventionEventsService } from '../../tables/intervention-events';
 
 vi.mock('@aws-lambda-powertools/logger');
 vi.mock('../../commons/metrics');
@@ -92,6 +93,9 @@ const mockValidateEventAgainstSchema = vi.spyOn(validationModule, 'validateEvent
 
 const accountStateEngine = AccountStateEngine.getInstance();
 accountStateEngine.getInterventionEnumFromCode = vi.fn().mockImplementation(() => EventsEnum.FRAUD_BLOCK_ACCOUNT);
+
+const emptyInterventionEventsService = new InMemoryInterventionEventsService([]);
+
 describe('intervention processor handler', () => {
   let mockEvent: SQSEvent;
   let mockRecord: SQSRecord;
@@ -151,7 +155,7 @@ describe('intervention processor handler', () => {
   describe('handle', () => {
     it('does nothing if SQS event contains no record', async () => {
       const loggerWarnSpy = vi.spyOn(logger, 'warn');
-      await handler({ Records: [] }, mockContext);
+      await handler({ Records: [] }, mockContext, emptyInterventionEventsService);
       expect(loggerWarnSpy).toHaveBeenCalledWith('Received no records.');
       expect(addMetric).toHaveBeenCalledWith('INVALID_EVENT_RECEIVED');
       expect(publishTimeToResolveMetrics).not.toHaveBeenCalled();
@@ -159,7 +163,7 @@ describe('intervention processor handler', () => {
 
     it('should not retry if message body cannot be parsed to valid JSON', async () => {
       mockRecord.body = ' ';
-      expect(await handler(mockEvent, mockContext)).toEqual({
+      expect(await handler(mockEvent, mockContext, emptyInterventionEventsService)).toEqual({
         batchItemFailures: [],
       });
       // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -188,7 +192,7 @@ describe('intervention processor handler', () => {
           interventionName: AISInterventionTypes.AIS_NO_INTERVENTION,
         });
       });
-      expect(await handler(mockEvent, mockContext)).toEqual({
+      expect(await handler(mockEvent, mockContext, emptyInterventionEventsService)).toEqual({
         batchItemFailures: [],
       });
       // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -224,7 +228,7 @@ describe('intervention processor handler', () => {
         interventionName: EventsEnum.FRAUD_BLOCK_ACCOUNT,
         nextAllowableInterventions: [],
       });
-      expect(await handler(mockEvent, mockContext)).toEqual({
+      expect(await handler(mockEvent, mockContext, emptyInterventionEventsService)).toEqual({
         batchItemFailures: [],
       });
       expect(sendAuditEvent).toHaveBeenLastCalledWith(
@@ -261,7 +265,7 @@ describe('intervention processor handler', () => {
         interventionName: EventsEnum.FRAUD_BLOCK_ACCOUNT,
         nextAllowableInterventions: [],
       });
-      expect(await handler(mockEvent, mockContext)).toEqual({
+      expect(await handler(mockEvent, mockContext, emptyInterventionEventsService)).toEqual({
         batchItemFailures: [],
       });
       expect(sendAuditEvent).toHaveBeenLastCalledWith(
@@ -299,7 +303,7 @@ describe('intervention processor handler', () => {
       });
       mockRecord.body = JSON.stringify(resetPasswordEventBody);
       mockEvent.Records = [mockRecord];
-      expect(await handler(mockEvent, mockContext)).toEqual({
+      expect(await handler(mockEvent, mockContext, emptyInterventionEventsService)).toEqual({
         batchItemFailures: [],
       });
       expect(sendAuditEvent).toHaveBeenLastCalledWith(
@@ -342,7 +346,7 @@ describe('intervention processor handler', () => {
         suspended: false,
         isAccountDeleted: true,
       });
-      expect(await handler(mockEvent, mockContext)).toEqual({
+      expect(await handler(mockEvent, mockContext, emptyInterventionEventsService)).toEqual({
         batchItemFailures: [],
       });
       expect(addMetric).toHaveBeenLastCalledWith(MetricNames.ACCOUNT_IS_MARKED_AS_DELETED);
@@ -374,7 +378,7 @@ describe('intervention processor handler', () => {
       mockValidateEventAgainstSchema.mockReturnValueOnce(interventionEventBodyInTheFuture);
 
       mockRecord.body = JSON.stringify(interventionEventBodyInTheFuture);
-      expect(await handler({ Records: [mockRecord] }, mockContext)).toEqual({
+      expect(await handler({ Records: [mockRecord] }, mockContext, emptyInterventionEventsService)).toEqual({
         batchItemFailures: [
           {
             itemIdentifier: '123',
@@ -402,7 +406,7 @@ describe('intervention processor handler', () => {
       mockValidateEventAgainstSchema.mockImplementationOnce(() => {
         throw new ValidationError('invalid event');
       });
-      expect(await handler(mockEvent, mockContext)).toEqual({
+      expect(await handler(mockEvent, mockContext, emptyInterventionEventsService)).toEqual({
         batchItemFailures: [],
       });
       expect(publishTimeToResolveMetrics).not.toHaveBeenCalled();
@@ -410,7 +414,7 @@ describe('intervention processor handler', () => {
 
     it('should return message id to be retried if dynamo db operation fails', async () => {
       mockRetrieveRecords.mockRejectedValue(new Error('Error'));
-      expect(await handler(mockEvent, mockContext)).toEqual({
+      expect(await handler(mockEvent, mockContext, emptyInterventionEventsService)).toEqual({
         batchItemFailures: [
           {
             itemIdentifier: '123',
@@ -432,7 +436,7 @@ describe('intervention processor handler', () => {
         appliedAt: t0ms + 10,
         sentAt: t0ms + 10000,
       });
-      expect(await handler({ Records: [mockRecord] }, mockContext)).toEqual({
+      expect(await handler({ Records: [mockRecord] }, mockContext, emptyInterventionEventsService)).toEqual({
         batchItemFailures: [],
       });
       // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -503,7 +507,7 @@ describe('intervention processor handler', () => {
         interventionName: AISInterventionTypes.AIS_FORCED_USER_PASSWORD_RESET,
         nextAllowableInterventions: [],
       });
-      expect(await handler({ Records: [mockRecord] }, mockContext)).toEqual({
+      expect(await handler({ Records: [mockRecord] }, mockContext, emptyInterventionEventsService)).toEqual({
         batchItemFailures: [],
       });
       expect(publishTimeToResolveMetrics).toHaveBeenCalledTimes(1);
@@ -511,7 +515,7 @@ describe('intervention processor handler', () => {
 
     it('should not retry if too many items are returned', async () => {
       mockRetrieveRecords.mockRejectedValueOnce(new TooManyRecordsError('Too many records'));
-      expect(await handler(mockEvent, mockContext)).toEqual({
+      expect(await handler(mockEvent, mockContext, emptyInterventionEventsService)).toEqual({
         batchItemFailures: [],
       });
       // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -552,7 +556,7 @@ describe('intervention processor handler', () => {
         eventSourceARN: '',
         awsRegion: '',
       };
-      expect(await handler({ Records: [mockRecord] }, mockContext)).toEqual({
+      expect(await handler({ Records: [mockRecord] }, mockContext, emptyInterventionEventsService)).toEqual({
         batchItemFailures: [],
       });
       expect(addMetric).toHaveBeenCalledWith('IDENTITY_NOT_SUFFICIENTLY_PROVED');
@@ -566,7 +570,7 @@ describe('intervention processor handler', () => {
 
     it('should log the expected error line when a message is retried - this line is used by a metric filter for canary deployment alarm', async () => {
       mockRetrieveRecords.mockRejectedValue(new Error('Error'));
-      await handler(mockEvent, mockContext);
+      await handler(mockEvent, mockContext, emptyInterventionEventsService);
       expect(publishTimeToResolveMetrics).not.toHaveBeenCalled();
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(logger.error).toHaveBeenCalledWith('Error caught, message will be retried.', { errorMessage: 'Error' });

--- a/src/services/app-config-service.ts
+++ b/src/services/app-config-service.ts
@@ -27,6 +27,10 @@ export class AppConfigService {
     return this.validateConfiguration('TABLE_NAME');
   }
 
+  public get interventionEventsTableName(): string {
+    return this.validateConfiguration('INTERVENTION_EVENTS_TABLE_NAME');
+  }
+
   public get cloudWatchMetricsWorkSpace(): string {
     return this.validateConfiguration('CLOUDWATCH_METRICS_NAMESPACE');
   }

--- a/src/services/db-client.ts
+++ b/src/services/db-client.ts
@@ -1,0 +1,26 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import tracer from '../commons/tracer';
+import { AppConfigService } from './app-config-service';
+import { NodeHttpHandler } from '@smithy/node-http-handler';
+import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+export { DynamoDBClient as DbClient } from '@aws-sdk/client-dynamodb';
+
+let dbClient: DynamoDBClient | undefined;
+let dbDocClient: DynamoDBDocumentClient | undefined;
+
+export function getDBClient(): DynamoDBClient {
+  dbClient ??= tracer.captureAWSv3Client(
+    new DynamoDBClient({
+      region: AppConfigService.getInstance().awsRegion,
+      maxAttempts: 2,
+      requestHandler: new NodeHttpHandler({ requestTimeout: 5000 }),
+    }),
+  );
+  return dbClient;
+}
+
+export function getDBDocClient(): DynamoDBDocumentClient {
+  dbDocClient ??= DynamoDBDocumentClient.from(getDBClient());
+
+  return dbDocClient;
+}

--- a/src/services/dynamo-db-record-service.ts
+++ b/src/services/dynamo-db-record-service.ts
@@ -1,0 +1,60 @@
+import { z, ZodArray, ZodObject, ZodRawShape } from 'zod';
+import { BatchWriteCommand, DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import TableConfig from '../tables/table-config';
+
+type ArrayFromT<T extends ZodObject<ZodRawShape>> = z.infer<z.ZodArray<T>>;
+
+export interface RecordService<T extends ZodObject<ZodRawShape>> {
+  queryByPkAndValidate(partionKeyValue: string): Promise<ArrayFromT<T>>;
+  batchWrite(input: ArrayFromT<T>): Promise<void>;
+}
+
+export class DynamoDBRecordService<
+  T extends ZodObject<ZodRawShape> = ZodObject<ZodRawShape>,
+> implements RecordService<T> {
+  readonly arraySchema: ZodArray<T>;
+
+  public constructor(
+    readonly config: TableConfig<T>,
+    readonly dbClient: DynamoDBDocumentClient,
+  ) {
+    this.arraySchema = z.array(config.schema);
+  }
+
+  async queryByPkAndValidate(partionKeyValue: string): Promise<ArrayFromT<T>> {
+    const results = await this.dbClient.send(
+      new QueryCommand({
+        TableName: this.config.tableName,
+        KeyConditionExpression: `#${this.config.partitionKeyName} = :pk`,
+        ExpressionAttributeNames: { '#pk': 'pk' },
+        ExpressionAttributeValues: { ':pk': partionKeyValue },
+      }),
+    );
+
+    return this.arraySchema.parse(results.Items ?? []);
+  }
+
+  async batchWrite(input: ArrayFromT<T>): Promise<void> {
+    await this.dbClient.send(
+      new BatchWriteCommand({
+        RequestItems: {
+          [this.config.tableName]: input.map((item) => ({
+            PutRequest: { Item: item },
+          })),
+        },
+      }),
+    );
+  }
+}
+
+export class InMemoryRecordService<T extends ZodObject<ZodRawShape>> implements RecordService<T> {
+  constructor(readonly results: ArrayFromT<T>) {}
+
+  queryByPkAndValidate(): Promise<ArrayFromT<T>> {
+    return Promise.resolve(this.results);
+  }
+
+  batchWrite(): Promise<void> {
+    return Promise.resolve();
+  }
+}

--- a/src/services/test/dynamo-db-record-service.test.ts
+++ b/src/services/test/dynamo-db-record-service.test.ts
@@ -1,0 +1,115 @@
+import z from 'zod';
+import TableConfig from '../../tables/table-config';
+import { DynamoDBRecordService } from '../dynamo-db-record-service';
+import { BatchWriteCommand, DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { mockClient } from 'aws-sdk-client-mock';
+import 'aws-sdk-client-mock-vitest/extend';
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+const schema = z.object({
+  pk1: z.string(),
+});
+
+const tableConfig: TableConfig<typeof schema> = {
+  tableName: 'test-table',
+  partitionKeyName: 'pk1',
+  schema,
+};
+
+beforeEach(() => {
+  ddbMock.reset();
+});
+
+describe('DynamoDBRecordService', () => {
+  test('queryByPkAndValidate', async () => {
+    ddbMock.on(QueryCommand).resolves({
+      Items: [
+        {
+          pk1: 'value1',
+        },
+      ],
+    });
+
+    const service = new DynamoDBRecordService<typeof schema>(tableConfig, ddbMock as unknown as DynamoDBDocumentClient);
+
+    const res = await service.queryByPkAndValidate('key_value_1');
+
+    expect(res).toEqual([
+      {
+        pk1: 'value1',
+      },
+    ]);
+
+    expect(ddbMock).toHaveReceivedCommandWith(QueryCommand, {
+      TableName: 'test-table',
+      KeyConditionExpression: '#pk1 = :pk',
+      ExpressionAttributeNames: { '#pk': 'pk' },
+      ExpressionAttributeValues: { ':pk': 'key_value_1' },
+    });
+  });
+
+  test('queryByPkAndValidate empty', async () => {
+    ddbMock.on(QueryCommand).resolves({
+      Items: [],
+    });
+
+    const service = new DynamoDBRecordService<typeof schema>(tableConfig, ddbMock as unknown as DynamoDBDocumentClient);
+
+    const res = await service.queryByPkAndValidate('key_value_1');
+
+    expect(res).toEqual([]);
+
+    expect(ddbMock).toHaveReceivedCommandWith(QueryCommand, {
+      TableName: 'test-table',
+      KeyConditionExpression: '#pk1 = :pk',
+      ExpressionAttributeNames: { '#pk': 'pk' },
+      ExpressionAttributeValues: { ':pk': 'key_value_1' },
+    });
+  });
+
+  test('queryByPkAndValidate no Items', async () => {
+    ddbMock.on(QueryCommand).resolves({
+      Items: undefined,
+    });
+
+    const service = new DynamoDBRecordService<typeof schema>(tableConfig, ddbMock as unknown as DynamoDBDocumentClient);
+
+    const res = await service.queryByPkAndValidate('key_value_1');
+
+    expect(res).toEqual([]);
+
+    expect(ddbMock).toHaveReceivedCommandWith(QueryCommand, {
+      TableName: 'test-table',
+      KeyConditionExpression: '#pk1 = :pk',
+      ExpressionAttributeNames: { '#pk': 'pk' },
+      ExpressionAttributeValues: { ':pk': 'key_value_1' },
+    });
+  });
+
+  test('batchWrite', async () => {
+    ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+    const service = new DynamoDBRecordService<typeof schema>(tableConfig, ddbMock as unknown as DynamoDBDocumentClient);
+
+    await service.batchWrite([
+      {
+        pk1: 'value1',
+      },
+    ]);
+
+    expect(ddbMock).toHaveReceivedCommandWith(BatchWriteCommand, {
+      RequestItems: {
+        'test-table': [
+          {
+            PutRequest: {
+              Item: {
+                pk1: 'value1',
+              },
+            },
+          },
+        ],
+      },
+    });
+  });
+});

--- a/src/tables/intervention-events.ts
+++ b/src/tables/intervention-events.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod';
+import { AppConfigService } from '../services/app-config-service';
+import { DynamoDBRecordService, RecordService } from '../services/dynamo-db-record-service';
+import TableConfig from './table-config';
+import { getDBDocClient } from '../services/db-client';
+
+const appConfig = AppConfigService.getInstance();
+
+export enum InterventionState {
+  ACTIVE = 'ACTIVE',
+  IGNORED = 'IGNORED',
+  SUPERSEDED = 'SUPERSEDED',
+  MITIGATED = 'MITIGATED',
+  REMOVED = 'REMOVED',
+}
+
+export enum InterventionName {
+  PERMENANT_SUSPENSION = 'PERMENANT_SUSPENSION',
+  TEMPORARY_SUSPENSION = 'TEMPORARY_SUSPENSION',
+  RESET_PASSWORD = 'RESET_PASSWORD', //pragma: allowlist secret
+  REPROVE_IDENTITY = 'REPROVE_IDENTITY',
+}
+
+const schema = z.object({
+  eventId: z.string(),
+  accountId: z.string(),
+  interventionId: z.string(),
+  createdAt: z.number(),
+  interventionState: z.enum(InterventionState),
+  interventionName: z.enum(InterventionName),
+  interventionReason: z.string(),
+  sentAt: z.number(),
+  componentId: z.string(),
+  originatingComponentId: z.string().optional(),
+  requesterId: z.string().optional(),
+  originatorReferenceId: z.union([z.string(), z.array(z.string())]).optional(),
+  ttl: z.number().optional(),
+});
+
+export const interventionEventsTableConfig: TableConfig<typeof schema> = {
+  tableName: appConfig.interventionEventsTableName,
+  partitionKeyName: 'accountId',
+  schema,
+};
+
+export type InterventionEvent = z.infer<typeof schema>;
+
+export interface InterventionEventsService {
+  fetchEventsForAccount(accountId: string): Promise<InterventionEvent[]>;
+}
+
+export class InMemoryInterventionEventsService implements InterventionEventsService {
+  constructor(readonly events: InterventionEvent[]) {}
+
+  fetchEventsForAccount() {
+    return Promise.resolve(this.events);
+  }
+}
+
+export class PersistentInterventionEventsService implements InterventionEventsService {
+  constructor(private readonly recordService: RecordService<typeof schema>) {}
+
+  fetchEventsForAccount(accountId: string) {
+    return this.recordService.queryByPkAndValidate(accountId);
+  }
+}
+
+export const getPersistentInterventionEventsService = (): PersistentInterventionEventsService =>
+  new PersistentInterventionEventsService(new DynamoDBRecordService(interventionEventsTableConfig, getDBDocClient()));

--- a/src/tables/table-config.ts
+++ b/src/tables/table-config.ts
@@ -1,0 +1,9 @@
+import { ZodObject, ZodRawShape } from 'zod';
+
+interface TableConfig<T extends ZodObject<ZodRawShape>> {
+  tableName: string;
+  partitionKeyName: string;
+  schema: T;
+}
+
+export default TableConfig;

--- a/src/tables/test/intervention-events.test.ts
+++ b/src/tables/test/intervention-events.test.ts
@@ -1,0 +1,31 @@
+import { InMemoryRecordService } from '../../services/dynamo-db-record-service';
+import {
+  interventionEventsTableConfig,
+  InterventionName,
+  InterventionState,
+  PersistentInterventionEventsService,
+} from '../intervention-events';
+
+describe('PersistentInterventionEventsService', () => {
+  test('fetchEventsForAccount', async () => {
+    const event = {
+      eventId: '1232',
+      accountId: 'abc',
+      interventionId: '13324',
+      createdAt: 1234,
+      interventionState: InterventionState.ACTIVE,
+      interventionName: InterventionName.TEMPORARY_SUSPENSION,
+      interventionReason: 'reason',
+      sentAt: 1234,
+      componentId: 'TEST',
+    };
+
+    const service = new PersistentInterventionEventsService(
+      new InMemoryRecordService<typeof interventionEventsTableConfig.schema>([event]),
+    );
+
+    const res = await service.fetchEventsForAccount('1234');
+
+    expect(res).toEqual([event]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
       CLOUDWATCH_METRICS_NAMESPACE: 'test_namespace',
       METRIC_SERVICE_NAME: 'test',
       TABLE_NAME: 'table_name',
+      INTERVENTION_EVENTS_TABLE_NAME: 'intervention-events',
       AWS_REGION: 'aws_region',
       DELETED_ACCOUNT_RETENTION_SECONDS: '12345',
       TXMA_QUEUE_URL: 'https://sqs.eu-west-2.amazonaws.com/111122223333/TxMAQueue',


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

A new database table class which validates returned rows against a `Zod` schema and gives correctly typed output.

## Why

DynamoDB doesn't have a fixed schema, so we need to handle scenarios where the data is not in the expected format.

## Notes

I have left the `AccountStatus` table as it is for now. 

I have deployed this to the `dev` environment and tested that this logs out correctly.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-8138](https://govukverify.atlassian.net/browse/FPAD-8138)

[FPAD-8138]: https://govukverify.atlassian.net/browse/FPAD-8138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ