### PR TITLE
FPAD-8434: Catch ConditionalCheckFailedException error

### DIFF
--- a/src/tables/account-status.ts
+++ b/src/tables/account-status.ts
@@ -5,6 +5,7 @@ import TableConfig from './table-config';
 import { AppConfigService } from '../services/app-config-service';
 import { getCurrentTimestamp } from '../commons/get-current-timestamp';
 import { UpdateCommandOutput } from '@aws-sdk/lib-dynamodb';
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb';
 import { AccountStateEngineOutput, CurrentTimeDescriptor } from '../data-types/interfaces';
 import { InterventionEventMessage } from '../contracts/intervention-events';
 import { LOGS_PREFIX_SENSITIVE_INFO } from '../data-types/constants';
@@ -126,27 +127,38 @@ export class PersistentAccountStatusService implements AccountStatusService {
     await this.recordService.update(accountId, partialCommandInput);
   }
 
-  updateDeleteStatus(accountId: string) {
+  async updateDeleteStatus(accountId: string) {
     const now = getCurrentTimestamp();
     const ttl = now.seconds + appConfig.maxRetentionSeconds;
 
-    return this.recordService.update(accountId, {
-      UpdateExpression: 'SET #isAccountDeleted = :isAccountDeleted, #ttl = :ttl, #deletedAt = :deletedAt',
-      ExpressionAttributeNames: {
-        '#isAccountDeleted': 'isAccountDeleted',
-        '#ttl': 'ttl',
-        '#deletedAt': 'deletedAt',
-      },
-      ExpressionAttributeValues: {
-        ':isAccountDeleted': true,
-        ':ttl': ttl,
-        ':false': false,
-        ':deletedAt': now.milliseconds,
-      },
-      ReturnValues: 'ALL_NEW',
-      ConditionExpression:
-        'attribute_exists(pk) AND (attribute_not_exists(isAccountDeleted) OR isAccountDeleted = :false)',
-    });
+    try {
+      return await this.recordService.update(accountId, {
+        UpdateExpression: 'SET #isAccountDeleted = :isAccountDeleted, #ttl = :ttl, #deletedAt = :deletedAt',
+        ExpressionAttributeNames: {
+          '#isAccountDeleted': 'isAccountDeleted',
+          '#ttl': 'ttl',
+          '#deletedAt': 'deletedAt',
+        },
+        ExpressionAttributeValues: {
+          ':isAccountDeleted': true,
+          ':ttl': ttl,
+          ':false': false,
+          ':deletedAt': now.milliseconds,
+        },
+        ReturnValues: 'ALL_NEW',
+        ConditionExpression:
+          'attribute_exists(pk) AND (attribute_not_exists(isAccountDeleted) OR isAccountDeleted = :false)',
+      });
+    } catch (error) {
+      if (error instanceof ConditionalCheckFailedException) {
+        logger.info(`${LOGS_PREFIX_SENSITIVE_INFO} No intervention exists for this account.`, {
+          error,
+          userId: accountId,
+        });
+        return;
+      }
+      throw error;
+    }
   }
 }
 

--- a/src/tables/test/account-status.test.ts
+++ b/src/tables/test/account-status.test.ts
@@ -5,6 +5,7 @@ import { accountStatusTableConfig, PersistentAccountStatusService } from '../acc
 import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 import 'aws-sdk-client-mock-vitest/extend';
 import { getCurrentTimestamp } from '../../commons/get-current-timestamp';
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb';
 
 beforeEach(() => {
   vi.useFakeTimers();
@@ -196,6 +197,83 @@ describe('PersistentAccountStatusService deep DynamoDB Tests', () => {
         ttl: 5678,
       },
     });
+
+    expect(ddbMock).toHaveReceivedCommandWith(UpdateCommand, {
+      ConditionExpression:
+        'attribute_exists(pk) AND (attribute_not_exists(isAccountDeleted) OR isAccountDeleted = :false)',
+      ExpressionAttributeNames: {
+        '#deletedAt': 'deletedAt',
+        '#isAccountDeleted': 'isAccountDeleted',
+        '#ttl': 'ttl',
+      },
+      ExpressionAttributeValues: {
+        ':deletedAt': 1678665600000,
+        ':false': false,
+        ':isAccountDeleted': true,
+        ':ttl': 1678677945,
+      },
+      Key: {
+        pk: '1234',
+      },
+      ReturnValues: 'ALL_NEW',
+      TableName: 'table_name',
+      UpdateExpression: 'SET #isAccountDeleted = :isAccountDeleted, #ttl = :ttl, #deletedAt = :deletedAt',
+    });
+  });
+
+  test('updateDeleteStatus throws ConditionalCheckFailedException', async () => {
+    ddbMock.on(UpdateCommand).rejects(
+      new ConditionalCheckFailedException({
+        $metadata: {},
+        message: '',
+      }),
+    );
+
+    const recordService = new DynamoDBRecordService<typeof accountStatusTableConfig.schema>(
+      accountStatusTableConfig,
+      ddbMock as unknown as DynamoDBDocumentClient,
+    );
+
+    const service = new PersistentAccountStatusService(recordService);
+
+    const res = await service.updateDeleteStatus('1234');
+
+    expect(res).toEqual(undefined);
+
+    expect(ddbMock).toHaveReceivedCommandWith(UpdateCommand, {
+      ConditionExpression:
+        'attribute_exists(pk) AND (attribute_not_exists(isAccountDeleted) OR isAccountDeleted = :false)',
+      ExpressionAttributeNames: {
+        '#deletedAt': 'deletedAt',
+        '#isAccountDeleted': 'isAccountDeleted',
+        '#ttl': 'ttl',
+      },
+      ExpressionAttributeValues: {
+        ':deletedAt': 1678665600000,
+        ':false': false,
+        ':isAccountDeleted': true,
+        ':ttl': 1678677945,
+      },
+      Key: {
+        pk: '1234',
+      },
+      ReturnValues: 'ALL_NEW',
+      TableName: 'table_name',
+      UpdateExpression: 'SET #isAccountDeleted = :isAccountDeleted, #ttl = :ttl, #deletedAt = :deletedAt',
+    });
+  });
+
+  test('updateDeleteStatus throws generic error', async () => {
+    ddbMock.on(UpdateCommand).rejects(new Error('Error message'));
+
+    const recordService = new DynamoDBRecordService<typeof accountStatusTableConfig.schema>(
+      accountStatusTableConfig,
+      ddbMock as unknown as DynamoDBDocumentClient,
+    );
+
+    const service = new PersistentAccountStatusService(recordService);
+
+    await expect(service.updateDeleteStatus('1234')).rejects.toThrow('Error message');
 
     expect(ddbMock).toHaveReceivedCommandWith(UpdateCommand, {
       ConditionExpression:


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Catch ConditionalCheckFailedException error

## Why

This shouldn't be raising an error

Handling copied from [here](https://github.com/govuk-one-login/account-interventions-service/pull/1009/changes#diff-c8325ea456d4325cb21094b0f84a7e8b22734015806c2c490bf975572cca9cb9L119)

## Notes

This may not deploy without the AWS alarms being cancelled by manually adjusting the threshold

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-8434](https://govukverify.atlassian.net/browse/FPAD-8434)

[FPAD-8434]: https://govukverify.atlassian.net/browse/FPAD-8434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ