### PR TITLE
FPAD-8447: Add transactionId and messageEventId to intervention-events

### DIFF
--- a/src/services/persist-intervention-events.ts
+++ b/src/services/persist-intervention-events.ts
@@ -115,6 +115,7 @@ export const removeUnnecessaryUpdates = (
  */
 export function enrichEvents(updates: InterventionUpdate[], message: InterventionEventMessage): InterventionEvent[] {
   const currentTime = getCurrentTimestamp().milliseconds;
+  const transactionId = randomUUID();
 
   return updates.map((update, index) => {
     const interventionExtension =
@@ -131,6 +132,8 @@ export function enrichEvents(updates: InterventionUpdate[], message: Interventio
       originatingComponentId: interventionExtension?.originating_component_id,
       requesterId: interventionExtension?.requester_id,
       originatorReferenceId: interventionExtension?.originator_reference_id,
+      transactionId,
+      messageEventId: message.event_id,
     };
   });
 }
@@ -138,16 +141,14 @@ export function enrichEvents(updates: InterventionUpdate[], message: Interventio
 export async function setTtlOnInactiveEvents(
   accountId: string,
   interventionEventsService: InterventionEventsService,
-  closedInterventionNames: InterventionName[]
+  closedInterventionNames: InterventionName[],
 ) {
   const allEvents = await interventionEventsService.fetchEventsForAccount(accountId);
   const now = getCurrentTimestamp();
   const ttl = now.seconds + appConfig.maxRetentionSeconds;
 
   const eventsNeedingTtl = allEvents.filter(
-    (event) =>
-      closedInterventionNames.includes(event.interventionName) &&
-      !event.ttl
+    (event) => closedInterventionNames.includes(event.interventionName) && !event.ttl,
   );
 
   if (eventsNeedingTtl.length > 0) {

--- a/src/services/test/persist-intervention-events.test.ts
+++ b/src/services/test/persist-intervention-events.test.ts
@@ -12,6 +12,7 @@ const baseMessage: InterventionEventMessage = {
   component_id: 'test',
   timestamp: 1722953808,
   event_timestamp_ms: 1722953808000,
+  event_id: '123abc',
   user: {
     user_id: '1',
   },
@@ -57,6 +58,8 @@ describe('persistInterventionEvents', () => {
         originatorReferenceId: undefined,
         requesterId: undefined,
         sentAt: 1722953808000,
+        transactionId: expect.any(String) as string,
+        messageEventId: '123abc',
       },
     ]);
   });
@@ -96,6 +99,8 @@ describe('generateEventsToAppend', () => {
         originatorReferenceId: undefined,
         requesterId: undefined,
         sentAt: 1722953808000,
+        transactionId: expect.any(String) as string,
+        messageEventId: '123abc',
       },
     ]);
   });
@@ -129,6 +134,8 @@ describe('generateEventsToAppend', () => {
         originatorReferenceId: undefined,
         requesterId: undefined,
         sentAt: 1722953808000,
+        transactionId: expect.any(String) as string,
+        messageEventId: '123abc',
       },
       {
         accountId: '1',
@@ -142,8 +149,12 @@ describe('generateEventsToAppend', () => {
         originatorReferenceId: undefined,
         requesterId: undefined,
         sentAt: 1722953808000,
+        transactionId: expect.any(String) as string,
+        messageEventId: '123abc',
       },
     ]);
+
+    expect(response[0]?.transactionId).toEqual(response[1]?.transactionId);
   });
 
   test('remove existing intervention', () => {
@@ -171,6 +182,8 @@ describe('generateEventsToAppend', () => {
         originatorReferenceId: undefined,
         requesterId: undefined,
         sentAt: 1722953808000,
+        transactionId: expect.any(String) as string,
+        messageEventId: '123abc',
       },
     ]);
   });

--- a/src/tables/intervention-events.ts
+++ b/src/tables/intervention-events.ts
@@ -22,6 +22,8 @@ const schema = z.object({
   requesterId: z.string().optional(),
   originatorReferenceId: z.union([z.string(), z.array(z.string())]).optional(),
   ttl: z.number().optional(),
+  transactionId: z.string().optional(),
+  messageEventId: z.string().optional(),
 });
 
 export const interventionEventsTableConfig: TableConfig<typeof schema> = {


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Add `transactionId` and `messageEventId` to intervention-events table

## Why

Allows us to group events into transactions and reference them to the incoming TxMA message

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-8447](https://govukverify.atlassian.net/browse/FPAD-8447)

[FPAD-8447]: https://govukverify.atlassian.net/browse/FPAD-8447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ