### PR TITLE
Set branch protection ruleset to evaluate

### DIFF
--- a/.github/rulesets/protect_main.json
+++ b/.github/rulesets/protect_main.json
@@ -1,11 +1,13 @@
 {
   "name": "Protect main",
   "target": "branch",
-  "enforcement": "disabled",
+  "enforcement": "evaluate",
   "conditions": {
     "ref_name": {
       "exclude": [],
-      "include": ["~DEFAULT_BRANCH"]
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
     }
   },
   "rules": [
@@ -27,7 +29,10 @@
         "require_code_owner_review": true,
         "require_last_push_approval": false,
         "required_review_thread_resolution": false,
-        "allowed_merge_methods": ["merge", "rebase"]
+        "allowed_merge_methods": [
+          "merge",
+          "rebase"
+        ]
       }
     },
     {


### PR DESCRIPTION
## What

Move branch protection ruleset from disabled to evaluate

## Why

This lets us check if and when rules from the ruleset are firing: https://docs.github.com/en/enterprise-cloud@latest/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/managing-rulesets-for-a-repository#viewing-insights-for-rulesets
