### PR TITLE
FPAD-8164: Remove ESlint unicorn/numeric-separators-style rule

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -17,3 +17,6 @@
 
 # move to vitest
 56b815bd0656373bda2e4d37607c209cc366413c
+
+# remove number separators
+2921b8518d3a3ea2018610a0e0f20a1b133176bc

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -49,6 +49,7 @@ export default defineConfig(
       'unicorn/prefer-string-raw': ['off'],
       'unicorn/error-message': ['error'],
       'unicorn/no-array-reduce': ['off'],
+      'unicorn/numeric-separators-style': ['off'],
       'unicorn/prefer-logical-operator-over-ternary': ['error'],
       'unicorn/prefer-spread': ['error'],
       'unicorn/prefer-ternary': ['error'],

--- a/feature-tests/utils/ais-events.ts
+++ b/feature-tests/utils/ais-events.ts
@@ -1,5 +1,5 @@
-const seconds = 12_345;
-const ms = 12_345_000;
+const seconds = 12345;
+const ms = 12345000;
 
 interface Event {
   timestamp: number;

--- a/feature-tests/utils/enhanced-ais-events.ts
+++ b/feature-tests/utils/enhanced-ais-events.ts
@@ -1,7 +1,7 @@
 export const aisEventsWithEnhancedFields = {
   suspendNoActionWithEnhancedExtensions: {
-    timestamp: 12_345,
-    event_timestamp_ms: 12_345_000,
+    timestamp: 12345,
+    event_timestamp_ms: 12345000,
     event_name: 'TICF_ACCOUNT_INTERVENTION',
     event_id: '123',
     component_id: 'TICF_CRI',

--- a/feature-tests/vitest.config.ts
+++ b/feature-tests/vitest.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     include: ['**/*.step.ts'],
     retry: 3,
     hideSkippedTests: true,
-    testTimeout: 60_000,
+    testTimeout: 60000,
     env: {
       SAM_STACK_NAME: 'ais-main',
       AWS_REGION: 'eu-west-2',

--- a/src/commons/test/build-partial-update-state-command.test.ts
+++ b/src/commons/test/build-partial-update-state-command.test.ts
@@ -12,15 +12,15 @@ vi.mock('@aws-lambda-powertools/logger');
 vi.mock('../../commons/metrics');
 vi.mock('../../commons/get-current-timestamp', () => ({
   getCurrentTimestamp: vi.fn().mockImplementation(() => ({
-    milliseconds: 1_706_544_555_234,
+    milliseconds: 1706544555234,
     isoString: 'today',
-    seconds: 1_706_544_555,
+    seconds: 1706544555,
   })),
 }));
 
 const interventionEventBody: TicfAccountIntervention = {
   timestamp: 1000,
-  event_timestamp_ms: 123_456,
+  event_timestamp_ms: 123456,
   user: {
     user_id: 'abc',
   },
@@ -41,8 +41,8 @@ const interventionEventBody: TicfAccountIntervention = {
 const resetPasswordEventBody: AuthPasswordResetSuccessful = {
   event_name: EventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL,
   event_id: '123',
-  timestamp: 10_000,
-  event_timestamp_ms: 10_000_000,
+  timestamp: 10000,
+  event_timestamp_ms: 10000000,
   component_id: 'UNKNOWN',
   user: {
     user_id: 'abc',
@@ -52,8 +52,8 @@ const resetPasswordEventBody: AuthPasswordResetSuccessful = {
 const ipvAccountInterventionEventBody: IpvAccountInterventionEnd = {
   event_name: EventsEnum.IPV_ACCOUNT_INTERVENTION_END,
   event_id: '123',
-  timestamp: 10_000,
-  event_timestamp_ms: 10_000_000,
+  timestamp: 10000,
+  event_timestamp_ms: 10000000,
   component_id: 'UNKNOWN',
   user: {
     user_id: 'abc',

--- a/src/commons/test/get-current-timestamp.test.ts
+++ b/src/commons/test/get-current-timestamp.test.ts
@@ -12,8 +12,8 @@ describe('currentTimestampInSeconds', () => {
 
   it('should return the Unix timestamp in seconds on 13 March 2023 00:00:00 UTC', () => {
     const response = getCurrentTimestamp();
-    expect(response.seconds).toEqual(1_678_665_600);
-    expect(response.milliseconds).toEqual(1_678_665_600_000);
+    expect(response.seconds).toEqual(1678665600);
+    expect(response.milliseconds).toEqual(1678665600000);
     expect(response.isoString).toEqual('2023-03-13T00:00:00.000Z');
   });
 });

--- a/src/commons/test/history-string-builder.test.ts
+++ b/src/commons/test/history-string-builder.test.ts
@@ -4,7 +4,7 @@ import { TicfAccountIntervention } from '../../contracts/intervention-events';
 
 const interventionEventBody: TicfAccountIntervention = {
   timestamp: 1000,
-  event_timestamp_ms: 123_456,
+  event_timestamp_ms: 123456,
   user: {
     user_id: 'abc',
   },
@@ -25,7 +25,7 @@ const interventionEventBody: TicfAccountIntervention = {
 describe('history-string-builder', () => {
   const stringBuilder = new HistoryStringBuilder();
   it('should return a history string formatted correctly', () => {
-    const result = stringBuilder.getHistoryString(interventionEventBody, 123_456);
+    const result = stringBuilder.getHistoryString(interventionEventBody, 123456);
     const expectedResult =
       '123456|TICF_CRI|01|reason|originating_component_id|intervention_predecessor_id|requester_id';
     expect(result).toEqual(expectedResult);

--- a/src/commons/test/metrics-helper.test.ts
+++ b/src/commons/test/metrics-helper.test.ts
@@ -94,19 +94,13 @@ describe('update-account-state-metrics', () => {
 
     describe('should publish TimeToResolve metric', () => {
       it('when an account becomes unsuspended', () => {
-        publishTimeToResolveMetrics(accountIsSuspended, accountIsOkay, 1000, 11_000, 'FRAUD_UNSUSPEND_ACCOUNT');
+        publishTimeToResolveMetrics(accountIsSuspended, accountIsOkay, 1000, 11000, 'FRAUD_UNSUSPEND_ACCOUNT');
         expect(addMetric).toHaveBeenCalledWith('TIME_TO_RESOLVE', [], 10, { type: 'suspension' });
         expect(addMetric).toHaveBeenCalledTimes(1);
       });
 
       it('when an account becomes unsuspended because a password has been reset successfully', () => {
-        publishTimeToResolveMetrics(
-          accountNeedsPswReset,
-          accountIsOkay,
-          1000,
-          11_000,
-          'AUTH_PASSWORD_RESET_SUCCESSFUL',
-        );
+        publishTimeToResolveMetrics(accountNeedsPswReset, accountIsOkay, 1000, 11000, 'AUTH_PASSWORD_RESET_SUCCESSFUL');
         expect(addMetric).toHaveBeenCalledWith('TIME_TO_RESOLVE', [], 10, { type: 'suspension' });
         expect(addMetric).toHaveBeenCalledWith('TIME_TO_RESOLVE', [], 10, { type: 'resetPassword' });
         expect(addMetric).toHaveBeenCalledTimes(2);
@@ -117,7 +111,7 @@ describe('update-account-state-metrics', () => {
           accountNeedsPswReset,
           accountIsSuspended,
           1000,
-          11_000,
+          11000,
           'AUTH_PASSWORD_RESET_SUCCESSFUL',
         );
         expect(addMetric).toHaveBeenCalledWith('TIME_TO_RESOLVE', [], 10, { type: 'resetPassword' });
@@ -125,7 +119,7 @@ describe('update-account-state-metrics', () => {
       });
 
       it('when an account becomes unsuspended because an identity has been reset successfully', () => {
-        publishTimeToResolveMetrics(accountNeedsIdReset, accountIsOkay, 1000, 11_000, 'IPV_ACCOUNT_INTERVENTION_END');
+        publishTimeToResolveMetrics(accountNeedsIdReset, accountIsOkay, 1000, 11000, 'IPV_ACCOUNT_INTERVENTION_END');
         expect(addMetric).toHaveBeenCalledWith('TIME_TO_RESOLVE', [], 10, { type: 'suspension' });
         expect(addMetric).toHaveBeenCalledWith('TIME_TO_RESOLVE', [], 10, { type: 'reproveIdentity' });
         expect(addMetric).toHaveBeenCalledTimes(2);
@@ -136,7 +130,7 @@ describe('update-account-state-metrics', () => {
           accountNeedsIdReset,
           accountIsSuspended,
           1000,
-          11_000,
+          11000,
           'IPV_ACCOUNT_INTERVENTION_END',
         );
         expect(addMetric).toHaveBeenCalledWith('TIME_TO_RESOLVE', [], 10, { type: 'reproveIdentity' });
@@ -146,12 +140,12 @@ describe('update-account-state-metrics', () => {
 
     describe('should NOT publish a TimeToResolve metric', () => {
       it('when an account stays suspended', () => {
-        publishTimeToResolveMetrics(accountIsSuspended, accountIsSuspended, 1000, 11_000, 'FRAUD_SUSPEND_ACCOUNT');
+        publishTimeToResolveMetrics(accountIsSuspended, accountIsSuspended, 1000, 11000, 'FRAUD_SUSPEND_ACCOUNT');
         expect(addMetric).not.toHaveBeenCalled();
       });
 
       it('for when an account becomes suspended', () => {
-        publishTimeToResolveMetrics(accountIsOkay, accountIsSuspended, 1000, 11_000, 'FRAUD_SUSPEND_ACCOUNT');
+        publishTimeToResolveMetrics(accountIsOkay, accountIsSuspended, 1000, 11000, 'FRAUD_SUSPEND_ACCOUNT');
         expect(addMetric).not.toHaveBeenCalled();
       });
     });

--- a/src/contract-testing/consumer/txma-ais-consumer.pact.test.ts
+++ b/src/contract-testing/consumer/txma-ais-consumer.pact.test.ts
@@ -22,8 +22,8 @@ describe('TxMA & AIS - Contract Testing - Consumer', () => {
         .expectsToReceive('a valid intervention event')
         .withContent({
           component_id: '',
-          timestamp: like(1_705_318_190),
-          event_timestamp_ms: number(1_705_318_190_000),
+          timestamp: like(1705318190),
+          event_timestamp_ms: number(1705318190000),
           event_name: 'TICF_ACCOUNT_INTERVENTION',
           user: {
             user_id: string('urn:fdc:gov.uk:2022:USER_ONE'),
@@ -42,8 +42,8 @@ describe('TxMA & AIS - Contract Testing - Consumer', () => {
         .expectsToReceive('a valid user action event - reset password')
         .withContent({
           component_id: '',
-          timestamp: number(1_705_318_190),
-          event_timestamp_ms: number(1_705_318_190_000),
+          timestamp: number(1705318190),
+          event_timestamp_ms: number(1705318190000),
           event_name: like('AUTH_PASSWORD_RESET_SUCCESSFUL'),
           user: {
             user_id: string('urn:fdc:gov.uk:2022:USER_ONE'),
@@ -56,8 +56,8 @@ describe('TxMA & AIS - Contract Testing - Consumer', () => {
         .expectsToReceive('a valid user action event - reset password')
         .withContent({
           component_id: '',
-          timestamp: number(1_705_318_190),
-          event_timestamp_ms: number(1_705_318_190_000),
+          timestamp: number(1705318190),
+          event_timestamp_ms: number(1705318190000),
           event_name: like('IPV_ACCOUNT_INTERVENTION_END'),
           user: {
             user_id: string('urn:fdc:gov.uk:2022:USER_ONE'),

--- a/src/contract-testing/test-helpers/mock-server.ts
+++ b/src/contract-testing/test-helpers/mock-server.ts
@@ -98,7 +98,7 @@ const createDefaultApiRequest = (userIdPathParameter: string): APIGatewayProxyEv
     path: '/hello',
     protocol: 'HTTP/1.1',
     requestId: 'c6af9ac6-7b61-11e6-9a41-93e8deadbeef',
-    requestTimeEpoch: 1_428_582_896_000,
+    requestTimeEpoch: 1428582896000,
     resourceId: '123456',
     resourcePath: '/hello',
     stage: 'dev',

--- a/src/handlers/tests/account-deletion-processor-handler.test.ts
+++ b/src/handlers/tests/account-deletion-processor-handler.test.ts
@@ -216,7 +216,6 @@ describe('Account Deletion Processor', () => {
         event_name: 'AUTH_DELETE_ACCOUNT',
         component_id: 'AUTH',
         event_id: '1234',
-        // eslint-disable-next-line unicorn/numeric-separators-style
         event_timestamp_ms: 1722953808667,
         extensions: {
           account_deletion_reason: 'USER_INITIATED',
@@ -227,7 +226,6 @@ describe('Account Deletion Processor', () => {
             encoded: 'encoded_data',
           },
         },
-        // eslint-disable-next-line unicorn/numeric-separators-style
         timestamp: 1722953808,
         user: {
           user_id: 'other_user_id',

--- a/src/handlers/tests/interventions-processor-lambda.test.ts
+++ b/src/handlers/tests/interventions-processor-lambda.test.ts
@@ -22,9 +22,9 @@ vi.mock('../../commons/metrics-helper');
 
 vi.mock('../../commons/get-current-timestamp', () => ({
   getCurrentTimestamp: vi.fn().mockImplementation(() => ({
-    milliseconds: 1_234_567_890,
+    milliseconds: 1234567890,
     isoString: 'today',
-    seconds: 1_234_567,
+    seconds: 1234567,
   })),
 }));
 
@@ -309,9 +309,7 @@ describe('intervention processor handler', () => {
           component_id: 'UNKNOWN',
           event_id: '123',
           event_name: 'AUTH_PASSWORD_RESET_SUCCESSFUL',
-          // eslint-disable-next-line unicorn/numeric-separators-style
           event_timestamp_ms: 1234562890,
-          // eslint-disable-next-line unicorn/numeric-separators-style
           timestamp: 1234562,
           user: {
             user_id: 'abc',
@@ -432,7 +430,7 @@ describe('intervention processor handler', () => {
         suspended: false,
         isAccountDeleted: false,
         appliedAt: t0ms + 10,
-        sentAt: t0ms + 10_000,
+        sentAt: t0ms + 10000,
       });
       expect(await handler({ Records: [mockRecord] }, mockContext)).toEqual({
         batchItemFailures: [],
@@ -531,8 +529,8 @@ describe('intervention processor handler', () => {
         body: JSON.stringify({
           component_id: 'UNKNOWN',
           event_id: '123',
-          timestamp: getCurrentTimestamp().milliseconds + 500_000,
-          event_timestamp_ms: getCurrentTimestamp().milliseconds + 500_000,
+          timestamp: getCurrentTimestamp().milliseconds + 500000,
+          event_timestamp_ms: getCurrentTimestamp().milliseconds + 500000,
           user: {
             user_id: 'abc',
           },

--- a/src/handlers/tests/status-retriever-handler.test.ts
+++ b/src/handlers/tests/status-retriever-handler.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable unicorn/no-null, unicorn/numeric-separators-style */
+/* eslint-disable unicorn/no-null */
 import { Mock } from 'vitest';
 import type { APIGatewayEvent, APIGatewayProxyEventQueryStringParameters } from 'aws-lambda';
 import { handle } from '../status-retriever-handler';

--- a/src/infra/main/template.yaml
+++ b/src/infra/main/template.yaml
@@ -185,7 +185,7 @@ Globals:
       SecurityGroupIds:
         - Fn::ImportValue: !Sub ${VpcStackName}-AWSServicesEndpointSecurityGroupId
     Layers: #Dynatrace lambda layer
-      - arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_329_73_20260123-140641_with_collector_nodejs_arm:1
+      - arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_13297320260123-140641_with_collector_nodejs_arm:1
 
 Resources:
   ### Interventions Processor ###

--- a/src/services/test/account-state-engine.test.ts
+++ b/src/services/test/account-state-engine.test.ts
@@ -161,9 +161,9 @@ vi.mock('@aws-lambda-powertools/logger');
 vi.mock('../../commons/metrics');
 vi.mock('../../commons/get-current-timestamp', () => ({
   getCurrentTimestamp: vi.fn().mockImplementation(() => ({
-    milliseconds: 1_234_567_890,
+    milliseconds: 1234567890,
     isoString: 'today',
-    seconds: 1_234_567,
+    seconds: 1234567,
   })),
 }));
 describe('account-state-service', () => {

--- a/src/services/test/app-config-service.test.ts
+++ b/src/services/test/app-config-service.test.ts
@@ -77,9 +77,9 @@ describe('AppConfigService', () => {
     expect(appConfig.tableName).toEqual('table_name');
     expect(appConfig.cloudWatchMetricsWorkSpace).toEqual('test_namespace');
     expect(appConfig.metricServiceName).toEqual('test');
-    expect(appConfig.maxRetentionSeconds).toEqual(12_345);
+    expect(appConfig.maxRetentionSeconds).toEqual(12345);
     expect(appConfig.txmaEgressQueueUrl).toEqual('https://sqs.eu-west-2.amazonaws.com/111122223333/TxMAQueue');
-    expect(appConfig.historyRetentionSeconds).toEqual(63_072_000);
+    expect(appConfig.historyRetentionSeconds).toEqual(63072000);
   });
 
   it('should throw an error if the environmental variable is not a number', () => {

--- a/src/services/test/send-audit-events.test.ts
+++ b/src/services/test/send-audit-events.test.ts
@@ -20,9 +20,9 @@ vi.mock('@aws-lambda-powertools/logger');
 vi.mock('../../commons/metrics');
 vi.mock('../../commons/get-current-timestamp', () => ({
   getCurrentTimestamp: vi.fn().mockImplementation(() => ({
-    milliseconds: 1_234_567_890,
+    milliseconds: 1234567890,
     isoString: 'today',
-    seconds: 1_234_567,
+    seconds: 1234567,
   })),
 }));
 
@@ -84,8 +84,8 @@ const sqsMock = mockClient(SQSClient);
 const sqsCommandInputForUserAction = {
   QueueUrl: AppConfigService.getInstance().txmaEgressQueueUrl,
   MessageBody: JSON.stringify({
-    timestamp: 1_234_567,
-    event_timestamp_ms: 1_234_567_890,
+    timestamp: 1234567,
+    event_timestamp_ms: 1234567890,
     component_id: 'ACCOUNT_INTERVENTION_SERVICE',
     event_name: 'AIS_EVENT_TRANSITION_APPLIED',
     user: {
@@ -105,8 +105,8 @@ const sqsCommandInputForUserAction = {
 const sqsCommandInputForBlockIntervention = {
   QueueUrl: AppConfigService.getInstance().txmaEgressQueueUrl,
   MessageBody: JSON.stringify({
-    timestamp: 1_234_567,
-    event_timestamp_ms: 1_234_567_890,
+    timestamp: 1234567,
+    event_timestamp_ms: 1234567890,
     component_id: COMPONENT_ID,
     event_name: 'AIS_EVENT_TRANSITION_APPLIED',
     user: { user_id: 'testUserId' },
@@ -125,8 +125,8 @@ const sqsCommandInputForBlockIntervention = {
 const sqsCommandInputForDeletedAccount = {
   QueueUrl: AppConfigService.getInstance().txmaEgressQueueUrl,
   MessageBody: JSON.stringify({
-    timestamp: 1_234_567,
-    event_timestamp_ms: 1_234_567_890,
+    timestamp: 1234567,
+    event_timestamp_ms: 1234567890,
     component_id: COMPONENT_ID,
     event_name: 'AIS_EVENT_IGNORED_ACCOUNT_DELETED',
     user: { user_id: 'testUserId' },
@@ -145,8 +145,8 @@ const sqsCommandInputForDeletedAccount = {
 const sqsCommandInputForSuspendIntervention = {
   QueueUrl: AppConfigService.getInstance().txmaEgressQueueUrl,
   MessageBody: JSON.stringify({
-    timestamp: 1_234_567,
-    event_timestamp_ms: 1_234_567_890,
+    timestamp: 1234567,
+    event_timestamp_ms: 1234567890,
     component_id: COMPONENT_ID,
     event_name: 'AIS_EVENT_TRANSITION_APPLIED',
     user: { user_id: 'testUserId' },
@@ -165,8 +165,8 @@ const sqsCommandInputForSuspendIntervention = {
 const sqsCommandInputForUnsuspendIntervention = {
   QueueUrl: AppConfigService.getInstance().txmaEgressQueueUrl,
   MessageBody: JSON.stringify({
-    timestamp: 1_234_567,
-    event_timestamp_ms: 1_234_567_890,
+    timestamp: 1234567,
+    event_timestamp_ms: 1234567890,
     component_id: COMPONENT_ID,
     event_name: 'AIS_EVENT_TRANSITION_APPLIED',
     user: { user_id: 'testUserId' },
@@ -185,8 +185,8 @@ const sqsCommandInputForUnsuspendIntervention = {
 const sqsCommandInputForFutureInterventions = {
   QueueUrl: AppConfigService.getInstance().txmaEgressQueueUrl,
   MessageBody: JSON.stringify({
-    timestamp: 1_234_567,
-    event_timestamp_ms: 1_234_567_890,
+    timestamp: 1234567,
+    event_timestamp_ms: 1234567890,
     component_id: COMPONENT_ID,
     event_name: 'AIS_EVENT_IGNORED_IN_FUTURE',
     user: { user_id: 'testUserId' },
@@ -202,8 +202,8 @@ const sqsCommandInputForFutureInterventions = {
 const sqsCommandInputForSuspendUserAction = {
   QueueUrl: AppConfigService.getInstance().txmaEgressQueueUrl,
   MessageBody: JSON.stringify({
-    timestamp: 1_234_567,
-    event_timestamp_ms: 1_234_567_890,
+    timestamp: 1234567,
+    event_timestamp_ms: 1234567890,
     component_id: COMPONENT_ID,
     event_name: 'AIS_EVENT_TRANSITION_APPLIED',
     user: { user_id: 'testUserId' },
@@ -223,8 +223,8 @@ const sqsCommandInputForSuspendUserAction = {
 const sqsCommandInputForSuspendUserActionReproveIdentityAndResetPass = {
   QueueUrl: AppConfigService.getInstance().txmaEgressQueueUrl,
   MessageBody: JSON.stringify({
-    timestamp: 1_234_567,
-    event_timestamp_ms: 1_234_567_890,
+    timestamp: 1234567,
+    event_timestamp_ms: 1234567890,
     component_id: COMPONENT_ID,
     event_name: 'AIS_EVENT_TRANSITION_APPLIED',
     user: { user_id: 'testUserId' },
@@ -244,8 +244,8 @@ const sqsCommandInputForSuspendUserActionReproveIdentityAndResetPass = {
 const sqsInputWithExtraFields = {
   QueueUrl: AppConfigService.getInstance().txmaEgressQueueUrl,
   MessageBody: JSON.stringify({
-    timestamp: 1_234_567,
-    event_timestamp_ms: 1_234_567_890,
+    timestamp: 1234567,
+    event_timestamp_ms: 1234567890,
     component_id: COMPONENT_ID,
     event_name: 'AIS_EVENT_TRANSITION_APPLIED',
     user: { user_id: 'testUserId' },
@@ -462,8 +462,8 @@ describe('send-audit-events', () => {
     const sqsCommandInput = {
       QueueUrl: AppConfigService.getInstance().txmaEgressQueueUrl,
       MessageBody: JSON.stringify({
-        timestamp: 1_234_567,
-        event_timestamp_ms: 1_234_567_890,
+        timestamp: 1234567,
+        event_timestamp_ms: 1234567890,
         component_id: COMPONENT_ID,
         event_name: 'AIS_EVENT_TRANSITION_APPLIED',
         user: { user_id: 'testUserId' },

--- a/src/services/test/validate-event.test.ts
+++ b/src/services/test/validate-event.test.ts
@@ -19,9 +19,9 @@ vi.mock('@aws-lambda-powertools/logger');
 vi.mock('../send-audit-events');
 vi.mock('../../commons/get-current-timestamp', () => ({
   getCurrentTimestamp: vi.fn().mockImplementation(() => ({
-    milliseconds: 1_234_567_890,
+    milliseconds: 1234567890,
     isoString: 'today',
-    seconds: 1_234_567,
+    seconds: 1234567,
   })),
 }));
 
@@ -175,7 +175,7 @@ describe('validateEventAgainstSchema', () => {
   it('should throw an error if event is stale', async () => {
     const staleEvent = {
       timestamp: timestamp.seconds - 10,
-      event_timestamp_ms: timestamp.milliseconds - 10_000,
+      event_timestamp_ms: timestamp.milliseconds - 10000,
       event_name: TriggerEventsEnum.TICF_ACCOUNT_INTERVENTION as const,
       event_id: '123',
       component_id: 'TICF_CRI',
@@ -320,7 +320,7 @@ describe('validateEventAgainstSchema', () => {
   it('should not throw an error if the event is not in the future', async () => {
     const eventNotInTheFuture = {
       timestamp: timestamp.seconds - 10,
-      event_timestamp_ms: timestamp.milliseconds - 10_000,
+      event_timestamp_ms: timestamp.milliseconds - 10000,
       event_name: TriggerEventsEnum.TICF_ACCOUNT_INTERVENTION as const,
       event_id: '123',
       component_id: 'TICF_CRI',
@@ -346,8 +346,8 @@ describe('validateEventAgainstSchema', () => {
     const idResetEventWithoutSuccess = {
       event_name: EventsEnum.IPV_ACCOUNT_INTERVENTION_END as const,
       event_id: '123',
-      event_timestamp_ms: 1_234_567_000,
-      timestamp: 1_234_567,
+      event_timestamp_ms: 1234567000,
+      timestamp: 1234567,
       component_id: 'https://identity.account.gov.uk',
       user: {
         user_id: 'urn:fdc:gov.uk:2022:USER_ONE',
@@ -370,8 +370,8 @@ describe('validateEventAgainstSchema', () => {
     const idResetEvent = {
       event_name: EventsEnum.IPV_ACCOUNT_INTERVENTION_END as const,
       event_id: '123',
-      timestamp: 1_234_567,
-      event_timestamp_ms: 1_234_567_000,
+      timestamp: 1234567,
+      event_timestamp_ms: 1234567000,
       client_id: 'UNKNOWN',
       component_id: 'https://identity.account.gov.uk',
       user: {
@@ -395,8 +395,8 @@ describe('validateEventAgainstSchema', () => {
     const idResetEventLowConfidence = {
       event_name: EventsEnum.IPV_ACCOUNT_INTERVENTION_END as const,
       event_id: '123',
-      timestamp: 1_234_567,
-      event_timestamp_ms: 1_234_567_000,
+      timestamp: 1234567,
+      event_timestamp_ms: 1234567000,
       client_id: 'UNKNOWN',
       component_id: 'https://identity.account.gov.uk',
       user: {


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Remove `ESlint` `unicorn/numeric-separators-style` rule

## Why

Not useful.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-8164](https://govukverify.atlassian.net/browse/FPAD-8164)


[FPAD-8164]: https://govukverify.atlassian.net/browse/FPAD-8164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ