### PR TITLE
FPAD-8128: Persist interventions TTL

### DIFF
--- a/src/services/persist-intervention-events.ts
+++ b/src/services/persist-intervention-events.ts
@@ -136,14 +136,14 @@ export function enrichEvents(updates: InterventionUpdate[], message: Interventio
 }
 
 export async function setTtlOnInactiveEvents(
-  accountId: string, 
+  accountId: string,
   interventionEventsService: InterventionEventsService,
   closedInterventionNames: InterventionName[]
 ) {
   const allEvents = await interventionEventsService.fetchEventsForAccount(accountId);
   const now = getCurrentTimestamp();
   const ttl = now.seconds + appConfig.maxRetentionSeconds;
-  
+
   const eventsNeedingTtl = allEvents.filter(
     (event) =>
       closedInterventionNames.includes(event.interventionName) &&

--- a/src/services/persist-intervention-events.ts
+++ b/src/services/persist-intervention-events.ts
@@ -7,11 +7,14 @@ import { InterventionEvent, InterventionEventsService } from '../tables/interven
 import { randomUUID } from 'node:crypto';
 import getActiveInterventions from './active-interventions-service';
 import { InterventionName } from '../data-types/intervention-name';
+import { AppConfigService } from './app-config-service';
 
 interface InterventionUpdate {
   interventionName: InterventionName;
   interventionState: InterventionState;
 }
+
+const appConfig = AppConfigService.getInstance();
 
 /**
  * Generate and append intervention events based on the received txma message
@@ -39,6 +42,11 @@ async function persistInterventionEvents(
   logger.debug(`${LOGS_PREFIX_SENSITIVE_INFO} Intervention events to add ${JSON.stringify(eventsToAppend)}`);
 
   await interventionEventsService.appendEvents(eventsToAppend);
+
+  const closedNames = eventsToAppend
+    .filter((event) => event.interventionState !== InterventionState.ACTIVE)
+    .map((event) => event.interventionName);
+  await setTtlOnInactiveEvents(message.user.user_id, interventionEventsService, closedNames);
 }
 
 export async function persistIgnoredInterventionEvent(
@@ -125,6 +133,27 @@ export function enrichEvents(updates: InterventionUpdate[], message: Interventio
       originatorReferenceId: interventionExtension?.originator_reference_id,
     };
   });
+}
+
+export async function setTtlOnInactiveEvents(
+  accountId: string, 
+  interventionEventsService: InterventionEventsService,
+  closedInterventionNames: InterventionName[]
+) {
+  const allEvents = await interventionEventsService.fetchEventsForAccount(accountId);
+  const now = getCurrentTimestamp();
+  const ttl = now.seconds + appConfig.maxRetentionSeconds;
+  
+  const eventsNeedingTtl = allEvents.filter(
+    (event) =>
+      closedInterventionNames.includes(event.interventionName) &&
+      !event.ttl
+  );
+
+  if (eventsNeedingTtl.length > 0) {
+    const updatedEvents = eventsNeedingTtl.map((event) => ({ ...event, ttl }));
+    await interventionEventsService.appendEvents(updatedEvents);
+  }
 }
 
 /**

--- a/src/services/test/persist-intervention-events.test.ts
+++ b/src/services/test/persist-intervention-events.test.ts
@@ -5,6 +5,7 @@ import { InMemoryInterventionEventsService } from '../../tables/intervention-eve
 import persistInterventionEvents, {
   generateEventsToAppend,
   persistIgnoredInterventionEvent,
+  setTtlOnInactiveEvents,
 } from '../persist-intervention-events';
 
 const baseMessage: InterventionEventMessage = {
@@ -42,7 +43,7 @@ describe('persistInterventionEvents', () => {
 
     await persistInterventionEvents(baseMessage, EventsEnum.FRAUD_SUSPEND_ACCOUNT, undefined, service);
 
-    expect(fetchEventsSpy).toHaveBeenCalledExactlyOnceWith('1');
+    expect(fetchEventsSpy).toHaveBeenCalledTimes(2);
     expect(appendEventsSpy).toHaveBeenCalledExactlyOnceWith([
       {
         accountId: '1',
@@ -248,6 +249,168 @@ describe('persistIgnoredInterventionEvent', () => {
         interventionName: InterventionName.RESET_PASSWORD,
         interventionState: InterventionState.IGNORED,
       }),
+    ]);
+  });
+});
+
+describe('setTtlOnInactiveEvents', () => {
+  const FIXED_TIMESTAMP = 1781253284370;
+  const EXPECTED_TTL = Math.floor(FIXED_TIMESTAMP / 1000) + 12345;
+
+  beforeAll(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_TIMESTAMP);
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  test('sets ttl on inactive events that do not already have a ttl', async () => {
+    const service = new InMemoryInterventionEventsService([
+      {
+        eventId: 'event-1',
+        accountId: '1',
+        createdAt: 1000,
+        interventionName: InterventionName.TEMPORARY_SUSPENSION,
+        interventionState: InterventionState.SUPERSEDED,
+        interventionReason: 'reason',
+        sentAt: 900,
+        componentId: 'test',
+      },
+    ]);
+    const appendEventsSpy = vi.spyOn(service, 'appendEvents');
+
+    await setTtlOnInactiveEvents('1', service, [InterventionName.TEMPORARY_SUSPENSION]);
+
+    expect(appendEventsSpy).toHaveBeenCalledExactlyOnceWith([
+      expect.objectContaining({ eventId: 'event-1', ttl: EXPECTED_TTL }),
+    ]);
+  });
+
+  test('does not set ttl on interventions that are still ACTIVE', async () => {
+    const service = new InMemoryInterventionEventsService([
+      {
+        eventId: 'event-1',
+        accountId: '1',
+        createdAt: 1000,
+        interventionName: InterventionName.RESET_PASSWORD,
+        interventionState: InterventionState.ACTIVE,
+        interventionReason: 'reason',
+        sentAt: 900,
+        componentId: 'test',
+      },
+    ]);
+    const appendEventsSpy = vi.spyOn(service, 'appendEvents');
+
+    await setTtlOnInactiveEvents('1', service, [InterventionName.TEMPORARY_SUSPENSION]);
+
+    expect(appendEventsSpy).not.toHaveBeenCalled();
+  });
+
+  test('does not rewrite events that already have a ttl', async () => {
+    const service = new InMemoryInterventionEventsService([
+      {
+        eventId: 'event-1',
+        accountId: '1',
+        createdAt: 1000,
+        interventionName: InterventionName.TEMPORARY_SUSPENSION,
+        interventionState: InterventionState.REMOVED,
+        interventionReason: 'reason',
+        sentAt: 900,
+        componentId: 'test',
+        ttl: 1234567890,
+      },
+    ]);
+    const appendEventsSpy = vi.spyOn(service, 'appendEvents');
+
+    await setTtlOnInactiveEvents('1', service, [InterventionName.TEMPORARY_SUSPENSION]);
+
+    expect(appendEventsSpy).not.toHaveBeenCalled();
+  });
+
+  test('does nothing when there are no events for the account', async () => {
+    const service = new InMemoryInterventionEventsService([]);
+    const appendEventsSpy = vi.spyOn(service, 'appendEvents');
+
+    await setTtlOnInactiveEvents('1', service, [InterventionName.TEMPORARY_SUSPENSION]);
+
+    expect(appendEventsSpy).not.toHaveBeenCalled();
+  });
+
+  test('only sets ttl on events matching the closed intervention names', async () => {
+    const service = new InMemoryInterventionEventsService([
+      {
+        eventId: 'event-1',
+        accountId: '1',
+        createdAt: 1000,
+        interventionName: InterventionName.TEMPORARY_SUSPENSION,
+        interventionState: InterventionState.SUPERSEDED,
+        interventionReason: 'reason',
+        sentAt: 900,
+        componentId: 'test',
+      },
+      {
+        eventId: 'event-2',
+        accountId: '1',
+        createdAt: 1001,
+        interventionName: InterventionName.RESET_PASSWORD,
+        interventionState: InterventionState.REMOVED,
+        interventionReason: 'reason',
+        sentAt: 901,
+        componentId: 'test',
+      },
+    ]);
+    const appendEventsSpy = vi.spyOn(service, 'appendEvents');
+
+    await setTtlOnInactiveEvents('1', service, [InterventionName.TEMPORARY_SUSPENSION]);
+
+    expect(appendEventsSpy).toHaveBeenCalledExactlyOnceWith([
+      expect.objectContaining({ eventId: 'event-1', ttl: EXPECTED_TTL }),
+    ]);
+  });
+
+  test('sets ttl on all events for a closed intervention including the original ACTIVE event', async () => {
+    const service = new InMemoryInterventionEventsService([
+      {
+        eventId: 'event-1',
+        accountId: '1',
+        createdAt: 1000,
+        interventionName: InterventionName.TEMPORARY_SUSPENSION,
+        interventionState: InterventionState.ACTIVE,
+        interventionReason: 'reason',
+        sentAt: 900,
+        componentId: 'test',
+      },
+      {
+        eventId: 'event-2',
+        accountId: '1',
+        createdAt: 2000,
+        interventionName: InterventionName.TEMPORARY_SUSPENSION,
+        interventionState: InterventionState.SUPERSEDED,
+        interventionReason: 'reason',
+        sentAt: 1900,
+        componentId: 'test',
+      },
+      {
+        eventId: 'event-3',
+        accountId: '1',
+        createdAt: 2001,
+        interventionName: InterventionName.RESET_PASSWORD,
+        interventionState: InterventionState.ACTIVE,
+        interventionReason: 'reason',
+        sentAt: 1901,
+        componentId: 'test',
+      },
+    ]);
+    
+    const appendEventsSpy = vi.spyOn(service, 'appendEvents');
+  
+    await setTtlOnInactiveEvents('1', service, [InterventionName.TEMPORARY_SUSPENSION]);
+  
+    expect(appendEventsSpy).toHaveBeenCalledExactlyOnceWith([
+      expect.objectContaining({ eventId: 'event-1', ttl: EXPECTED_TTL }),
+      expect.objectContaining({ eventId: 'event-2', ttl: EXPECTED_TTL }),
     ]);
   });
 });

--- a/src/services/test/persist-intervention-events.test.ts
+++ b/src/services/test/persist-intervention-events.test.ts
@@ -403,11 +403,11 @@ describe('setTtlOnInactiveEvents', () => {
         componentId: 'test',
       },
     ]);
-    
+
     const appendEventsSpy = vi.spyOn(service, 'appendEvents');
-  
+
     await setTtlOnInactiveEvents('1', service, [InterventionName.TEMPORARY_SUSPENSION]);
-  
+
     expect(appendEventsSpy).toHaveBeenCalledExactlyOnceWith([
       expect.objectContaining({ eventId: 'event-1', ttl: EXPECTED_TTL }),
       expect.objectContaining({ eventId: 'event-2', ttl: EXPECTED_TTL }),


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What
When an intervention has reached a terminal state we want to update its events to have a ttl value so that the data is deleted once the ttl period elapses

## Why
We can and should only store data for a certain period of time

## Notes
This solution assumes that an intervention has reached a terminal state when the intervention state is no longer active. The intervention name is then used to decide which events should be modified to have a ttl value so that only the inactive events for the required intervention are given a ttl value

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-8128](https://govukverify.atlassian.net/browse/FPAD-8128)


[FPAD-8128]: https://govukverify.atlassian.net/browse/FPAD-8128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ