### PR TITLE
FPAD-8109: Status API v2

### DIFF
--- a/feature-tests/apiEndpoints/endpoints.ts
+++ b/feature-tests/apiEndpoints/endpoints.ts
@@ -3,6 +3,10 @@ export default class EndPoints {
     process.env.TEST_ENVIRONMENT === 'dev'
       ? `https://ysxfdzicei.execute-api.${process.env.AWS_REGION}.amazonaws.com/v1`
       : process.env.CFN_PrivateApiEndpoint;
+  public static AIS_MAIN_URL =
+    process.env.TEST_ENVIRONMENT === 'dev'
+      ? `https://4ziiqv75a4.execute-api.${process.env.AWS_REGION}.amazonaws.com/main`
+      : process.env.CFN_MainPrivateApiEndpoint;
   public static SQS_QUEUE_URL =
     process.env.TEST_ENVIRONMENT === 'dev'
       ? `https://sqs.${process.env.AWS_REGION}.amazonaws.com/484907510598/${process.env.SAM_STACK_NAME}-TxMAIngressQueue`

--- a/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-HappyPath.feature
+++ b/feature-tests/tests/resources/features/aisGET/InvokeApiGateWay-HappyPath.feature
@@ -27,6 +27,12 @@ Feature: Invoke-APIGateway-HappyPath.feature
             | suspendNoActionWithEnhancedExtensions |
 
     @regression
+    Scenario: Happy Path - Get Request to /v2/ais/userId Returns Expected Data
+        Given I send an intervention message to the TxMA ingress SQS queue
+        When I invoke an API v2 to retrieve the intervention status of the account
+        Then I expect the API to return a list of active interventions
+
+    @regression
     Scenario Outline: Happy Path - Get Request to /ais/userId - Returns Expected Data for <aisEventType>
         Given I send an <aisEventType> intervention message to the TxMA ingress SQS queue
         When I invoke the API to retrieve the intervention status of the user's account. With history <historyValue>

--- a/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/invoke-api-gateway-happy-path.step.ts
@@ -69,6 +69,27 @@ describeFeature(feature, ({ Scenario, ScenarioOutline, BeforeEachScenario }) => 
     },
   );
 
+  Scenario('Happy Path - Get Request to /v2/ais/userId Returns Expected Data', ({ Given, When, Then }) => {
+    Given('I send an intervention message to the TxMA ingress SQS queue', async () => {
+      await sendSQSEvent(testUserId, 'suspendNoAction');
+    });
+
+    When('I invoke an API v2 to retrieve the intervention status of the account', async () => {
+      await timeDelayForTestEnvironment(4000);
+      response = await invokeGetAccountState(testUserId, false, true);
+    });
+
+    Then('I expect the API to return a list of active interventions', () => {
+      expect(response).toEqual({
+        interventions: [
+          {
+            name: 'TEMPORARY_SUSPENSION',
+          },
+        ],
+      });
+    });
+  });
+
   ScenarioOutline(
     'Happy Path - Get Request to /ais/userId with enhanced fields- Returns Expected Data for <aisEventType>',
     ({ Given, When, Then }, { enhancedAisEventType }) => {

--- a/feature-tests/utils/invoke-apigateway-lambda.ts
+++ b/feature-tests/utils/invoke-apigateway-lambda.ts
@@ -1,22 +1,35 @@
 import { InvokeCommand, LambdaClient } from '@aws-sdk/client-lambda';
 import EndPoints from '../apiEndpoints/endpoints';
 import request from 'supertest';
-import { App } from 'supertest/types';
+import { CustomEvent } from '../../src/handlers/invoke-private-api';
 
-export async function invokeGetAccountState(testUserId: string, historyValue: boolean) {
+export async function invokeGetAccountState(testUserId: string, historyValue: boolean, v2Endpoint: boolean = false) {
   if (process.platform === 'darwin' || process.env['USE_PRIVATE_API_GATEWAY']) {
     const client = new LambdaClient({});
+
+    const payload: CustomEvent = {
+      userId: testUserId,
+      queryParameters: `history=${historyValue}`,
+      ...(v2Endpoint && {
+        privateApi: true,
+        endpoint: '/v2/ais',
+      }),
+    };
+
     const command = new InvokeCommand({
       FunctionName: EndPoints.INVOKE_PRIVATE_API_GATEWAY,
-      Payload: JSON.stringify({ userId: testUserId, queryParameters: `history=${historyValue}` }),
+      Payload: JSON.stringify(payload),
     });
     const { Payload } = await client.send(command);
     const resultStringFromLambda = Payload ? Buffer.from(Payload).toString() : '';
     const resultObjectFromLambda = JSON.parse(resultStringFromLambda);
     return JSON.parse(resultObjectFromLambda.body);
   } else if (process.platform === 'linux') {
-    const resultFromAPI = await request(EndPoints.AIS_BASE_URL as unknown as App)
-      .get(EndPoints.PATH_AIS + testUserId)
+    const url = v2Endpoint ? EndPoints.AIS_MAIN_URL! : EndPoints.AIS_BASE_URL!;
+    const basePath = v2Endpoint ? '/v2/ais/' : /ais/;
+
+    const resultFromAPI = await request(url)
+      .get(basePath + testUserId)
       .query({ history: historyValue })
       .set('Content-Type', 'application/json')
       .set('Accept', '*/*');

--- a/src/handlers/invoke-private-api.ts
+++ b/src/handlers/invoke-private-api.ts
@@ -3,16 +3,17 @@
 import getEnvOrThrow from '../commons/get-env-or-throw';
 import logger from '../commons/logger';
 
-interface CustomEvent {
+export interface CustomEvent {
   userId?: string;
   queryParameters?: string;
   baseUrl?: string;
   endpoint?: string;
   headers?: Record<string, string>;
+  privateApi?: boolean;
 }
 
 export async function handle(event: CustomEvent) {
-  const baseUrl = event.baseUrl ?? getBaseUrl();
+  const baseUrl = event.baseUrl ?? getBaseUrl(event);
   const endpoint = event.endpoint ?? getEndpoint();
   const userId = encodeURI(event.userId ?? getUserId());
   const headers = event.headers ?? { 'Content-Type': 'application/json' };
@@ -42,8 +43,8 @@ function getUserId() {
   return getEnvOrThrow('USER_ID');
 }
 
-function getBaseUrl() {
-  return validateConfiguration('BASE_URL');
+function getBaseUrl(event: CustomEvent) {
+  return event.privateApi ? validateConfiguration('PRIVATE_API_URL') : validateConfiguration('BASE_URL');
 }
 
 function getEndpoint() {

--- a/src/handlers/status-retriever-handler.ts
+++ b/src/handlers/status-retriever-handler.ts
@@ -7,6 +7,8 @@ import { AccountStatus, FullAccountInformation, HistoryObject } from '../data-ty
 import { DynamoDatabaseService } from '../services/dynamo-database-service';
 import { getCurrentTimestamp } from '../commons/get-current-timestamp';
 import { HistoryStringBuilder } from '../commons/history-string-builder';
+import getActiveInterventions from '../services/active-interventions-service';
+import { getPersistentInterventionEventsService, InterventionEventsService } from '../tables/intervention-events';
 
 const appConfig = AppConfigService.getInstance();
 const dynamoDatabaseServiceInstance = new DynamoDatabaseService(appConfig.tableName);
@@ -17,16 +19,12 @@ const dynamoDatabaseServiceInstance = new DynamoDatabaseService(appConfig.tableN
  * @param context - This object provides methods and properties that provide information about the invocation, function, and execution environment.
  * @returns - The status of the account when matched with the User ID. Returns a default object if unable to do so. Also returns the relevant status code.
  */
-export async function handle(event: APIGatewayEvent, context: Context): Promise<APIGatewayProxyResult> {
+export async function handle(
+  event: APIGatewayEvent,
+  context: Context,
+  interventionEventsService: InterventionEventsService = getPersistentInterventionEventsService(),
+): Promise<APIGatewayProxyResult> {
   logger.addContext(context);
-
-  if (event.resource === '/v2/ais/{userId}') {
-    logger.debug('v2 endpoint');
-    return {
-      statusCode: 501,
-      body: JSON.stringify({ message: 'Not Implemented.' }),
-    };
-  }
 
   if (!event.pathParameters?.['userId']) {
     addMetric(MetricNames.INVALID_SUBJECT_ID);
@@ -40,44 +38,84 @@ export async function handle(event: APIGatewayEvent, context: Context): Promise<
   logger.info('This is a comment for tests');
 
   const userId = decodeURIComponent(validateEvent(event.pathParameters['userId']));
-  const historyQuery = event.queryStringParameters?.['history'];
 
   try {
-    const response = await dynamoDatabaseServiceInstance.getFullAccountInformation(userId);
-    if (!response) {
-      logger.info('Query matched no records in DynamoDB.');
-      addMetric(MetricNames.ACCOUNT_NOT_FOUND);
+    if (event.resource === '/v2/ais/{userId}') return await v2StatusApiHandler(userId, interventionEventsService);
 
-      const undefinedAccount = transformResponseFromDynamoDatabase({});
+    const historyQuery = event.queryStringParameters?.['history'];
 
-      if (historyQuery && historyQuery === 'true') {
-        undefinedAccount.history = [];
-      }
-      metric.publishStoredMetrics();
-      return {
-        statusCode: 200,
-        body: JSON.stringify(undefinedAccount),
-      };
-    }
-
-    const accountStatus = transformResponseFromDynamoDatabase(response);
-
-    if (historyQuery && historyQuery === 'true') {
-      accountStatus.history = constructHistoryObjectField(response.history);
-    }
-    metric.publishStoredMetrics();
-    return {
-      statusCode: 200,
-      body: JSON.stringify(accountStatus),
-    };
+    return await v1StatusApiHandler(userId, historyQuery);
   } catch (error) {
     logger.error('A problem occurred with the query.', { error });
     addMetric(MetricNames.DB_QUERY_ERROR);
   }
+
   metric.publishStoredMetrics();
+
   return {
     statusCode: 500,
     body: JSON.stringify({ message: 'Internal Server Error.' }),
+  };
+}
+
+async function v1StatusApiHandler(userId: string, historyQuery: string | undefined) {
+  const response = await dynamoDatabaseServiceInstance.getFullAccountInformation(userId);
+  if (!response) {
+    logger.info('Query matched no records in DynamoDB.');
+    addMetric(MetricNames.ACCOUNT_NOT_FOUND);
+
+    const undefinedAccount = transformResponseFromDynamoDatabase({});
+
+    if (historyQuery && historyQuery === 'true') {
+      undefinedAccount.history = [];
+    }
+
+    metric.publishStoredMetrics();
+    return {
+      statusCode: 200,
+      body: JSON.stringify(undefinedAccount),
+    };
+  }
+
+  const accountStatus = transformResponseFromDynamoDatabase(response);
+
+  if (historyQuery && historyQuery === 'true') {
+    accountStatus.history = constructHistoryObjectField(response.history);
+  }
+
+  metric.publishStoredMetrics();
+  return {
+    statusCode: 200,
+    body: JSON.stringify(accountStatus),
+  };
+}
+
+async function v2StatusApiHandler(userId: string, interventionEventsService: InterventionEventsService) {
+  logger.debug('v2 endpoint');
+
+  const response = await dynamoDatabaseServiceInstance.getAccountStateInformation(userId);
+  if (!response) {
+    logger.info('Query matched no records in DynamoDB.');
+    addMetric(MetricNames.ACCOUNT_NOT_FOUND);
+
+    metric.publishStoredMetrics();
+    return {
+      statusCode: 200,
+      body: JSON.stringify({
+        interventions: [],
+      }),
+    };
+  }
+
+  const activeInterventions = await getActiveInterventions(userId, interventionEventsService, response);
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify({
+      interventions: activeInterventions.map((name) => ({
+        name,
+      })),
+    }),
   };
 }
 

--- a/src/handlers/tests/status-retriever-handler.test.ts
+++ b/src/handlers/tests/status-retriever-handler.test.ts
@@ -6,8 +6,13 @@ import logger from '../../commons/logger';
 import { DynamoDatabaseService } from '../../services/dynamo-database-service';
 import { addMetric } from '../../commons/metrics';
 import jestOpenAPI from 'jest-openapi';
+import {
+  InMemoryInterventionEventsService,
+  InterventionName,
+  InterventionState,
+} from '../../tables/intervention-events';
 
-jestOpenAPI(`${__dirname}/../../specs/api.yaml`);
+jestOpenAPI(`${__dirname}/../../specs/main.yaml`);
 
 vi.mock('../../commons/logger.ts');
 vi.mock('../../commons/metrics');
@@ -84,6 +89,8 @@ const mockConfig = {
 };
 // eslint-disable-next-line @typescript-eslint/unbound-method
 const mockDynamoDBServiceRetrieveRecords = DynamoDatabaseService.prototype.getFullAccountInformation as Mock;
+// eslint-disable-next-line @typescript-eslint/unbound-method
+const mockDynamoDBServiceRetrieveAccountState = DynamoDatabaseService.prototype.getAccountStateInformation as Mock;
 
 describe('status-retriever-handler', () => {
   beforeAll(() => {
@@ -572,5 +579,114 @@ describe('status-retriever-handler', () => {
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(logger.error).toHaveBeenCalledWith('History string is malformed.', { error });
     expect(addMetric).toHaveBeenCalled();
+  });
+});
+
+describe('v2 Status API handler', () => {
+  beforeAll(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(Date.UTC(2023, 4, 30)).getTime());
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetAllMocks();
+  });
+
+  it("returns an empty list of interventions if the requested account doesn't exist", async () => {
+    const response = await handle({ ...testEvent, resource: '/v2/ais/{userId}' }, mockConfig);
+    expect(response.statusCode).toBe(200);
+
+    const payload = JSON.parse(response.body) as unknown as Record<string, unknown>;
+    expect(payload).toEqual({
+      interventions: [],
+    });
+    expect(payload).toSatisfySchemaInApiSpec('AccountStatusResponse');
+  });
+
+  it('return a list of interventions from the account status table', async () => {
+    const accountFound = {
+      pk: 'testUserID',
+      intervention: 'AIS_NO_INTERVENTION',
+      updatedAt: 123455,
+      appliedAt: 12345685809,
+      sentAt: 123456789,
+      reprovedIdentityAt: 849473,
+      resetPasswordAt: 5847392,
+      deletedAt: 12345685809,
+      blocked: false,
+      suspended: true,
+      resetPassword: true,
+      reproveIdentity: false,
+      auditLevel: 'standard',
+      ttl: 1234567890,
+    };
+
+    mockDynamoDBServiceRetrieveAccountState.mockResolvedValueOnce(accountFound);
+    const response = await handle(
+      { ...testEvent, resource: '/v2/ais/{userId}' },
+      mockConfig,
+      new InMemoryInterventionEventsService([]),
+    );
+    expect(response.statusCode).toBe(200);
+
+    const payload = JSON.parse(response.body) as Record<string, unknown>;
+    expect(payload).toEqual({
+      interventions: [
+        {
+          name: 'RESET_PASSWORD',
+        },
+      ],
+    });
+    expect(payload).toSatisfySchemaInApiSpec('AccountStatusResponse');
+  });
+
+  it('return a list of interventions from the intervention events table', async () => {
+    const accountFound = {
+      pk: 'testUserID',
+      intervention: 'AIS_NO_INTERVENTION',
+      updatedAt: 123455,
+      appliedAt: 12345685809,
+      sentAt: 123456789,
+      reprovedIdentityAt: 849473,
+      resetPasswordAt: 5847392,
+      deletedAt: 12345685809,
+      blocked: false,
+      suspended: false,
+      resetPassword: false,
+      reproveIdentity: false,
+      auditLevel: 'standard',
+      ttl: 1234567890,
+    };
+
+    mockDynamoDBServiceRetrieveAccountState.mockResolvedValueOnce(accountFound);
+    const response = await handle(
+      { ...testEvent, resource: '/v2/ais/{userId}' },
+      mockConfig,
+      new InMemoryInterventionEventsService([
+        {
+          eventId: '1234',
+
+          accountId: 'user1',
+          createdAt: 1234,
+          interventionReason: '',
+          sentAt: 1234,
+          componentId: 'TEST',
+          interventionName: InterventionName.REPROVE_IDENTITY,
+          interventionState: InterventionState.ACTIVE,
+        },
+      ]),
+    );
+    expect(response.statusCode).toBe(200);
+
+    const payload = JSON.parse(response.body) as Record<string, unknown>;
+    expect(payload).toEqual({
+      interventions: [
+        {
+          name: 'REPROVE_IDENTITY',
+        },
+      ],
+    });
+    expect(payload).toSatisfySchemaInApiSpec('AccountStatusResponse');
   });
 });

--- a/src/infra/main/template.yaml
+++ b/src/infra/main/template.yaml
@@ -1301,6 +1301,8 @@ Resources:
         Variables:
           TABLE_NAME:
             Fn::ImportValue: !Sub '${CoreStackName}-AccountStatusTableName'
+          INTERVENTION_EVENTS_TABLE_NAME:
+            Fn::ImportValue: !Sub '${CoreStackName}-InterventionEventsTableName'
           METRIC_SERVICE_NAME: StatusRetrieverFunction
       Handler: status-retriever-handler.handle
       Role: !GetAtt StatusRetrieverFunctionRole.Arn
@@ -1369,9 +1371,20 @@ Resources:
               - Fn::ImportValue: !Sub '${CoreStackName}-AccountStatusTableArn'
           - Effect: Allow
             Action:
+              - 'dynamodb:BatchWriteItem'
+              - 'dynamodb:Query'
+            Resource:
+              - Fn::ImportValue: !Sub '${CoreStackName}-InterventionEventsTableArn'
+          - Effect: Allow
+            Action:
               - 'kms:decrypt'
             Resource:
               - Fn::ImportValue: !Sub '${CoreStackName}-AccountStatusTableEncryptionKeyArn'
+          - Effect: Allow
+            Action:
+              - 'kms:decrypt'
+            Resource:
+              - Fn::ImportValue: !Sub '${CoreStackName}-InterventionEventsTableEncryptionKeyArn'
       Roles:
         - !Ref StatusRetrieverFunctionRole
 

--- a/src/infra/main/template.yaml
+++ b/src/infra/main/template.yaml
@@ -1436,6 +1436,11 @@ Resources:
             - - https://
               - !GetAtt PrivateRestApi.RestApiId
               - !Sub .execute-api.${AWS::Region}.amazonaws.com/${ApiStageName}
+          PRIVATE_API_URL: !Join
+            - ''
+            - - https://
+              - !GetAtt PrivateApi.RestApiId
+              - !Sub .execute-api.${AWS::Region}.amazonaws.com/main
           END_POINT: /ais
           QUERY_PARAMETERS: ''
           HTTP_REQUEST_METHOD: GET
@@ -1975,6 +1980,10 @@ Outputs:
   PrivateApiEndpoint:
     Description: 'Private API Gateway endpoint URL for AIS methods'
     Value: !Sub 'https://${PrivateRestApi}.execute-api.${AWS::Region}.amazonaws.com/${ApiStageName}'
+
+  MainPrivateApiEndpoint:
+    Description: 'Private API Gateway endpoint URL for AIS methods'
+    Value: !Sub 'https://${PrivateApi}.execute-api.${AWS::Region}.amazonaws.com/main'
 
   TxMAEgressSqsQueueUrl:
     Description: 'Endpoint URL for TxMA Egress Queue'

--- a/vitest.contract.config.ts
+++ b/vitest.contract.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
       CLOUDWATCH_METRICS_NAMESPACE: 'test_namespace',
       METRIC_SERVICE_NAME: 'test',
       TABLE_NAME: 'table_name',
+      INTERVENTION_EVENTS_TABLE_NAME: 'intervention-events',
       AWS_REGION: 'aws_region',
       PROVIDER_BASE_URL: 'http://127.0.0.1',
       PROVIDER_PORT: ':8080',


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Status API v2

## Notes

This has been implemented under `main/v2/ais/{userId}` on a new API Gateway, as it isn't possible to have different API specs for different stage names.

This has been tested in AWS on `dev`.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-8109](https://govukverify.atlassian.net/browse/FPAD-8109)


[FPAD-8109]: https://govukverify.atlassian.net/browse/FPAD-8109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ