### PR TITLE
FPAD-8334: Incident docs

### DIFF
--- a/docs/incidents/20260618-lambda-retries.md
+++ b/docs/incidents/20260618-lambda-retries.md
@@ -1,0 +1,42 @@
+# Lambda retries
+
+## Summary
+
+The intervention processor lambda was throwing an error at the very end of its execution because of a malformed DynamoDB query.
+Because the error was at the end of the execution this led to many retries of tasks which had already been successfully carried out.
+These retries were idempotent so the impact was limited.
+The remediation was to revert the change, but this failed because the canary deployments were listening for the alarm that was still going off and rolled back the reverted version.
+The remediation for the deployment failing was to increase the thresholds on the alarm to stop it firing, then revert the increase after the deployment succeeded.
+
+### Things that went well
+
+- An alert fired!
+- No fundamental missing test capability
+
+### Things that went poorly
+
+- We have a missing test case (no feature test for the final output of the lambda)
+- We can't diagnose things without escalated access or VPN access, and we can't gain escalated access without using TEAM which requires 2 team members to be online.
+    - It wasn't obvious that the VPN not being on was blocking the ability to diagnose the issue
+- It was unclear how severe the problem was, and who was responsible for it being resolved
+- The alarm only went off when an event came in
+- The alarm was hard to turn off
+
+### Where we got lucky
+
+- The issue wasn't a P1
+
+## Actions
+- Ed to create some docs around incidents.
+- Developers to come up with a response approach to non-critical alarms in the next engineering catchup - something like a doc with:
+    - Our responsibilities if a non-critical alarm is going off.
+    - Principles like using IaC for changes where possible.
+    - Practical things like probably get on the vpc.
+    - "Hacks" like using alarm thresholds for unblocking canaries.
+
+# Timeline
+
+[2026-06-09]
+[19:27] An alarm goes off
+[2026-06-10]
+[The morning] Edward and Kirsty fix the issue

--- a/docs/incidents/README.md
+++ b/docs/incidents/README.md
@@ -1,0 +1,21 @@
+# Incidents
+
+We're obliged to run a post-incident review for any P1 or P2 incident - for these incidents you should refer to [the team manual](https://team-manual.account.gov.uk/supporting-govuk-one-login/managing-incidents/create-post-incident-review/).
+For incidents less severe than that we can hold an incident review as an internal process (while still inviting people from outside the team where needed).
+An action for holding a post-incident review meeting and writing up a report should be assigned to someone soon after the incident happens.
+
+## Running a post-incident review meeting
+
+You should write the first draft of the incident report before the meeting, based on the [report template](./template.md).
+
+The meeting is designed to spread context about what happened and consolidate learnings and improvements.
+The invite list is flexible but a good place to start is the whole team, plus representatives of any other teams affected.
+
+At the start of the review meeting you should reiterate that it's a **blame-free** process based on the processes and systems that failed, not the people.
+Run through the report template and focus on establishing the facts and finding good learnings.
+After the meeting the final report should be placed in this directory, which is linked to from the Team Manual for discoverability.
+
+## External links
+
+The template is based on recommendations from the [Google SRE manual Postmortem culture chapter](https://sre.google/workbook/postmortem-culture/).
+The book also provides [a separate example postmortem](https://sre.google/sre-book/example-postmortem/).

--- a/docs/incidents/template.md
+++ b/docs/incidents/template.md
@@ -1,0 +1,38 @@
+# Incident report template
+
+This is a template for incident reports, based on recommendations from the [Google SRE Book](https://sre.google/workbook/postmortem-culture/); refer to it for more detail on the sections below.
+This document and the wider incident response process should be blame-free and focus on processes and systems and not people.
+
+## Summary
+
+A quick summary of the incident; what went wrong, its impact, and how it was remediated.
+
+## Learnings
+
+These sections are bullet point lists to help generate actions.
+
+### What went well
+
+### What went poorly
+
+### Where we got lucky
+
+## Actions
+
+The actions are the most important outcome of the incident process.
+They should drive the improvement of the team's processes and practices.
+All actions should be assigned to someone, as in the examples below.
+
+- Alice to automate the server reboot process.
+- Bob to fix the bug that brought the server down.
+
+## Timeline
+
+A timeline of the events important to the incident.
+The example below demonstrates one way of formatting it.
+
+[2026-05-10]
+[23:46] Alice gets paged because the server has gone down
+[23:52] Alice finds the root cause
+[2026-05-11]
+[00:11] Alice brings the server back up


### PR DESCRIPTION
## What

Some docs for running post-incident reviews and writing reports.

## Why

We had an incident recently and did the PIR process on the fly - writing it down now will save us repeating the thinking in the future.

## Notes

The docs refer to a page in the team manual - I'll add that once this is merged and I have something to link to.

These docs don't cover managing the actual incident itself.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-8334](https://govukverify.atlassian.net/browse/FPAD-8334)


[FPAD-8334]: https://govukverify.atlassian.net/browse/FPAD-8334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ