### PR TITLE
FPAD-8280: Use Zod to generate main.yaml OpenAPI spec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
+        "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@aws-sdk/client-sso-oidc": "^3.1063.0",
         "@aws-sdk/client-sts": "^3.1063.0",
         "@eslint/js": "^10.0.1",
@@ -62,6 +63,19 @@
       },
       "engines": {
         "node": ">=24.14.0 <25"
+      }
+    },
+    "node_modules/@asteasolutions/zod-to-openapi": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@asteasolutions/zod-to-openapi/-/zod-to-openapi-8.5.0.tgz",
+      "integrity": "sha512-SABbKiObg5dLRiTFnqiW1WWwGcg1BJfmHtT2asIBnBHg6Smy/Ms2KHc650+JI4Hw7lSkdiNebEGXpwoxfben8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "openapi3-ts": "^4.1.2"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
       }
     },
     "node_modules/@asyncapi/specs": {
@@ -10139,6 +10153,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/openapi3-ts": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.6.0.tgz",
+      "integrity": "sha512-a4sfn6L2sIShhtzJqmjGrARvxAW/3F2BJDdyRVvNF9VhAsZSh5hSyI3a9TNvmzBxXmq66nY5LNT5bQcBxYAZZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.9.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -12999,6 +13023,22 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "build": "sam build -t src/infra/main/template.yaml",
     "package": "npm run clean && npm run build",
     "precommit": "pre-commit run",
-    "send-audit-event": "tsx src/commands/send-audit-event.ts"
+    "send-audit-event": "tsx src/commands/send-audit-event.ts",
+    "generate:spec:main": "tsx src/scripts/generate-main-spec.ts"
   },
   "dependencies": {
     "@aws-lambda-powertools/logger": "^2.33.1",
@@ -46,6 +47,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@aws-sdk/client-sso-oidc": "^3.1063.0",
     "@aws-sdk/client-sts": "^3.1063.0",
     "@eslint/js": "^10.0.1",

--- a/src/data-types/api-schemas-v1.ts
+++ b/src/data-types/api-schemas-v1.ts
@@ -1,0 +1,140 @@
+import z from 'zod';
+import { AISInterventionTypes } from './constants';
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+
+extendZodWithOpenApi(z);
+
+const InterventionMetadataSchema = z
+  .object({
+    updatedAt: z.number().int().openapi({
+      description: 'A timestamp (ms) when the status was last updated to the database.',
+      example: 1_696_969_322_935,
+      format: 'int64',
+    }),
+    appliedAt: z.number().int().openapi({
+      description: "A timestamp (ms) when the Intervention was Applied to the User's Account.",
+      example: 1_696_869_005_821,
+      format: 'int64',
+    }),
+    sentAt: z.number().int().openapi({
+      description: 'A timestamp (ms) when the Intervention was sent by Fraud Analyst/Risk Engine.',
+      example: 1696869003456,
+      format: 'int64',
+    }),
+    description: z.enum(AISInterventionTypes).openapi({
+      description: 'The specific intervention currently applied to the account.',
+      example: AISInterventionTypes.AIS_ACCOUNT_UNSUSPENDED,
+    }),
+    reprovedIdentityAt: z.number().int().optional().openapi({
+      description:
+        'A timestamp (ms) of when the User performed the reprove identity action to unsuspend their account.',
+      example: 1_696_969_322_935,
+      format: 'int64',
+    }),
+    resetPasswordAt: z.number().int().optional().openapi({
+      description: 'A timestamp (ms) of when the User performed the password reset action to unsuspend their account.',
+      example: 1_696_875_903_456,
+      format: 'int64',
+    }),
+    accountDeletedAt: z.number().int().optional().openapi({
+      description: 'A timestamp (ms) of when the account was deleted.',
+      example: 1_696_969_359_935,
+      format: 'int64',
+    }),
+  })
+  .openapi('InterventionMetadata', {
+    title: 'Intervention Metadata Schema',
+    description: 'Information about the current intervention',
+    readOnly: true,
+  });
+
+const AccountStateSchema = z
+  .object({
+    blocked: z.boolean().openapi({
+      example: false,
+      description:
+        'Indicates that the Account is **BLOCKED** and therefore permanently suspended.\n**N.B.** Overrides any other AccountState attributes.\nIf this value is `true` the user should be completely **BLOCKED** from accessing their account\nand is normally never expected to regain access.',
+    }),
+    suspended: z.boolean().openapi({
+      example: false,
+      description:
+        'Indicates that the Account is **SUSPENDED**.\n- If this value is `true` but `reproveIdentity` **AND** `resetPassword` are both set to `false` then the\nAccount is **SUSPENDED** and does NOT require the User to perform any actions.\n- If this value is `true` but `reproveIdentity` **OR** `resetPassword` is `true` then the Account\nis **SUSPENDED** and requires the User to perform an action to unsuspend their account.\n- If this value is `true` but `reproveIdentity` **AND** `resetPassword` are `true` then the Account\nis **SUSPENDED** and requires the User to perform multiple actions to unsuspend their account.',
+    }),
+    reproveIdentity: z.boolean().openapi({
+      example: false,
+      description:
+        'Indicates that the Account is **SUSPENDED** and requires the User to reprove their identity as a\nprerequisite to being able to regain access to their account.',
+    }),
+    resetPassword: z.boolean().openapi({
+      example: false,
+      description:
+        'Indicates that the Account is **SUSPENDED** and requires the User to reset their password as a\nprerequisite to being able to regain access to their account.',
+    }),
+  })
+  .openapi('AccountState', {
+    title: 'Account State Schema',
+    description: "Current state of the User's Account and whether user actions have been requested",
+    readOnly: true,
+  });
+
+const HistoryObjectSchema = z
+  .object({
+    sentAt: z.string().openapi({
+      example: '2023-10-10T20:22:02.925Z',
+      description:
+        'timestamp in ISO String format of when the intervention event was sent by the originating component',
+    }),
+    component: z
+      .string()
+      .openapi({ example: 'TICF_CRI', description: 'the name of the component that generated the intervention' }),
+    code: z.string().openapi({ example: '01', description: 'the numeric code associated with the intervention' }),
+    intervention: z.string().openapi({
+      example: 'FRAUD_SUSPEND_ACCOUNT',
+      description: 'the name of the intervention corresponding to the code',
+    }),
+    reason: z.string().openapi({
+      example: 'a reason for the intervention',
+      description: 'the reason field from the original intervention event',
+    }),
+    originatingComponent: z
+      .string()
+      .optional()
+      .openapi({ example: 'CMS', description: 'the name of the component that originated the intervention event' }),
+    originatorReferenceId: z.string().optional().openapi({
+      example: '12345',
+      description: 'the numeric code identifying the case that triggered the intervention',
+    }),
+    requesterId: z
+      .string()
+      .optional()
+      .openapi({ example: '12345', description: 'opaque id of the user that requested the intervention (no PII)' }),
+  })
+  .openapi('HistoryObject', {
+    title: 'Past intervention object',
+    description: 'JSON object representing an intervention previously applied on the account',
+    readOnly: true,
+  });
+
+const AuditLevelSchema = z.enum(['standard', 'enhanced']).default('standard').openapi('AuditLevel', {
+  title: 'Audit Level Schema',
+  description: 'Indicates if normal or enhanced downstream auditing is required for this account',
+  example: 'standard',
+});
+
+export const V1ResponseSchema = z
+  .object({
+    intervention: InterventionMetadataSchema,
+    state: AccountStateSchema,
+    auditLevel: AuditLevelSchema,
+    history: z.array(HistoryObjectSchema).optional().openapi('HistoryList', {
+      title: 'Intervention history',
+      description: 'History of intervention applied to this account',
+    }),
+  })
+  .openapi('InterventionStatusResponse', {
+    title: 'Account Intervention Status Schema',
+    description: "The Intervention Status of the User's OneLogin Account",
+    readOnly: true,
+  });
+
+export type V1Response = z.infer<typeof V1ResponseSchema>;

--- a/src/data-types/api-schemas-v2.ts
+++ b/src/data-types/api-schemas-v2.ts
@@ -1,0 +1,37 @@
+import z from 'zod';
+import { InterventionName } from './constants';
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+
+extendZodWithOpenApi(z);
+
+const InterventionNameSchema = z
+  .enum(InterventionName)
+  .openapi('InterventionName', { description: 'Enum of possible Intervention names' });
+
+const InterventionSchema = z
+  .object({
+    name: z.union([z.string(), InterventionNameSchema]).openapi({ example: InterventionName.RESET_PASSWORD }),
+  })
+  .openapi('Intervention', {
+    title: 'Intervention Schema',
+    description: 'Details about an intervention applied to an account',
+  });
+
+const InterventionsListSchema = z.array(InterventionSchema).openapi('InterventionsList', {
+  title: 'Interventions List',
+  description: 'List of interventions applied to an account',
+  example: [{ name: 'RESET_PASSWORD' }, { name: 'REPROVE_IDENTITY' }],
+  readOnly: true,
+});
+
+export const V2ResponseSchema = z
+  .object({
+    interventions: InterventionsListSchema,
+  })
+  .openapi('AccountStatusResponse', {
+    title: 'Account Status Schema',
+    description: "The Status of the User's OneLogin Account",
+    readOnly: true,
+  });
+
+export type V2Response = z.infer<typeof V2ResponseSchema>;

--- a/src/data-types/constants.ts
+++ b/src/data-types/constants.ts
@@ -131,3 +131,18 @@ export enum Codes {
 }
 
 export const isCode = (value: string): value is Codes => Object.values(Codes).includes(value as Codes);
+
+export enum InterventionState {
+  ACTIVE = 'ACTIVE',
+  IGNORED = 'IGNORED',
+  SUPERSEDED = 'SUPERSEDED',
+  MITIGATED = 'MITIGATED',
+  REMOVED = 'REMOVED',
+}
+
+export enum InterventionName {
+  PERMANENT_SUSPENSION = 'PERMANENT_SUSPENSION',
+  TEMPORARY_SUSPENSION = 'TEMPORARY_SUSPENSION',
+  RESET_PASSWORD = 'RESET_PASSWORD', //pragma: allowlist secret
+  REPROVE_IDENTITY = 'REPROVE_IDENTITY',
+}

--- a/src/handlers/status-retriever-handler.ts
+++ b/src/handlers/status-retriever-handler.ts
@@ -3,12 +3,14 @@ import { AppConfigService } from '../services/app-config-service';
 import logger from '../commons/logger';
 import { addMetric, metric } from '../commons/metrics';
 import { MetricNames, AISInterventionTypes } from '../data-types/constants';
-import { AccountStatus, FullAccountInformation, HistoryObject } from '../data-types/interfaces';
+import { FullAccountInformation, HistoryObject } from '../data-types/interfaces';
 import { DynamoDatabaseService } from '../services/dynamo-database-service';
 import { getCurrentTimestamp } from '../commons/get-current-timestamp';
 import { HistoryStringBuilder } from '../commons/history-string-builder';
 import getActiveInterventions from '../services/active-interventions-service';
 import { getPersistentInterventionEventsService, InterventionEventsService } from '../tables/intervention-events';
+import { UserIdParamSchema, V1QuerySchema } from '../scripts/generate-main-spec';
+import { V1Response } from '../data-types/api-schemas-v1';
 
 const appConfig = AppConfigService.getInstance();
 const dynamoDatabaseServiceInstance = new DynamoDatabaseService(appConfig.tableName);
@@ -26,7 +28,8 @@ export async function handle(
 ): Promise<APIGatewayProxyResult> {
   logger.addContext(context);
 
-  if (!event.pathParameters?.['userId']) {
+  const params = UserIdParamSchema.safeParse(event.pathParameters);
+  if (!params.success) {
     addMetric(MetricNames.INVALID_SUBJECT_ID);
     metric.publishStoredMetrics();
     return {
@@ -37,12 +40,12 @@ export async function handle(
 
   logger.info('This is a comment for tests');
 
-  const userId = decodeURIComponent(validateEvent(event.pathParameters['userId']));
+  const userId = decodeURIComponent(params.data.userId);
 
   try {
     if (event.resource === '/v2/ais/{userId}') return await v2StatusApiHandler(userId, interventionEventsService);
 
-    const historyQuery = event.queryStringParameters?.['history'];
+    const { history: historyQuery } = V1QuerySchema.parse(event.queryStringParameters ?? {});
 
     return await v1StatusApiHandler(userId, historyQuery);
   } catch (error) {
@@ -58,7 +61,7 @@ export async function handle(
   };
 }
 
-async function v1StatusApiHandler(userId: string, historyQuery: string | undefined) {
+async function v1StatusApiHandler(userId: string, historyQuery: boolean | undefined) {
   const response = await dynamoDatabaseServiceInstance.getFullAccountInformation(userId);
   if (!response) {
     logger.info('Query matched no records in DynamoDB.');
@@ -66,9 +69,7 @@ async function v1StatusApiHandler(userId: string, historyQuery: string | undefin
 
     const undefinedAccount = transformResponseFromDynamoDatabase({});
 
-    if (historyQuery && historyQuery === 'true') {
-      undefinedAccount.history = [];
-    }
+    if (historyQuery) undefinedAccount.history = [];
 
     metric.publishStoredMetrics();
     return {
@@ -79,9 +80,7 @@ async function v1StatusApiHandler(userId: string, historyQuery: string | undefin
 
   const accountStatus = transformResponseFromDynamoDatabase(response);
 
-  if (historyQuery && historyQuery === 'true') {
-    accountStatus.history = constructHistoryObjectField(response.history);
-  }
+  if (historyQuery) accountStatus.history = constructHistoryObjectField(response.history);
 
   metric.publishStoredMetrics();
   return {
@@ -120,32 +119,19 @@ async function v2StatusApiHandler(userId: string, interventionEventsService: Int
 }
 
 /**
- * Helper function to remove whitespace from the user id and to validate that the event contains a valid user id
- * @param userId - Obtained from APIGateway
- * @returns - the userId that is passed in, trimmed of any whitespace
- */
-function validateEvent(userId: string) {
-  const trimmedUserId = userId.trim();
-  if (!trimmedUserId) {
-    logger.warn('Attribute invalid: user_id is empty.');
-  }
-  return trimmedUserId;
-}
-
-/**
  * Function to transform the response from DynamoDB into an object.
  * @param item - Response from DynamoDB
  * @returns - An object with all the required fields for the handler response. Creates a default object if any fields are undefined.
  * Updates timestamps to now if they are returned as null.
  */
-function transformResponseFromDynamoDatabase(item: Partial<FullAccountInformation>) {
+function transformResponseFromDynamoDatabase(item: Partial<FullAccountInformation>): V1Response {
   const currentTimestampMs = getCurrentTimestamp().milliseconds;
-  const accountStatus: AccountStatus = {
+  return {
     intervention: {
       updatedAt: item.updatedAt ?? currentTimestampMs,
       appliedAt: item.appliedAt ?? currentTimestampMs,
       sentAt: item.sentAt ?? currentTimestampMs,
-      description: item.intervention ?? AISInterventionTypes.AIS_NO_INTERVENTION,
+      description: (item.intervention as AISInterventionTypes | undefined) ?? AISInterventionTypes.AIS_NO_INTERVENTION,
       reprovedIdentityAt: item.reprovedIdentityAt ?? undefined,
       resetPasswordAt: item.resetPasswordAt ?? undefined,
       accountDeletedAt: item.deletedAt ?? undefined,
@@ -156,9 +142,8 @@ function transformResponseFromDynamoDatabase(item: Partial<FullAccountInformatio
       resetPassword: item.resetPassword ?? false,
       reproveIdentity: item.reproveIdentity ?? false,
     },
-    auditLevel: item.auditLevel ?? 'standard',
+    auditLevel: (item.auditLevel as 'standard' | 'enhanced' | undefined) ?? 'standard',
   };
-  return accountStatus;
 }
 
 /**

--- a/src/handlers/tests/status-retriever-handler.test.ts
+++ b/src/handlers/tests/status-retriever-handler.test.ts
@@ -278,37 +278,16 @@ describe('status-retriever-handler', () => {
     expect(payload).toSatisfySchemaInApiSpec('InterventionStatusResponse');
   });
 
-  it('will return a default response if the userId contains whitespace and cannot find a userId that matches', async () => {
-    const accountNotFoundDefaultObject = {
-      intervention: {
-        updatedAt: 1685404800000,
-        appliedAt: 1685404800000,
-        sentAt: 1685404800000,
-        description: 'AIS_NO_INTERVENTION',
-      },
-      state: {
-        blocked: false,
-        suspended: false,
-        resetPassword: false,
-        reproveIdentity: false,
-      },
-      auditLevel: 'standard',
-    };
-
+  it('will return an error if the userId contains whitespace', async () => {
     const invalidPathParameters = {
       proxy: '/ais/{user_id}',
       userId: ' ',
     };
     const invalidTestEvent = { ...testEvent, pathParameters: invalidPathParameters };
     const response = await handle(invalidTestEvent, mockConfig);
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(logger.warn).toHaveBeenCalledTimes(1);
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(logger.warn).toHaveBeenCalledWith('Attribute invalid: user_id is empty.');
-    expect(response.statusCode).toBe(200);
+    expect(response.statusCode).toBe(400);
     const payload = JSON.parse(response.body) as unknown as Record<string, unknown>;
-    expect(payload).toEqual(accountNotFoundDefaultObject);
-    expect(payload).toSatisfySchemaInApiSpec('InterventionStatusResponse');
+    expect(payload).toEqual({ message: 'Invalid Request.' });
   });
 
   it('will return the correct response if there is a problem with the query to dynamoDB', async () => {

--- a/src/handlers/tests/status-retriever-handler.test.ts
+++ b/src/handlers/tests/status-retriever-handler.test.ts
@@ -6,11 +6,8 @@ import logger from '../../commons/logger';
 import { DynamoDatabaseService } from '../../services/dynamo-database-service';
 import { addMetric } from '../../commons/metrics';
 import jestOpenAPI from 'jest-openapi';
-import {
-  InMemoryInterventionEventsService,
-  InterventionName,
-  InterventionState,
-} from '../../tables/intervention-events';
+import { InMemoryInterventionEventsService } from '../../tables/intervention-events';
+import { InterventionName, InterventionState } from '../../data-types/constants';
 
 jestOpenAPI(`${__dirname}/../../specs/main.yaml`);
 

--- a/src/scripts/generate-main-spec.ts
+++ b/src/scripts/generate-main-spec.ts
@@ -1,0 +1,215 @@
+import { OpenApiGeneratorV3, OpenAPIRegistry, type RouteConfig } from '@asteasolutions/zod-to-openapi';
+import { writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { ResponseObject } from 'openapi3-ts/oas30';
+import { stringify } from 'yaml';
+
+import { z } from 'zod';
+import { V1ResponseSchema } from '../data-types/api-schemas-v1';
+import { V2ResponseSchema } from '../data-types/api-schemas-v2';
+
+const registry = new OpenAPIRegistry();
+
+registry.register(
+  'Error',
+  z.object({ message: z.string().openapi({ example: 'error message' }).optional() }).openapi({ title: 'Error Schema' }),
+);
+
+interface ResponseEntry {
+  description: string;
+  content?: Record<string, unknown>;
+}
+
+/**
+ * Put the responses at the top level with references rather than in schemas
+ * @param responses - OpenAPI responses
+ * @returns
+ */
+const hoistResponses = (responses: Record<number, ResponseEntry>): RouteConfig['responses'] =>
+  Object.entries(responses).reduce<RouteConfig['responses']>((acc, [statusCode, response]) => {
+    if (Number(statusCode) === 200)
+      // Ignore the default response
+      return { ...acc, [statusCode]: response as RouteConfig['responses'][string] };
+
+    const name = response.description.replaceAll(' ', '');
+    registry.registerComponent('responses', name, response as ResponseObject);
+    return { ...acc, [statusCode]: { $ref: `#/components/responses/${name}` } };
+  }, {});
+
+const errorResponses = {
+  400: {
+    description: 'Bad Request',
+    content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } },
+  },
+  500: {
+    description: 'Server Error',
+    content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } },
+  },
+  502: {
+    description: 'Bad Gateway',
+    content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } },
+  },
+  504: {
+    description: 'Gateway Timeout',
+    content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } },
+  },
+  default: {
+    description: 'Unexpected Error',
+    content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } },
+  },
+};
+
+registry.register('InterventionStatusResponse', V1ResponseSchema);
+registry.register('AccountStatusResponse', V2ResponseSchema);
+
+// --- Params ---
+
+export const UserIdParam = registry.registerParameter(
+  'UserId',
+  z
+    .string()
+    .trim()
+    .regex(/^[^,\s]+$/)
+    .openapi({
+      param: { name: 'userId', in: 'path', example: 'urn:fdc:gov.uk:2022:JG0RJI1pYbnanbvPs-j4j5-a-PFcmhry9Qu9NCEp5d4' },
+      description:
+        'An internal DI subject identifier. See [ADR-0061](https://github.com/govuk-one-login/architecture/blob/RFC_identity_inheritance/adr/0061-common-subject-identifier-for-internal-DI-functions.md#internal-di-functions-to-use-subjectid) which refers to the `SubjectId` described in [ADR-0024](https://github.com/govuk-one-login/architecture/blob/RFC_identity_inheritance/adr/0024-user-identifiers.md#decision) which follows the format defined in [RFC-0027](https://github.com/govuk-one-login/architecture/blob/RFC_identity_inheritance/rfc/0027-subject-identifier-format.md).',
+    }),
+);
+
+export const UserIdParamSchema = z.object({ userId: UserIdParam });
+
+export const HistoryParam = registry.registerParameter(
+  'History',
+  z.coerce
+    .boolean()
+    .optional()
+    .openapi({
+      description: "A flag to enable the recall of the account's previous intervention history.",
+      param: { name: 'history', in: 'query', example: true },
+    }),
+);
+
+export const V1QuerySchema = z.object({ history: HistoryParam });
+
+registry.registerPath({
+  method: 'get',
+  path: '/v1/ais/{userId}',
+  operationId: 'ais',
+  tags: ['Status'],
+  summary: 'Get User Account Intervention Status',
+  description: "Returns the state of the latest intervention applied on a user's account",
+  request: {
+    params: UserIdParamSchema,
+    query: V1QuerySchema,
+  },
+  responses: hoistResponses({
+    200: {
+      description: 'Ok',
+      content: { 'application/json': { schema: { $ref: '#/components/schemas/InterventionStatusResponse' } } },
+    },
+    ...errorResponses,
+  }),
+  'x-amazon-apigateway-integration': {
+    httpMethod: 'POST',
+    type: 'aws_proxy',
+    uri: {
+      'Fn::Sub':
+        'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${StatusRetrieverFunction.Arn}:live/invocations',
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/v2/ais/{userId}',
+  operationId: 'aisV2',
+  tags: ['Status'],
+  summary: 'Get User Account Intervention Status',
+  description: "Returns the active interventions applied on a user's account",
+  request: {
+    params: UserIdParamSchema,
+  },
+  responses: hoistResponses({
+    200: {
+      description: 'Ok',
+      content: { 'application/json': { schema: { $ref: '#/components/schemas/AccountStatusResponse' } } },
+    },
+    ...errorResponses,
+  }),
+  'x-amazon-apigateway-integration': {
+    httpMethod: 'POST',
+    type: 'aws_proxy',
+    uri: {
+      'Fn::Sub':
+        'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${StatusRetrieverFunction.Arn}:live/invocations',
+    },
+  },
+});
+
+const generator = new OpenApiGeneratorV3(registry.definitions);
+
+const document = generator.generateDocument({
+  openapi: '3.0.3',
+  info: {
+    title: 'Account Intervention Status API',
+    description:
+      "An API that provides methods to query the OneLogin Account Interventions Service\nfor the current intervention state of a User's Account.\n\nThis solution was created as part of the Interventions initiative.\n\n__N.B__\n - Recommend HTTP client __Timeout__ settings of `5 seconds` to handle requests where backend services experience cold starts.",
+    version: '0.0.1',
+    contact: {
+      name: 'Government Digital Service - Accounts Bravo Team',
+      email: 'interventions@digital.cabinet-office.gov.uk',
+    },
+    license: {
+      name: 'MIT',
+      url: 'https://github.com/govuk-one-login/account-interventions-service/blob/main/LICENCE.md',
+    },
+  },
+  servers: [
+    {
+      url: 'https://{environment}.execute-api.eu-west-2.amazonaws.com/main',
+      description: 'defaults to staging environment',
+      variables: {
+        environment: {
+          default: 'vjdj6kjrj2',
+          enum: [
+            'u9uw8aqu0c', //dev
+            'rg7pm38qj4', //build
+            'vjdj6kjrj2', //staging
+            '65zhj32bjb', //integration
+            'ruz07ekh4b', //production
+          ],
+        },
+      },
+    },
+  ],
+  tags: [
+    {
+      name: 'Status',
+      description:
+        "Provides information on an account's intervention status.\n\nExpected users are the **DI Internal** teams ONLY.",
+    },
+  ],
+});
+
+// Inline parameter schemas so they don't use $ref to components/schemas
+const schemas = document.components?.schemas;
+const parameters = document.components?.parameters as
+  | Record<string, { schema?: { $ref?: string; description?: string } }>
+  | undefined;
+if (schemas && parameters) {
+  for (const param of Object.values(parameters)) {
+    const ref = param.schema?.$ref;
+    const schemaName = ref?.split('/').pop();
+    if (schemaName) {
+      param.schema = schemas[schemaName] as { $ref?: string; description?: string };
+      delete param.schema.description;
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete schemas[schemaName];
+    }
+  }
+}
+
+const outputPath = path.resolve(import.meta.dirname, '../specs/main.yaml');
+writeFileSync(outputPath, stringify(document, { lineWidth: 0 }));
+console.log(`Written to ${outputPath}`);

--- a/src/services/active-interventions-service.ts
+++ b/src/services/active-interventions-service.ts
@@ -1,7 +1,7 @@
 import logger from '../commons/logger';
-import { LOGS_PREFIX_SENSITIVE_INFO } from '../data-types/constants';
+import { InterventionName, InterventionState, LOGS_PREFIX_SENSITIVE_INFO } from '../data-types/constants';
 import { StateDetails } from '../data-types/interfaces';
-import { InterventionEventsService, InterventionName, InterventionState } from '../tables/intervention-events';
+import { InterventionEventsService } from '../tables/intervention-events';
 
 /**
  * Get a list of currently active interventions on an account

--- a/src/services/persist-intervention-events.ts
+++ b/src/services/persist-intervention-events.ts
@@ -1,14 +1,9 @@
 import { getCurrentTimestamp } from '../commons/get-current-timestamp';
 import logger from '../commons/logger';
 import { InterventionEventMessage } from '../contracts/intervention-events';
-import { EventsEnum, LOGS_PREFIX_SENSITIVE_INFO } from '../data-types/constants';
+import { EventsEnum, InterventionName, InterventionState, LOGS_PREFIX_SENSITIVE_INFO } from '../data-types/constants';
 import { StateDetails } from '../data-types/interfaces';
-import {
-  InterventionEvent,
-  InterventionEventsService,
-  InterventionName,
-  InterventionState,
-} from '../tables/intervention-events';
+import { InterventionEvent, InterventionEventsService } from '../tables/intervention-events';
 import { randomUUID } from 'node:crypto';
 import getActiveInterventions from './active-interventions-service';
 

--- a/src/services/test/active-interventions-service.test.ts
+++ b/src/services/test/active-interventions-service.test.ts
@@ -1,4 +1,4 @@
-import { InterventionName, InterventionState } from '../../tables/intervention-events';
+import { InterventionName, InterventionState } from '../../data-types/constants';
 import { filterEventStreamToActive, previousStateToInterventions } from '../active-interventions-service';
 
 describe('previousStateToInterventions', () => {

--- a/src/services/test/persist-intervention-events.test.ts
+++ b/src/services/test/persist-intervention-events.test.ts
@@ -1,10 +1,6 @@
 import { InterventionEventMessage } from '../../contracts/intervention-events';
-import { EventsEnum, TriggerEventsEnum } from '../../data-types/constants';
-import {
-  InMemoryInterventionEventsService,
-  InterventionName,
-  InterventionState,
-} from '../../tables/intervention-events';
+import { EventsEnum, InterventionName, InterventionState, TriggerEventsEnum } from '../../data-types/constants';
+import { InMemoryInterventionEventsService } from '../../tables/intervention-events';
 import persistInterventionEvents, { generateEventsToAppend } from '../persist-intervention-events';
 
 const baseMessage: InterventionEventMessage = {

--- a/src/specs/main.yaml
+++ b/src/specs/main.yaml
@@ -1,8 +1,6 @@
----
 openapi: 3.0.3
-
 info:
-  title: 'Account Intervention Status API'
+  title: Account Intervention Status API
   description: |-
     An API that provides methods to query the OneLogin Account Interventions Service
     for the current intervention state of a User's Account.
@@ -11,164 +9,108 @@ info:
 
     __N.B__
      - Recommend HTTP client __Timeout__ settings of `5 seconds` to handle requests where backend services experience cold starts.
-
   version: 0.0.1
   contact:
     name: Government Digital Service - Accounts Bravo Team
     email: interventions@digital.cabinet-office.gov.uk
   license:
-    name: 'MIT'
-    url: 'https://github.com/govuk-one-login/account-interventions-service/blob/main/LICENCE.md'
-
+    name: MIT
+    url: https://github.com/govuk-one-login/account-interventions-service/blob/main/LICENCE.md
 servers:
-  - url: 'https://{environment}.execute-api.eu-west-2.amazonaws.com/main'
+  - url: https://{environment}.execute-api.eu-west-2.amazonaws.com/main
     description: defaults to staging environment
     variables:
       environment:
-        default: vjdj6kjrj2 # staging
+        default: vjdj6kjrj2
         enum:
-          - u9uw8aqu0c # dev
-          - rg7pm38qj4 # build
-          - vjdj6kjrj2 # staging
-          - 65zhj32bjb # integration
-          - ruz07ekh4b # Production
+          - u9uw8aqu0c
+          - rg7pm38qj4
+          - vjdj6kjrj2
+          - 65zhj32bjb
+          - ruz07ekh4b
+tags:
+  - name: Status
+    description: |-
+      Provides information on an account's intervention status.
 
-paths:
-  /v1/ais/{userId}:
-    get:
-      summary: 'Get User Account Intervention Status'
-      description: "Returns the state of the latest intervention applied on a user's account"
-      operationId: 'ais'
-      tags:
-        - Status
-      parameters:
-        - $ref: '#/components/parameters/UserId'
-        - $ref: '#/components/parameters/History'
-      responses:
-        '200':
-          description: 'Ok'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InterventionStatusResponse'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '500':
-          $ref: '#/components/responses/ServerError'
-        '502':
-          $ref: '#/components/responses/BadGateway'
-        '504':
-          $ref: '#/components/responses/GatewayTimeout'
-        default:
-          $ref: '#/components/responses/UnexpectedError'
-      x-amazon-apigateway-integration:
-        httpMethod: 'POST'
-        type: aws_proxy
-        uri:
-          Fn::Sub: 'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${StatusRetrieverFunction.Arn}:live/invocations'
-
-  /v2/ais/{userId}:
-    get:
-      summary: 'Get User Account Intervention Status'
-      description: "Returns the active interventions on a user's account"
-      operationId: 'aisV2'
-      tags:
-        - Status
-      parameters:
-        - $ref: '#/components/parameters/UserId'
-      responses:
-        '200':
-          description: 'Ok'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AccountStatusResponse'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '500':
-          $ref: '#/components/responses/ServerError'
-        '502':
-          $ref: '#/components/responses/BadGateway'
-        '504':
-          $ref: '#/components/responses/GatewayTimeout'
-        default:
-          $ref: '#/components/responses/UnexpectedError'
-      x-amazon-apigateway-integration:
-        httpMethod: 'POST'
-        type: aws_proxy
-        uri:
-          Fn::Sub: 'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${StatusRetrieverFunction.Arn}:live/invocations'
-
+      Expected users are the **DI Internal** teams ONLY.
 components:
+  responses:
+    BadRequest:
+      description: Bad Request
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    ServerError:
+      description: Server Error
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    BadGateway:
+      description: Bad Gateway
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    GatewayTimeout:
+      description: Gateway Timeout
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    UnexpectedError:
+      description: Unexpected Error
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
   schemas:
-    # v2 schemas
-    AccountStatusResponse:
-      title: 'Account Status Schema'
-      description: "The Status of the User's OneLogin Account"
+    Error:
       type: object
-      readOnly: true
+      properties:
+        message:
+          type: string
+          example: error message
+      title: Error Schema
+    InterventionStatusResponse:
+      type: object
+      properties:
+        intervention:
+          $ref: "#/components/schemas/InterventionMetadata"
+        state:
+          $ref: "#/components/schemas/AccountState"
+        auditLevel:
+          $ref: "#/components/schemas/AuditLevel"
+        history:
+          $ref: "#/components/schemas/HistoryList"
       required:
-        - interventions
-      properties:
-        interventions:
-          $ref: '#/components/schemas/InterventionsList'
-    InterventionsList:
-      title: 'Interventions List'
-      description: 'List of interventions applied to an account'
+        - intervention
+        - state
+      title: Account Intervention Status Schema
+      description: The Intervention Status of the User's OneLogin Account
       readOnly: true
-      type: array
-      items:
-        $ref: '#/components/schemas/Intervention'
-      example: [{ name: 'RESET_PASSWORD' }, { name: 'REPROVE_IDENTITY' }]
-    Intervention:
-      title: 'Intervention Schema'
-      description: 'Details about an intervention applied to an account'
-      type: object
-      properties:
-        name:
-          anyOf:
-            - type: string
-            - $ref: '#/components/schemas/InterventionName'
-          example: 'RESET_PASSWORD'
-    InterventionName:
-      type: string
-      description: 'Enum of possible Intervention names'
-      enum:
-        - 'PERMANENT_SUSPENSION'
-        - 'TEMPORARY_SUSPENSION'
-        - 'RESET_PASSWORD'
-        - 'REPROVE_IDENTITY'
-    # v1 schemas
     InterventionMetadata:
-      title: 'Intervention Metadata Schema'
-      description: 'Information about the current intervention'
-      type: 'object'
-      readOnly: true
-      required:
-        - updatedAt
-        - appliedAt
-        - sentAt
-        - description
+      type: object
       properties:
         updatedAt:
+          type: integer
           description: A timestamp (ms) when the status was last updated to the database.
-          type: integer
+          example: 1696969322935
           format: int64
-          example: 1696969322935 # 2023-10-10T20:22:02.925Z
         appliedAt:
+          type: integer
           description: A timestamp (ms) when the Intervention was Applied to the User's Account.
-          type: integer
+          example: 1696869005821
           format: int64
-          example: 1696869005821 # 2023-10-09T16:30:05.821Z
         sentAt:
-          description: A timestamp (ms) when the Intervention was sent by Fraud Analyst/Risk Engine.
           type: integer
+          description: A timestamp (ms) when the Intervention was sent by Fraud Analyst/Risk Engine.
+          example: 1696869003456
           format: int64
-          example: 1696869003456 # 2023-10-09T16:30:03.456Z
         description:
-          description: The specific intervention currently applied to the account.
           type: string
-          example: AIS_ACCOUNT_UNSUSPENDED
           enum:
             - AIS_NO_INTERVENTION
             - AIS_ACCOUNT_SUSPENDED
@@ -178,39 +120,38 @@ components:
             - AIS_FORCED_USER_PASSWORD_RESET
             - AIS_FORCED_USER_IDENTITY_VERIFY
             - AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY
+          description: The specific intervention currently applied to the account.
+          example: AIS_ACCOUNT_UNSUSPENDED
         reprovedIdentityAt:
-          description: |
-            A timestamp (ms) of when the User performed the reprove identity action to unsuspend their account.
           type: integer
+          description: A timestamp (ms) of when the User performed the reprove identity action to unsuspend their account.
+          example: 1696969322935
           format: int64
-          example: 1696969322935 # 2023-10-10T20:22:02.925Z
         resetPasswordAt:
-          description: |
-            A timestamp (ms) of when the User performed the password reset action to unsuspend their account.
           type: integer
+          description: A timestamp (ms) of when the User performed the password reset action to unsuspend their account.
+          example: 1696875903456
           format: int64
-          example: 1696875903456 # 2023-10-09T18:25:03.789Z
         accountDeletedAt:
-          description: |
-            A timestamp (ms) of when the account was deleted.
           type: integer
+          description: A timestamp (ms) of when the account was deleted.
+          example: 1696969359935
           format: int64
-          example: 1696969359935 # 2023-10-10T20:59:02.925Z
-    AccountState:
-      title: 'Account State Schema'
-      description: "Current state of the User's Account and whether user actions have been requested"
-      type: 'object'
-      readOnly: true
       required:
-        - blocked
-        - suspended
-        - reproveIdentity
-        - resetPassword
+        - updatedAt
+        - appliedAt
+        - sentAt
+        - description
+      title: Intervention Metadata Schema
+      description: Information about the current intervention
+      readOnly: true
+    AccountState:
+      type: object
       properties:
         blocked:
           type: boolean
           example: false
-          description: |
+          description: |-
             Indicates that the Account is **BLOCKED** and therefore permanently suspended.
             **N.B.** Overrides any other AccountState attributes.
             If this value is `true` the user should be completely **BLOCKED** from accessing their account
@@ -218,7 +159,7 @@ components:
         suspended:
           type: boolean
           example: false
-          description: |
+          description: |-
             Indicates that the Account is **SUSPENDED**.
             - If this value is `true` but `reproveIdentity` **AND** `resetPassword` are both set to `false` then the
             Account is **SUSPENDED** and does NOT require the User to perform any actions.
@@ -229,84 +170,72 @@ components:
         reproveIdentity:
           type: boolean
           example: false
-          description: |
+          description: |-
             Indicates that the Account is **SUSPENDED** and requires the User to reprove their identity as a
             prerequisite to being able to regain access to their account.
         resetPassword:
           type: boolean
           example: false
-          description: |
+          description: |-
             Indicates that the Account is **SUSPENDED** and requires the User to reset their password as a
             prerequisite to being able to regain access to their account.
+      required:
+        - blocked
+        - suspended
+        - reproveIdentity
+        - resetPassword
+      title: Account State Schema
+      description: Current state of the User's Account and whether user actions have been requested
+      readOnly: true
     AuditLevel:
-      title: 'Audit Level Schema'
-      description: 'Indicates if normal or enhanced downstream auditing is required for this account'
       type: string
-      example: standard
       enum:
         - standard
         - enhanced
       default: standard
-    History:
-      title: 'Intervention history'
-      description: 'History of intervention applied to this account'
+      title: Audit Level Schema
+      description: Indicates if normal or enhanced downstream auditing is required for this account
+      example: standard
+    HistoryList:
       type: array
       items:
-        $ref: '#/components/schemas/HistoryObject'
-    InterventionStatusResponse:
-      title: 'Account Intervention Status Schema'
-      description: "The Intervention Status of the User's OneLogin Account"
-      type: 'object'
-      readOnly: true
-      required:
-        - intervention
-        - state
-      properties:
-        intervention:
-          $ref: '#/components/schemas/InterventionMetadata'
-        state:
-          $ref: '#/components/schemas/AccountState'
-        auditLevel:
-          $ref: '#/components/schemas/AuditLevel'
-        history:
-          $ref: '#/components/schemas/History'
+        $ref: "#/components/schemas/HistoryObject"
+      title: Intervention history
+      description: History of intervention applied to this account
     HistoryObject:
-      title: 'Past intervention object'
-      description: 'JSON object representing an intervention previously applied on the account'
-      type: 'object'
-      readOnly: true
+      type: object
       properties:
         sentAt:
           type: string
-          example: '2023-10-10T20:22:02.925Z'
+          example: 2023-10-10T20:22:02.925Z
           description: timestamp in ISO String format of when the intervention event was sent by the originating component
         component:
           type: string
-          example: 'TICF_CRI'
+          example: TICF_CRI
           description: the name of the component that generated the intervention
         code:
           type: string
-          example: '01'
+          example: "01"
           description: the numeric code associated with the intervention
         intervention:
           type: string
-          example: 'FRAUD_SUSPEND_ACCOUNT'
+          example: FRAUD_SUSPEND_ACCOUNT
           description: the name of the intervention corresponding to the code
         reason:
           type: string
-          example: 'a reason for the intervention'
+          example: a reason for the intervention
           description: the reason field from the original intervention event
         originatingComponent:
           type: string
-          example: 'CMS'
+          example: CMS
           description: the name of the component that originated the intervention event
         originatorReferenceId:
           type: string
-          example: '12345'
+          example: "12345"
           description: the numeric code identifying the case that triggered the intervention
         requesterId:
           type: string
-          example: '12345'
+          example: "12345"
           description: opaque id of the user that requested the intervention (no PII)
       required:
         - sentAt
@@ -314,73 +243,129 @@ components:
         - code
         - intervention
         - reason
-
-    Error:
-      title: 'Error Schema'
-      type: 'object'
+      title: Past intervention object
+      description: JSON object representing an intervention previously applied on the account
+      readOnly: true
+    AccountStatusResponse:
+      type: object
       properties:
-        message:
-          type: 'string'
-          example: 'error message'
+        interventions:
+          $ref: "#/components/schemas/InterventionsList"
+      required:
+        - interventions
+      title: Account Status Schema
+      description: The Status of the User's OneLogin Account
+      readOnly: true
+    InterventionsList:
+      type: array
+      items:
+        $ref: "#/components/schemas/Intervention"
+      title: Interventions List
+      description: List of interventions applied to an account
+      example:
+        - name: RESET_PASSWORD
+        - name: REPROVE_IDENTITY
+      readOnly: true
+    Intervention:
+      type: object
+      properties:
+        name:
+          anyOf:
+            - type: string
+            - $ref: "#/components/schemas/InterventionName"
+          example: RESET_PASSWORD
+      required:
+        - name
+      title: Intervention Schema
+      description: Details about an intervention applied to an account
+    InterventionName:
+      type: string
+      enum:
+        - PERMANENT_SUSPENSION
+        - TEMPORARY_SUSPENSION
+        - RESET_PASSWORD
+        - REPROVE_IDENTITY
+      description: Enum of possible Intervention names
   parameters:
     UserId:
-      name: userId
-      in: path
-      description: >-
-        A internal DI subject identifier. See
-        [ADR-0061](https://github.com/govuk-one-login/architecture/blob/RFC_identity_inheritance/adr/0061-common-subject-identifier-for-internal-DI-functions.md#internal-di-functions-to-use-subjectid)
-        which refers to the `SubjectId` described in
-        [ADR-0024](https://github.com/govuk-one-login/architecture/blob/RFC_identity_inheritance/adr/0024-user-identifiers.md#decision)
-        which follows the format defined in
-        [RFC-0027](https://github.com/govuk-one-login/architecture/blob/RFC_identity_inheritance/rfc/0027-subject-identifier-format.md).
-      required: true
-      example: 'urn:fdc:gov.uk:2022:JG0RJI1pYbnanbvPs-j4j5-a-PFcmhry9Qu9NCEp5d4'
       schema:
         type: string
         pattern: ^[^,\s]+$
+      required: true
+      description: An internal DI subject identifier. See [ADR-0061](https://github.com/govuk-one-login/architecture/blob/RFC_identity_inheritance/adr/0061-common-subject-identifier-for-internal-DI-functions.md#internal-di-functions-to-use-subjectid) which refers to the `SubjectId` described in [ADR-0024](https://github.com/govuk-one-login/architecture/blob/RFC_identity_inheritance/adr/0024-user-identifiers.md#decision) which follows the format defined in [RFC-0027](https://github.com/govuk-one-login/architecture/blob/RFC_identity_inheritance/rfc/0027-subject-identifier-format.md).
+      name: userId
+      in: path
+      example: urn:fdc:gov.uk:2022:JG0RJI1pYbnanbvPs-j4j5-a-PFcmhry9Qu9NCEp5d4
     History:
-      name: history
-      in: query
-      description: "A flag to enable the recall of the account's previous intervention history."
-      required: false
-      example: true
       schema:
         type: boolean
-  responses:
-    BadRequest:
-      description: 'Bad Request'
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Error'
-    ServerError:
-      description: 'Server Error'
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Error'
-    BadGateway:
-      description: 'Bad Gateway'
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Error'
-    GatewayTimeout:
-      description: 'Gateway Timeout'
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Error'
-    UnexpectedError:
-      description: 'Unexpected Error'
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Error'
-
-tags:
-  - name: Status
-    description: |-
-      Provides information on an account's intervention status.
-
-      Expected users are the **DI Internal** teams ONLY.
+        nullable: true
+      required: false
+      description: A flag to enable the recall of the account's previous intervention history.
+      name: history
+      in: query
+      example: true
+paths:
+  /v1/ais/{userId}:
+    get:
+      operationId: ais
+      tags:
+        - Status
+      summary: Get User Account Intervention Status
+      description: Returns the state of the latest intervention applied on a user's account
+      x-amazon-apigateway-integration:
+        httpMethod: POST
+        type: aws_proxy
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${StatusRetrieverFunction.Arn}:live/invocations
+      parameters:
+        - $ref: "#/components/parameters/UserId"
+        - $ref: "#/components/parameters/History"
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InterventionStatusResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/ServerError"
+        "502":
+          $ref: "#/components/responses/BadGateway"
+        "504":
+          $ref: "#/components/responses/GatewayTimeout"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
+  /v2/ais/{userId}:
+    get:
+      operationId: aisV2
+      tags:
+        - Status
+      summary: Get User Account Intervention Status
+      description: Returns the active interventions applied on a user's account
+      x-amazon-apigateway-integration:
+        httpMethod: POST
+        type: aws_proxy
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${StatusRetrieverFunction.Arn}:live/invocations
+      parameters:
+        - $ref: "#/components/parameters/UserId"
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AccountStatusResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/ServerError"
+        "502":
+          $ref: "#/components/responses/BadGateway"
+        "504":
+          $ref: "#/components/responses/GatewayTimeout"
+        default:
+          $ref: "#/components/responses/UnexpectedError"

--- a/src/tables/intervention-events.ts
+++ b/src/tables/intervention-events.ts
@@ -3,23 +3,9 @@ import { AppConfigService } from '../services/app-config-service';
 import { DynamoDBRecordService, RecordService } from '../services/dynamo-db-record-service';
 import TableConfig from './table-config';
 import { getDBDocClient } from '../services/db-client';
+import { InterventionName, InterventionState } from '../data-types/constants';
 
 const appConfig = AppConfigService.getInstance();
-
-export enum InterventionState {
-  ACTIVE = 'ACTIVE',
-  IGNORED = 'IGNORED',
-  SUPERSEDED = 'SUPERSEDED',
-  MITIGATED = 'MITIGATED',
-  REMOVED = 'REMOVED',
-}
-
-export enum InterventionName {
-  PERMANENT_SUSPENSION = 'PERMANENT_SUSPENSION',
-  TEMPORARY_SUSPENSION = 'TEMPORARY_SUSPENSION',
-  RESET_PASSWORD = 'RESET_PASSWORD', //pragma: allowlist secret
-  REPROVE_IDENTITY = 'REPROVE_IDENTITY',
-}
 
 const schema = z.object({
   eventId: z.string(),

--- a/src/tables/test/intervention-events.test.ts
+++ b/src/tables/test/intervention-events.test.ts
@@ -1,10 +1,6 @@
+import { InterventionName, InterventionState } from '../../data-types/constants';
 import { InMemoryRecordService } from '../../services/dynamo-db-record-service';
-import {
-  interventionEventsTableConfig,
-  InterventionName,
-  InterventionState,
-  PersistentInterventionEventsService,
-} from '../intervention-events';
+import { interventionEventsTableConfig, PersistentInterventionEventsService } from '../intervention-events';
 
 describe('PersistentInterventionEventsService', () => {
   test('fetchEventsForAccount', async () => {


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Use Zod to generate main.yaml OpenAPI spec

## Why

This allows us to validate the inputs.

This should make it easy to generate Typescript types for an SDK.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-8280](https://govukverify.atlassian.net/browse/FPAD-8280)

[FPAD-8280]: https://govukverify.atlassian.net/browse/FPAD-8280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ