### PR TITLE
FPAD-7826: Mutation testing in CI

### DIFF
--- a/.github/workflows/mutation-tests.yaml
+++ b/.github/workflows/mutation-tests.yaml
@@ -1,0 +1,44 @@
+---
+name: 'Mutation Tests'
+permissions:
+  contents: read
+  packages: read
+
+on:
+  pull_request:
+    paths:
+      - src/**
+      - package.json
+      - package-lock.json
+      - stryker-ci.config.json
+      - .stryker/**
+      - .node-version
+      - .github/workflows/mutation-tests.yaml
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
+
+jobs:
+  mutation-tests:
+    name: 'Run Mutation Tests'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+
+      - name: Setup NodeJS
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # pin@v6.3.0
+        with:
+          node-version-file: '.node-version'
+          registry-url: 'https://npm.pkg.github.com/'
+          scope: '@govuk-one-login'
+          cache: npm
+
+      - name: Run npm install
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ github.token }}
+
+      - name: Run mutation tests
+        run: npm run test:mutation:ci

--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ npx stryker run
 
 These commands are equivalent and running either will run the mutation tests, then produce an html report in the `/reports` directory. This report can be opened in the browser and shows where in the code the mutation tests failed, i.e. where Stryker made meaningful changes to the code and the tests still passed.
 
+#### CI
+
+Mutation tests run automatically on pull requests via a separate GitHub Actions workflow (`.github/workflows/mutation-tests.yaml`).
+
+The CI command uses a dedicated config file (`stryker-ci.config.json`) with text-only output:
+
+```sh
+npm run test:mutation:ci
+```
+
 ### Build & deploy **main** application manually stack for development
 
 To build the application code and deploy the ais-main stack use the following commands **from project root directory**.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:pact:provider": "vitest -c vitest.contract.config.ts src/contract-testing/provider/*",
     "test:pact:consumer": "vitest -c vitest.contract.config.ts src/contract-testing/consumer/*",
     "test:mutation": "stryker run",
+    "test:mutation:ci": "stryker run stryker-ci.config.json",
     "connect:pact:broker": "tsx src/contract-testing/test-helpers/connect-to-pact-broker.ts",
     "pact:publish:contracts": "tsx src/contract-testing/test-helpers/publish-pacts.ts",
     "lint": "npm run lint:code && npm run lint:spec && npm run lint:iac",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "test": "npm run test:unit",
-    "test:unit": "vitest --coverage",
+    "test:unit": "vitest run --coverage",
+    "test:unit:watch": "vitest --coverage",
     "test:types": "tsc --noEmit",
     "test:pact:provider": "vitest -c vitest.contract.config.ts src/contract-testing/provider/*",
     "test:pact:consumer": "vitest -c vitest.contract.config.ts src/contract-testing/consumer/*",

--- a/stryker-ci.config.json
+++ b/stryker-ci.config.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "./node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "_comment": "This configuration is for running Stryker in CI. For running Stryker manually, use `stryker.config.json`.",
+  "packageManager": "npm",
+  "reporters": [
+    "clear-text"
+  ],
+  "clearTextReporter": {
+    "allowColor": true,
+    "allowEmojis": true,
+    "logTests": false,
+    "maxTestsToLog": 3,
+    "reportTests": false,
+    "reportMutants": true,
+    "reportScoreTable": true,
+    "skipFull": false
+  },
+  "testRunner": "vitest",
+  "testRunner_comment": "Take a look at https://stryker-mutator.io/docs/stryker-js/vitest-runner for information about the vitest plugin.",
+  "coverageAnalysis": "perTest",
+  "ignorePatterns": [
+    "src/contract-testing/**"
+  ],
+  "ignorers": [
+    "logger"
+  ],
+  "plugins": [
+    "@stryker-mutator/*",
+    "./.stryker/logger-ignorer.js"
+  ]
+}


### PR DESCRIPTION
## What

Adds a simple CI workflow for running mutation tests. It runs separately to the unit tests and doesn't block merge

## Why

This is a step towards having some kind of ratchet for mutation testing in new work

### Issue tracking

- [FPAD-7826](https://govukverify.atlassian.net/browse/FPAD-7826)


[FPAD-7826]: https://govukverify.atlassian.net/browse/FPAD-7826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ