### PR TITLE
FPAD-8282: Build feature-tests Docker image in CI

### DIFF
--- a/.github/workflows/acceptance-checks.yaml
+++ b/.github/workflows/acceptance-checks.yaml
@@ -27,8 +27,6 @@ on:
       - tsconfig.json
       - .node-version
       - .github/workflows/acceptance-checks.yaml
-    branches:
-      - main
     types:
       - opened
       - reopened

--- a/.github/workflows/build-feature-tests-environment.yaml
+++ b/.github/workflows/build-feature-tests-environment.yaml
@@ -1,0 +1,44 @@
+---
+name: 'Build feature test environment'
+permissions:
+  contents: read
+  packages: read
+
+on:
+  push:
+    paths:
+      - feature-tests/**
+      - .github/workflows/build-feature-tests-environment.yaml
+    branches:
+      - main
+  pull_request:
+    paths:
+      - feature-tests/**
+      - .github/workflows/build-feature-tests-environment.yaml
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
+  workflow_call:
+    inputs:
+      gitRef:
+        required: false
+        type: string
+        default: ${{ github.ref }}
+
+jobs:
+  build-feature-test-environment:
+    name: 'Build feature test environment'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./feature-tests
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+        with:
+          ref: ${{ inputs.gitRef || github.ref }}
+
+      # We don't run the feature tests here but we build the docker image to surface any build-time issues
+      - name: Build feature test docker image
+        run: docker build .

--- a/feature-tests/README.md
+++ b/feature-tests/README.md
@@ -77,6 +77,8 @@ docker run --rm -it \
   account-intervention-service-feature-tests-image
 ```
 
+The Docker image gets built in CI to verify the build won't break the pipeline post-merge.
+
 ## Environment configuration
 
 If new values are added to **endpoints.ts**, associated values will then need to be added to the main template


### PR DESCRIPTION
## What

Build the feature-tests docker image in CI

## Why

We blocked the pipeline recently because the feature tests environment was broken (not the tests themselves) and we didn't raise this in CI. This adds a CI step to build the docker image which which checks the environment implicitly, but doesn't actually run the feature tests.

## Notes

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-8282](https://govukverify.atlassian.net/browse/FPAD-8282)


[FPAD-8282]: https://govukverify.atlassian.net/browse/FPAD-8282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ