### PR TITLE
Pre-prod VPC endpoint config for AMC

### DIFF
--- a/src/infra/main/template.yaml
+++ b/src/infra/main/template.yaml
@@ -1,5 +1,15 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Transform: AWS::Serverless-2016-10-31
+Transform:
+  - AWS::Serverless-2016-10-31
+  - AWS::LanguageExtensions
+
+Metadata:
+  cfn-lint:
+    config:
+      ignore_checks:
+        - E3031
+        - E3510
+        - E3033
 
 Description: >-
   The main Account Interventions Service (AIS) solution stack

--- a/src/infra/main/template.yaml
+++ b/src/infra/main/template.yaml
@@ -104,6 +104,7 @@ Mappings:
       AuthenticationVPCID: vpc-03688222b1d03a1f7 # di-account-interventions-dev VPC ID
       OneLoginHomeVPCID: vpc-03688222b1d03a1f7 # di-account-interventions-dev VPC ID
       IPVCoreVPCID: vpc-03688222b1d03a1f7 # di-account-interventions-dev VPC ID
+      AccountManagementComponentsVPCID: vpc-03688222b1d03a1f7 # di-account-interventions-dev VPC ID
       UniqueVPCEndpointIDs: []
       DynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables # pragma: allowlist secret
     build:
@@ -116,6 +117,7 @@ Mappings:
       AuthenticationVPCID: vpc-0f30b7754111ecc68 # di-account-interventions-build VPC ID
       OneLoginHomeVPCID: vpc-0f30b7754111ecc68 # di-account-interventions-build VPC ID
       IPVCoreVPCID: vpc-0f30b7754111ecc68 # di-account-interventions-build VPC ID
+      AccountManagementComponentsVPCID: vpc-0f30b7754111ecc68 # di-account-interventions-build VPC ID
       UniqueVPCEndpointIDs: []
       DynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables # pragma: allowlist secret
     staging:
@@ -128,11 +130,13 @@ Mappings:
       AuthenticationVPCID: vpc-07cf1e76e27f28e86 # Authentication Staging VPC ID
       OneLoginHomeVPCID: vpc-02e4eb3b0cffc08b0 # Performance testing VPC ID
       IPVCoreVPCID: vpc-039e664a2b3abb03e # IPV Core Staging VPC ID
+      AccountManagementComponentsVPCID: vpc-068b8f80c6182d7cf # AMC Staging VPC ID
       UniqueVPCEndpointIDs:
         - vpce-0339d04aeb67de9da # Auth Old Staging VPC Endpoint ID
         - vpce-0a81481bcd8257f5e # Orchestration? Staging VPC Endpoint ID
         - vpce-0cc0de10742b83b8a # IPV Core? Staging VPC Endpoint ID
         - vpce-07078f5f005fe5efc # Auth New Staging VPC Endpoint ID
+        - vpce-04ae8d53b32b38278 # AMC Staging VPC Endpoint ID
       DynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables # pragma: allowlist secret
     integration:
       LambdaLogLevel: INFO
@@ -1581,6 +1585,12 @@ Resources:
             - !FindInMap [EnvConfig, !Ref Environment, OneLoginHomeVPCID]
             - !FindInMap [EnvConfig, !Ref Environment, OrchestrationVPCID]
             - !FindInMap [EnvConfig, !Ref Environment, IPVCoreVPCID]
+            - !FindInMap [
+                EnvConfig,
+                !Ref Environment,
+                AccountManagementComponentsVPCID,
+                { DefaultValue: !Ref AWS::NoValue },
+              ]
       AccessLogSetting:
         Format: >-
           {
@@ -1700,6 +1710,12 @@ Resources:
             - !FindInMap [EnvConfig, !Ref Environment, OneLoginHomeVPCID]
             - !FindInMap [EnvConfig, !Ref Environment, OrchestrationVPCID]
             - !FindInMap [EnvConfig, !Ref Environment, IPVCoreVPCID]
+            - !FindInMap [
+                EnvConfig,
+                !Ref Environment,
+                AccountManagementComponentsVPCID,
+                { DefaultValue: !Ref AWS::NoValue },
+              ]
       AccessLogSetting:
         Format: >-
           {


### PR DESCRIPTION
## What

This adds the pre-prod configuration from https://github.com/govuk-one-login/account-interventions-service/pull/1015

## Why

We don't need security sign-off for the pre-prod environments so we can expedite auth's ability to test this in staging 