### PR TITLE
FPAD-8127: Persist interventions store events

### DIFF
--- a/src/services/persist-intervention-events.ts
+++ b/src/services/persist-intervention-events.ts
@@ -41,6 +41,8 @@ async function persistInterventionEvents(
   const eventsToAppend = generateEventsToAppend(updates, activeInterventions, message);
 
   logger.debug(`${LOGS_PREFIX_SENSITIVE_INFO} Intervention events to add ${JSON.stringify(eventsToAppend)}`);
+
+  await interventionEventsService.appendEvents(eventsToAppend);
 }
 
 /**

--- a/src/services/test/persist-intervention-events.test.ts
+++ b/src/services/test/persist-intervention-events.test.ts
@@ -1,4 +1,3 @@
-import logger from '../../commons/logger';
 import { InterventionEventMessage } from '../../contracts/intervention-events';
 import { EventsEnum, TriggerEventsEnum } from '../../data-types/constants';
 import {
@@ -7,8 +6,6 @@ import {
   InterventionState,
 } from '../../tables/intervention-events';
 import persistInterventionEvents, { generateEventsToAppend } from '../persist-intervention-events';
-
-const loggerDebugSpy = vi.spyOn(logger, 'debug');
 
 const baseMessage: InterventionEventMessage = {
   component_id: 'test',
@@ -26,22 +23,41 @@ const baseMessage: InterventionEventMessage = {
   },
 };
 
-describe('persistInterventionEvents', () => {
-  test('persists a new intervention event when no existing events are present', async () => {
-    await persistInterventionEvents(
-      baseMessage,
-      EventsEnum.FRAUD_SUSPEND_ACCOUNT,
-      undefined,
-      new InMemoryInterventionEventsService([]),
-    );
+const FIXED_TIMESTAMP = 1781253284370;
 
-    expect(loggerDebugSpy).toHaveBeenNthCalledWith(1, 'Sensitive info - Fetched existingInterventionEvents []');
-    expect(loggerDebugSpy).toHaveBeenNthCalledWith(
-      2,
-      expect.stringMatching(
-        /^Sensitive info - Intervention events to add \[{"interventionName":"TEMPORARY_SUSPENSION","interventionState":"ACTIVE","eventId":".+","accountId":"1","createdAt":\d+,"interventionReason":"reason","sentAt":1722953808000,"componentId":"test"}\]$/,
-      ),
-    );
+describe('persistInterventionEvents', () => {
+  beforeAll(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_TIMESTAMP);
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  test('persists a new intervention event when no existing events are present', async () => {
+    const service = new InMemoryInterventionEventsService([]);
+    const fetchEventsSpy = vi.spyOn(service, 'fetchEventsForAccount');
+    const appendEventsSpy = vi.spyOn(service, 'appendEvents');
+
+    await persistInterventionEvents(baseMessage, EventsEnum.FRAUD_SUSPEND_ACCOUNT, undefined, service);
+
+    expect(fetchEventsSpy).toHaveBeenCalledExactlyOnceWith('1');
+    expect(appendEventsSpy).toHaveBeenCalledExactlyOnceWith([
+      {
+        accountId: '1',
+        componentId: 'test',
+        createdAt: FIXED_TIMESTAMP,
+        eventId: expect.any(String) as string,
+        interventionName: 'TEMPORARY_SUSPENSION',
+        interventionReason: 'reason',
+        interventionState: 'ACTIVE',
+        originatingComponentId: undefined,
+        originatorReferenceId: undefined,
+        requesterId: undefined,
+        sentAt: 1722953808000,
+      },
+    ]);
   });
 });
 

--- a/src/tables/intervention-events.ts
+++ b/src/tables/intervention-events.ts
@@ -46,6 +46,7 @@ export type InterventionEvent = z.infer<typeof schema>;
 
 export interface InterventionEventsService {
   fetchEventsForAccount(accountId: string): Promise<InterventionEvent[]>;
+  appendEvents(events: InterventionEvent[]): Promise<void>;
 }
 
 export class InMemoryInterventionEventsService implements InterventionEventsService {
@@ -54,6 +55,10 @@ export class InMemoryInterventionEventsService implements InterventionEventsServ
   fetchEventsForAccount() {
     return Promise.resolve(this.events);
   }
+
+  async appendEvents() {
+    await Promise.resolve();
+  }
 }
 
 export class PersistentInterventionEventsService implements InterventionEventsService {
@@ -61,6 +66,10 @@ export class PersistentInterventionEventsService implements InterventionEventsSe
 
   fetchEventsForAccount(accountId: string) {
     return this.recordService.queryByPkAndValidate(accountId);
+  }
+
+  async appendEvents(events: InterventionEvent[]) {
+    await this.recordService.batchWrite(events);
   }
 }
 

--- a/src/tables/test/intervention-events.test.ts
+++ b/src/tables/test/intervention-events.test.ts
@@ -28,4 +28,26 @@ describe('PersistentInterventionEventsService', () => {
 
     expect(res).toEqual([event]);
   });
+
+  test('appendEvents', async () => {
+    const event = {
+      eventId: '1232',
+      accountId: 'abc',
+      interventionId: '13324',
+      createdAt: 1234,
+      interventionState: InterventionState.ACTIVE,
+      interventionName: InterventionName.TEMPORARY_SUSPENSION,
+      interventionReason: 'reason',
+      sentAt: 1234,
+      componentId: 'TEST',
+    };
+
+    const recordService = new InMemoryRecordService<typeof interventionEventsTableConfig.schema>([]);
+    const batchWriteSpy = vi.spyOn(recordService, 'batchWrite');
+    const service = new PersistentInterventionEventsService(recordService);
+
+    await service.appendEvents([event]);
+
+    expect(batchWriteSpy).toHaveBeenCalledWith([event]);
+  });
 });


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Store intervention events in the database

## Notes

This has been tested on `AWS`.

I have added a simple command to send sample TxMA messages to the SQS queue for testing purposes.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-8127](https://govukverify.atlassian.net/browse/FPAD-8127)

[FPAD-8127]: https://govukverify.atlassian.net/browse/FPAD-8127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ