### PR TITLE
FPAD-8204: Fix for Invalid KeyConditionExpression

### DIFF
--- a/src/infra/main/template.yaml
+++ b/src/infra/main/template.yaml
@@ -47,7 +47,7 @@ Parameters:
   LambdaDeploymentPreference:
     Description: "Specifies the configuration to enable gradual Lambda deployments. It can be used to set deployment type and also allows skipping canary deployment by setting to 'AllAtOnce'"
     Type: String
-    Default: 'AllAtOnce'
+    Default: 'Canary10Percent10Minutes'
     AllowedValues:
       - AllAtOnce
       - Canary10Percent5Minutes

--- a/src/services/dynamo-db-record-service.ts
+++ b/src/services/dynamo-db-record-service.ts
@@ -25,8 +25,8 @@ export class DynamoDBRecordService<
     const results = await this.dbClient.send(
       new QueryCommand({
         TableName: this.config.tableName,
-        KeyConditionExpression: `#${this.config.partitionKeyName} = :pk`,
-        ExpressionAttributeNames: { '#pk': 'pk' },
+        KeyConditionExpression: '#pk = :pk',
+        ExpressionAttributeNames: { '#pk': this.config.partitionKeyName },
         ExpressionAttributeValues: { ':pk': partionKeyValue },
       }),
     );

--- a/src/services/test/dynamo-db-record-service.test.ts
+++ b/src/services/test/dynamo-db-record-service.test.ts
@@ -43,8 +43,8 @@ describe('DynamoDBRecordService', () => {
 
     expect(ddbMock).toHaveReceivedCommandWith(QueryCommand, {
       TableName: 'test-table',
-      KeyConditionExpression: '#pk1 = :pk',
-      ExpressionAttributeNames: { '#pk': 'pk' },
+      KeyConditionExpression: '#pk = :pk',
+      ExpressionAttributeNames: { '#pk': 'pk1' },
       ExpressionAttributeValues: { ':pk': 'key_value_1' },
     });
   });
@@ -62,8 +62,8 @@ describe('DynamoDBRecordService', () => {
 
     expect(ddbMock).toHaveReceivedCommandWith(QueryCommand, {
       TableName: 'test-table',
-      KeyConditionExpression: '#pk1 = :pk',
-      ExpressionAttributeNames: { '#pk': 'pk' },
+      KeyConditionExpression: '#pk = :pk',
+      ExpressionAttributeNames: { '#pk': 'pk1' },
       ExpressionAttributeValues: { ':pk': 'key_value_1' },
     });
   });
@@ -81,8 +81,8 @@ describe('DynamoDBRecordService', () => {
 
     expect(ddbMock).toHaveReceivedCommandWith(QueryCommand, {
       TableName: 'test-table',
-      KeyConditionExpression: '#pk1 = :pk',
-      ExpressionAttributeNames: { '#pk': 'pk' },
+      KeyConditionExpression: '#pk = :pk',
+      ExpressionAttributeNames: { '#pk': 'pk1' },
       ExpressionAttributeValues: { ':pk': 'key_value_1' },
     });
   });


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Fix for Invalid `KeyConditionExpression` error, caused by an incorrectly formed `QueryCommand`.

## Why

We noticed a number of alarms overnight, caused by this issue.

## Notes

This should be tested on `dev` first, to make sure it is working correctly.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-8204](https://govukverify.atlassian.net/browse/FPAD-8204)


[FPAD-8204]: https://govukverify.atlassian.net/browse/FPAD-8204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ