### PR TITLE
Allow npm published to bypass branch protection

### DIFF
--- a/.github/rulesets/protect_main.json
+++ b/.github/rulesets/protect_main.json
@@ -62,5 +62,13 @@
         ]
       }
     }
-  ]
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 4175315,
+      "actor_type": "Integration",
+      "bypass_mode": "always"
+    }
+  ],
+  "current_user_can_bypass": "never"
 }


### PR DESCRIPTION
## What

Allows the new npm package publishing Github app to bypass `main` branch protection rules

## Why

We want to automatically update the main branch when we publish.
