### PR TITLE
Remove EndpointConfiguration from PrivateAPI

### DIFF
--- a/src/infra/main/template.yaml
+++ b/src/infra/main/template.yaml
@@ -1687,10 +1687,12 @@ Resources:
       TracingEnabled: true
       EndpointConfiguration:
         Type: PRIVATE
-        VpcEndpointIds: !If
-          - IsNotInternal
-          - !Split [',', !FindInMap [EnvConfig, !Ref Environment, UniqueVPCEndpointIDs]]
-          - []
+        # TODO - figure out status of the perf VPC id
+        VpcEndpointIds: []
+        # VpcEndpointIds: !If
+        #   - IsNotInternal
+        #   - !Split [',', !FindInMap [EnvConfig, !Ref Environment, UniqueVPCEndpointIDs]]
+        #   - []
       Tags:
         CheckovRulesToSkip: CKV_AWS_120
         Product: !Ref ProductTagValue


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Remove EndpointConfiguration from PrivateAPI

## Why

The first endpoint in staging can't be found, which is blocking deployment

## Notes

At some point we should put this back, so that other teams have access to this Gateway