### PR TITLE
FPAD-8429: Improvements to update command

### DIFF
--- a/src/commons/build-partial-update-state-command.ts
+++ b/src/commons/build-partial-update-state-command.ts
@@ -4,11 +4,7 @@ import { addMetric } from './metrics';
 import { HistoryStringBuilder } from './history-string-builder';
 import { AppConfigService } from '../services/app-config-service';
 import { InterventionEventMessage } from '../contracts/intervention-events';
-import { UpdateCommandInput } from '@aws-sdk/lib-dynamodb';
-
-type DeepRequiredKey<T, K extends keyof T> = Omit<T, K> & {
-  [P in K]-?: Exclude<T[P], undefined>;
-};
+import { AccountStatus } from '../tables/account-status';
 
 /**
  * Method to build a Partial of UpdateItemCommandInput
@@ -25,55 +21,38 @@ export function buildPartialUpdateAccountStateCommand(
   interventionEvent: InterventionEventMessage,
   historyList: string[],
   interventionName?: AISInterventionTypes,
-): Partial<UpdateCommandInput> {
+): { input: Partial<AccountStatus>; keysToRemove?: (keyof AccountStatus)[] } {
   const eventTimestamp = interventionEvent.event_timestamp_ms;
 
-  const baseUpdateItemCommandInput: DeepRequiredKey<
-    Partial<UpdateCommandInput>,
-    'ExpressionAttributeNames' | 'ExpressionAttributeValues' | 'UpdateExpression'
-  > = {
-    ExpressionAttributeNames: {
-      '#B': 'blocked',
-      '#S': 'suspended',
-      '#RP': 'resetPassword',
-      '#RI': 'reproveIdentity',
-      '#UA': 'updatedAt',
-    },
-    ExpressionAttributeValues: {
-      ':b': finalState.blocked,
-      ':s': finalState.suspended,
-      ':rp': finalState.resetPassword,
-      ':ri': finalState.reproveIdentity,
-      ':ua': currentTimestamp,
-    },
-    UpdateExpression: 'SET #B = :b, #S = :s, #RP = :rp, #RI = :ri, #UA = :ua',
+  const baseUpdateItemCommandInput: Partial<AccountStatus> = {
+    blocked: finalState.blocked,
+    suspended: finalState.suspended,
+    resetPassword: finalState.resetPassword,
+    reproveIdentity: finalState.reproveIdentity,
+    updatedAt: currentTimestamp,
   };
 
   if (interventionEvent.event_name === EventsEnum.IPV_ACCOUNT_INTERVENTION_END) {
-    baseUpdateItemCommandInput.ExpressionAttributeNames['#RIdA'] = 'reprovedIdentityAt';
-    baseUpdateItemCommandInput.ExpressionAttributeValues[':rida'] = eventTimestamp;
-    baseUpdateItemCommandInput.ExpressionAttributeNames['#H'] = 'history';
-    baseUpdateItemCommandInput.ExpressionAttributeValues[':h'] = extractValidHistoryItems(
-      historyList,
-      currentTimestamp,
-    );
-    baseUpdateItemCommandInput.UpdateExpression += ', #RIdA = :rida, #H = :h';
-    return baseUpdateItemCommandInput;
+    return {
+      input: {
+        ...baseUpdateItemCommandInput,
+        reprovedIdentityAt: eventTimestamp,
+        history: extractValidHistoryItems(historyList, currentTimestamp),
+      },
+    };
   }
 
   if (
     interventionEvent.event_name === EventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL ||
     interventionEvent.event_name === EventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL_FOR_TEST_CLIENT
   ) {
-    baseUpdateItemCommandInput.ExpressionAttributeNames['#RPswdA'] = 'resetPasswordAt';
-    baseUpdateItemCommandInput.ExpressionAttributeValues[':rpswda'] = eventTimestamp;
-    baseUpdateItemCommandInput.ExpressionAttributeNames['#H'] = 'history';
-    baseUpdateItemCommandInput.ExpressionAttributeValues[':h'] = extractValidHistoryItems(
-      historyList,
-      currentTimestamp,
-    );
-    baseUpdateItemCommandInput.UpdateExpression += ', #RPswdA = :rpswda, #H = :h';
-    return baseUpdateItemCommandInput;
+    return {
+      input: {
+        ...baseUpdateItemCommandInput,
+        resetPasswordAt: eventTimestamp,
+        history: extractValidHistoryItems(historyList, currentTimestamp),
+      },
+    };
   }
 
   if (!interventionName) {
@@ -81,30 +60,29 @@ export function buildPartialUpdateAccountStateCommand(
     throw new Error('The intervention received did not have an interventionName field.');
   }
 
-  baseUpdateItemCommandInput.ExpressionAttributeNames['#INT'] = 'intervention';
-  baseUpdateItemCommandInput.ExpressionAttributeValues[':int'] = interventionName;
-  baseUpdateItemCommandInput.ExpressionAttributeNames['#AA'] = 'appliedAt';
-  baseUpdateItemCommandInput.ExpressionAttributeValues[':aa'] = currentTimestamp;
-  baseUpdateItemCommandInput.ExpressionAttributeNames['#SA'] = 'sentAt';
-  baseUpdateItemCommandInput.ExpressionAttributeValues[':sa'] = eventTimestamp;
   const stringBuilder = new HistoryStringBuilder();
-  baseUpdateItemCommandInput.ExpressionAttributeNames['#H'] = 'history';
-  baseUpdateItemCommandInput.ExpressionAttributeValues[':h'] = [
-    ...extractValidHistoryItems(historyList, currentTimestamp),
-    stringBuilder.getHistoryString(interventionEvent, eventTimestamp),
-  ];
-  baseUpdateItemCommandInput.UpdateExpression += ', #INT = :int, #SA = :sa, #AA = :aa, #H = :h';
-  baseUpdateItemCommandInput.UpdateExpression += buildRemoveExpression(finalState);
 
-  return baseUpdateItemCommandInput;
+  return {
+    input: {
+      ...baseUpdateItemCommandInput,
+      intervention: interventionName,
+      appliedAt: currentTimestamp,
+      sentAt: eventTimestamp,
+      history: [
+        ...extractValidHistoryItems(historyList, currentTimestamp),
+        stringBuilder.getHistoryString(interventionEvent, eventTimestamp),
+      ],
+    },
+    keysToRemove: keysToRemove(finalState),
+  };
 }
 
 /**
  * Helper function to build the Remove Expression for DynamoDB update
  * @param finalState - new account state object
  */
-function buildRemoveExpression(finalState: StateDetails) {
-  const itemsToRemove = [];
+function keysToRemove(finalState: StateDetails): (keyof AccountStatus)[] {
+  const itemsToRemove: (keyof AccountStatus)[] = [];
 
   if (finalState.resetPassword) {
     itemsToRemove.push('resetPasswordAt');
@@ -113,11 +91,7 @@ function buildRemoveExpression(finalState: StateDetails) {
     itemsToRemove.push('reprovedIdentityAt');
   }
 
-  if (itemsToRemove.length === 0) {
-    return '';
-  }
-
-  return ' REMOVE ' + itemsToRemove.join(', ');
+  return itemsToRemove;
 }
 
 /**

--- a/src/commons/test/build-partial-update-state-command.test.ts
+++ b/src/commons/test/build-partial-update-state-command.test.ts
@@ -70,29 +70,20 @@ describe('build-partial-update-state-command', () => {
       resetPassword: true,
       reproveIdentity: true,
     };
-    const expectedOutput = {
-      ExpressionAttributeNames: {
-        '#B': 'blocked',
-        '#H': 'history',
-        '#S': 'suspended',
-        '#RP': 'resetPassword',
-        '#RI': 'reproveIdentity',
-        '#UA': 'updatedAt',
-        '#RPswdA': 'resetPasswordAt',
-      },
-      ExpressionAttributeValues: {
-        ':b': false,
-        ':h': [],
-        ':s': false,
-        ':rp': true,
-        ':ri': true,
-        ':ua': 4444,
-        ':rpswda': 10000000,
-      },
-      UpdateExpression: 'SET #B = :b, #S = :s, #RP = :rp, #RI = :ri, #UA = :ua, #RPswdA = :rpswda, #H = :h',
-    };
+
     const command = buildPartialUpdateAccountStateCommand(state, 4444, resetPasswordEventBody, []);
-    expect(command).toEqual(expectedOutput);
+
+    expect(command).toEqual({
+      input: {
+        blocked: false,
+        history: [],
+        suspended: false,
+        resetPassword: true,
+        reproveIdentity: true,
+        updatedAt: 4444,
+        resetPasswordAt: 10000000,
+      },
+    });
   });
 
   it('should return a partial update command given IPV successful id reset is applied', () => {
@@ -102,27 +93,19 @@ describe('build-partial-update-state-command', () => {
       resetPassword: true,
       reproveIdentity: true,
     };
+
     const command = buildPartialUpdateAccountStateCommand(state, 4444, ipvAccountInterventionEventBody, []);
+
     expect(command).toEqual({
-      ExpressionAttributeNames: {
-        '#B': 'blocked',
-        '#H': 'history',
-        '#S': 'suspended',
-        '#RP': 'resetPassword',
-        '#RI': 'reproveIdentity',
-        '#UA': 'updatedAt',
-        '#RIdA': 'reprovedIdentityAt',
+      input: {
+        blocked: false,
+        history: [],
+        suspended: false,
+        resetPassword: true,
+        reproveIdentity: true,
+        updatedAt: 4444,
+        reprovedIdentityAt: 10000000,
       },
-      ExpressionAttributeValues: {
-        ':b': false,
-        ':h': [],
-        ':s': false,
-        ':rp': true,
-        ':ri': true,
-        ':ua': 4444,
-        ':rida': 10000000,
-      },
-      UpdateExpression: 'SET #B = :b, #S = :s, #RP = :rp, #RI = :ri, #UA = :ua, #RIdA = :rida, #H = :h',
     });
   });
 
@@ -133,32 +116,7 @@ describe('build-partial-update-state-command', () => {
       resetPassword: true,
       reproveIdentity: false,
     };
-    const expectedOutput = {
-      ExpressionAttributeNames: {
-        '#B': 'blocked',
-        '#S': 'suspended',
-        '#RP': 'resetPassword',
-        '#RI': 'reproveIdentity',
-        '#UA': 'updatedAt',
-        '#SA': 'sentAt',
-        '#AA': 'appliedAt',
-        '#H': 'history',
-        '#INT': 'intervention',
-      },
-      ExpressionAttributeValues: {
-        ':b': false,
-        ':s': true,
-        ':rp': true,
-        ':ri': false,
-        ':ua': 4444,
-        ':sa': 123456,
-        ':aa': 4444,
-        ':h': ['123456|TICF_CRI|01|reason|originating_component_id|originator_reference_id|requester_id'],
-        ':int': 'AIS_FORCED_USER_PASSWORD_RESET',
-      },
-      UpdateExpression:
-        'SET #B = :b, #S = :s, #RP = :rp, #RI = :ri, #UA = :ua, #INT = :int, #SA = :sa, #AA = :aa, #H = :h REMOVE resetPasswordAt',
-    };
+
     const command = buildPartialUpdateAccountStateCommand(
       state,
       4444,
@@ -166,7 +124,21 @@ describe('build-partial-update-state-command', () => {
       [],
       AISInterventionTypes.AIS_FORCED_USER_PASSWORD_RESET,
     );
-    expect(command).toEqual(expectedOutput);
+
+    expect(command).toEqual({
+      input: {
+        blocked: false,
+        suspended: true,
+        resetPassword: true,
+        reproveIdentity: false,
+        updatedAt: 4444,
+        sentAt: 123456,
+        appliedAt: 4444,
+        history: ['123456|TICF_CRI|01|reason|originating_component_id|originator_reference_id|requester_id'],
+        intervention: 'AIS_FORCED_USER_PASSWORD_RESET',
+      },
+      keysToRemove: ['resetPasswordAt'],
+    });
   });
   it('should return a partial update command given an unsuspend intervention is applied', () => {
     const state: StateDetails = {
@@ -175,32 +147,7 @@ describe('build-partial-update-state-command', () => {
       resetPassword: false,
       reproveIdentity: false,
     };
-    const expectedOutput = {
-      ExpressionAttributeNames: {
-        '#B': 'blocked',
-        '#S': 'suspended',
-        '#RP': 'resetPassword',
-        '#RI': 'reproveIdentity',
-        '#UA': 'updatedAt',
-        '#SA': 'sentAt',
-        '#AA': 'appliedAt',
-        '#H': 'history',
-        '#INT': 'intervention',
-      },
-      ExpressionAttributeValues: {
-        ':b': false,
-        ':s': false,
-        ':rp': false,
-        ':ri': false,
-        ':ua': 4444,
-        ':sa': 123456,
-        ':aa': 4444,
-        ':h': ['123456|TICF_CRI|01|reason|originating_component_id|originator_reference_id|requester_id'],
-        ':int': 'AIS_ACCOUNT_UNSUSPENDED',
-      },
-      UpdateExpression:
-        'SET #B = :b, #S = :s, #RP = :rp, #RI = :ri, #UA = :ua, #INT = :int, #SA = :sa, #AA = :aa, #H = :h',
-    };
+
     const command = buildPartialUpdateAccountStateCommand(
       state,
       4444,
@@ -208,7 +155,21 @@ describe('build-partial-update-state-command', () => {
       [],
       AISInterventionTypes.AIS_ACCOUNT_UNSUSPENDED,
     );
-    expect(command).toEqual(expectedOutput);
+
+    expect(command).toEqual({
+      input: {
+        blocked: false,
+        suspended: false,
+        resetPassword: false,
+        reproveIdentity: false,
+        updatedAt: 4444,
+        sentAt: 123456,
+        appliedAt: 4444,
+        history: ['123456|TICF_CRI|01|reason|originating_component_id|originator_reference_id|requester_id'],
+        intervention: 'AIS_ACCOUNT_UNSUSPENDED',
+      },
+      keysToRemove: [],
+    });
   });
 
   it('should return a partial update command given an intervention is applied and id reset user action is needed', () => {
@@ -218,32 +179,7 @@ describe('build-partial-update-state-command', () => {
       resetPassword: false,
       reproveIdentity: true,
     };
-    const expectedOutput = {
-      ExpressionAttributeNames: {
-        '#B': 'blocked',
-        '#S': 'suspended',
-        '#RP': 'resetPassword',
-        '#RI': 'reproveIdentity',
-        '#UA': 'updatedAt',
-        '#SA': 'sentAt',
-        '#AA': 'appliedAt',
-        '#H': 'history',
-        '#INT': 'intervention',
-      },
-      ExpressionAttributeValues: {
-        ':b': false,
-        ':s': true,
-        ':rp': false,
-        ':ri': true,
-        ':ua': 4444,
-        ':sa': 123456,
-        ':aa': 4444,
-        ':h': ['123456|TICF_CRI|01|reason|originating_component_id|originator_reference_id|requester_id'],
-        ':int': 'AIS_FORCED_USER_IDENTITY_VERIFY',
-      },
-      UpdateExpression:
-        'SET #B = :b, #S = :s, #RP = :rp, #RI = :ri, #UA = :ua, #INT = :int, #SA = :sa, #AA = :aa, #H = :h REMOVE reprovedIdentityAt',
-    };
+
     const command = buildPartialUpdateAccountStateCommand(
       state,
       4444,
@@ -251,7 +187,21 @@ describe('build-partial-update-state-command', () => {
       [],
       AISInterventionTypes.AIS_FORCED_USER_IDENTITY_VERIFY,
     );
-    expect(command).toEqual(expectedOutput);
+
+    expect(command).toEqual({
+      input: {
+        blocked: false,
+        suspended: true,
+        resetPassword: false,
+        reproveIdentity: true,
+        updatedAt: 4444,
+        sentAt: 123456,
+        appliedAt: 4444,
+        history: ['123456|TICF_CRI|01|reason|originating_component_id|originator_reference_id|requester_id'],
+        intervention: 'AIS_FORCED_USER_IDENTITY_VERIFY',
+      },
+      keysToRemove: ['reprovedIdentityAt'],
+    });
   });
 
   it('should return a partial update command given an intervention is applied and id reset and psw reset user actions are needed', () => {
@@ -261,32 +211,6 @@ describe('build-partial-update-state-command', () => {
       resetPassword: true,
       reproveIdentity: true,
     };
-    const expectedOutput = {
-      ExpressionAttributeNames: {
-        '#B': 'blocked',
-        '#S': 'suspended',
-        '#RP': 'resetPassword',
-        '#RI': 'reproveIdentity',
-        '#UA': 'updatedAt',
-        '#SA': 'sentAt',
-        '#AA': 'appliedAt',
-        '#H': 'history',
-        '#INT': 'intervention',
-      },
-      ExpressionAttributeValues: {
-        ':b': false,
-        ':s': true,
-        ':rp': true,
-        ':ri': true,
-        ':ua': 4444,
-        ':sa': 123456,
-        ':aa': 4444,
-        ':h': ['1000000|TICF_CRI|01|reason|originating_component_id|originator_reference_id|requester_id'],
-        ':int': 'AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY',
-      },
-      UpdateExpression:
-        'SET #B = :b, #S = :s, #RP = :rp, #RI = :ri, #UA = :ua, #INT = :int, #SA = :sa, #AA = :aa, #H = :h REMOVE resetPasswordAt, reprovedIdentityAt',
-    };
 
     const command = buildPartialUpdateAccountStateCommand(
       state,
@@ -295,11 +219,24 @@ describe('build-partial-update-state-command', () => {
       ['1706544554234|TICF_CRI|02|reason|originating_component_id|originator_reference_id|requester_id'],
       AISInterventionTypes.AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY,
     );
-    expectedOutput.ExpressionAttributeValues[':h'] = [
-      '1706544554234|TICF_CRI|02|reason|originating_component_id|originator_reference_id|requester_id',
-      '123456|TICF_CRI|01|reason|originating_component_id|originator_reference_id|requester_id',
-    ];
-    expect(command).toEqual(expectedOutput);
+
+    expect(command).toEqual({
+      input: {
+        blocked: false,
+        suspended: true,
+        resetPassword: true,
+        reproveIdentity: true,
+        updatedAt: 4444,
+        sentAt: 123456,
+        appliedAt: 4444,
+        history: [
+          '1706544554234|TICF_CRI|02|reason|originating_component_id|originator_reference_id|requester_id',
+          '123456|TICF_CRI|01|reason|originating_component_id|originator_reference_id|requester_id',
+        ],
+        intervention: 'AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY',
+      },
+      keysToRemove: ['resetPasswordAt', 'reprovedIdentityAt'],
+    });
   });
 
   it('should throw an error if an intervention is passed without an intervention name', () => {

--- a/src/commons/test/build-partial-update-state-command.test.ts
+++ b/src/commons/test/build-partial-update-state-command.test.ts
@@ -63,6 +63,7 @@ describe('build-partial-update-state-command', () => {
   afterAll(() => {
     vi.useRealTimers();
   });
+
   it('should return a partial update command given Auth successful password reset is applied', () => {
     const state: StateDetails = {
       blocked: false,

--- a/src/services/db-helpers.ts
+++ b/src/services/db-helpers.ts
@@ -1,0 +1,13 @@
+export const generateExpressionAttributeNames = (keys: string[]) =>
+  Object.fromEntries(keys.map((key) => [`#${key}`, key]));
+
+export const generateExpressionAttributeValues = (input: Record<string, unknown>) =>
+  Object.fromEntries(Object.entries(input).map(([key, value]) => [`:${key}`, value]));
+
+export const generateUpdateExpressionClause = (keys: string[], keysToRemove?: string[]) =>
+  `SET ${keys.map((key) => keyToUpdateExpressionClause(key)).join(', ')}${keysToRemoveExpressionClause(keysToRemove)}`;
+
+const keyToUpdateExpressionClause = (key: string) => `#${key} = :${key}`;
+
+export const keysToRemoveExpressionClause = (keysToRemove?: string[]) =>
+  keysToRemove && keysToRemove.length > 0 ? ` REMOVE ${keysToRemove.join(', ')}` : '';

--- a/src/services/dynamo-db-record-service.ts
+++ b/src/services/dynamo-db-record-service.ts
@@ -1,6 +1,7 @@
 import { z, ZodArray, ZodObject, ZodRawShape } from 'zod';
 import {
   BatchWriteCommand,
+  BatchWriteCommandOutput,
   DynamoDBDocumentClient,
   NativeAttributeValue,
   QueryCommand,
@@ -71,7 +72,7 @@ export interface RecordService<T extends ZodObject<ZodRawShape>> {
    * Note this will update if the partitionKey and sortKey match an existing row.
    * @param input - Array of objects to insert or update.
    */
-  batchWrite(input: ArrayFromT<T>): Promise<void>;
+  batchWrite(input: ArrayFromT<T>): Promise<BatchWriteCommandOutput>;
 
   /**
    * Update a row in the database
@@ -142,8 +143,8 @@ export class DynamoDBRecordService<
     return res[0];
   }
 
-  async batchWrite(input: ArrayFromT<T>): Promise<void> {
-    await this.databaseClient.send(
+  async batchWrite(input: ArrayFromT<T>): Promise<BatchWriteCommandOutput> {
+    return await this.databaseClient.send(
       new BatchWriteCommand({
         RequestItems: {
           [this.config.tableName]: input.map((item) => ({
@@ -204,10 +205,14 @@ export class InMemoryRecordService<T extends ZodObject<ZodRawShape>> implements 
   }
 
   batchWrite() {
-    return Promise.resolve();
+    return Promise.resolve({
+      $metadata: { attempts: 1 },
+    });
   }
 
   update() {
-    return Promise.resolve(undefined);
+    return Promise.resolve({
+      $metadata: {},
+    });
   }
 }

--- a/src/services/dynamo-db-record-service.ts
+++ b/src/services/dynamo-db-record-service.ts
@@ -2,32 +2,88 @@ import { z, ZodArray, ZodObject, ZodRawShape } from 'zod';
 import {
   BatchWriteCommand,
   DynamoDBDocumentClient,
+  NativeAttributeValue,
   QueryCommand,
   UpdateCommand,
-  UpdateCommandInput,
   UpdateCommandOutput,
 } from '@aws-sdk/lib-dynamodb';
 import TableConfig from '../tables/table-config';
+import { ReturnValue } from '@aws-sdk/client-dynamodb';
+import {
+  generateExpressionAttributeNames,
+  generateExpressionAttributeValues,
+  generateUpdateExpressionClause,
+} from './db-helpers';
 
 type ArrayFromT<T extends ZodObject<ZodRawShape>> = z.infer<z.ZodArray<T>>;
 type PickedArray<T extends ZodObject<ZodRawShape>, K extends keyof z.infer<T>> = Pick<z.infer<T>, K>[];
 
+/**
+ * Optional config parameters for an update call
+ */
+export interface UpdateConfig<T extends string> {
+  /**
+   * Use ReturnValues if you want to get the item attributes as they appear before or after they are successfully updated.
+   */
+  ReturnValues?: ReturnValue;
+  /**
+   * A condition that must be satisfied in order for a conditional update to succeed.
+   * If booleans are used as part of the expression, they should be added to ExpressionAttributeValues
+   */
+  ConditionExpression?: string;
+  /**
+   * Keys that will be removed as part of the update command
+   */
+  RemoveKeys?: T[] | undefined;
+  /**
+   * One or more values that can be substituted in an expression.
+   * These are combined with values from the update input
+   * Can be used with ConditionExpression to set booleans
+   */
+  ExpressionAttributeValues?: Record<string, NativeAttributeValue> | undefined;
+}
+
 export interface RecordService<T extends ZodObject<ZodRawShape>> {
+  /**
+   * Query database for a partitionKey value
+   * @param partitionKeyValue - Value for the partitionKey
+   * @param includedKeys - Optionally return a subset of fields
+   */
   queryByPkAndValidate(partitionKeyValue: string, includedKeys?: undefined): Promise<ArrayFromT<T>>;
   queryByPkAndValidate<K extends keyof z.infer<T>>(
     partitionKeyValue: string,
     includedKeys: K[],
   ): Promise<PickedArray<T, K>>;
 
+  /**
+   * Get the first item for a partitionKey
+   * @param partitionKeyValue - Value for the partitionKey
+   * @param includedKeys - Optionally return a subset of fields
+   */
   getByPkAndValidate(partitionKeyValue: string, includedKeys?: undefined): Promise<z.infer<T> | undefined>;
   getByPkAndValidate<K extends keyof z.infer<T>>(
     partitionKeyValue: string,
     includedKeys: K[],
   ): Promise<Pick<z.infer<T>, K> | undefined>;
 
+  /**
+   * Batch write a number of rows in the database.
+   * Note this will update if the partitionKey and sortKey match an existing row.
+   * @param input - Array of objects to insert or update.
+   */
   batchWrite(input: ArrayFromT<T>): Promise<void>;
 
-  update(partitionKeyValue: string, input: Partial<UpdateCommandInput>): Promise<UpdateCommandOutput | undefined>;
+  /**
+   * Update a row in the database
+   * @param partitionKeyValue - Value for the partition key.
+   * @param input - Object containing keys and values to update
+   * @param config - Optional additional config
+   */
+  update(
+    partitionKeyValue: string,
+    input: Partial<z.infer<T>>,
+    config?: UpdateConfig<string & keyof z.infer<T>>,
+  ): Promise<UpdateCommandOutput | undefined>;
 }
 
 export class DynamoDBRecordService<
@@ -98,14 +154,29 @@ export class DynamoDBRecordService<
     );
   }
 
-  async update(partitionKeyValue: string, input: Partial<UpdateCommandInput>) {
+  async update(
+    partitionKeyValue: string,
+    input: Partial<z.infer<T>>,
+    config?: UpdateConfig<string & keyof z.infer<T>>,
+  ) {
+    const keys = Object.keys(input);
+
+    if (keys.length === 0) return;
+
     return this.databaseClient.send(
       new UpdateCommand({
-        ...input,
+        UpdateExpression: generateUpdateExpressionClause(keys, config?.RemoveKeys),
+        ExpressionAttributeNames: generateExpressionAttributeNames(keys),
+        ExpressionAttributeValues: {
+          ...generateExpressionAttributeValues(input),
+          ...config?.ExpressionAttributeValues,
+        },
         TableName: this.config.tableName,
         Key: {
           [this.config.partitionKeyName]: partitionKeyValue,
         },
+        ReturnValues: config?.ReturnValues,
+        ConditionExpression: config?.ConditionExpression,
       }),
     );
   }

--- a/src/services/test/db-helpers.test.ts
+++ b/src/services/test/db-helpers.test.ts
@@ -1,0 +1,19 @@
+import { keysToRemoveExpressionClause } from '../db-helpers';
+
+describe('keysToRemoveExpressionClause', () => {
+  test('with single key to remove', () => {
+    expect(keysToRemoveExpressionClause(['key1'])).toEqual(' REMOVE key1');
+  });
+
+  test('with multiple keys to remove', () => {
+    expect(keysToRemoveExpressionClause(['key1', 'key2'])).toEqual(' REMOVE key1, key2');
+  });
+
+  test('with no keys to remove', () => {
+    expect(keysToRemoveExpressionClause()).toEqual('');
+  });
+
+  test('with empty list of keys to remove', () => {
+    expect(keysToRemoveExpressionClause([])).toEqual('');
+  });
+});

--- a/src/services/test/dynamo-db-record-service.test.ts
+++ b/src/services/test/dynamo-db-record-service.test.ts
@@ -1,4 +1,4 @@
-import z from 'zod';
+import z, { ZodError } from 'zod';
 import TableConfig from '../../tables/table-config';
 import { DynamoDBRecordService } from '../dynamo-db-record-service';
 import { BatchWriteCommand, DynamoDBDocumentClient, QueryCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
@@ -77,6 +77,68 @@ describe('DynamoDBRecordService', () => {
     });
   });
 
+  test('queryByPkAndValidate includedKeys not including otherwise required field', async () => {
+    const schema2 = schema.safeExtend({
+      requiredKey: z.string(),
+    });
+
+    ddbMock.on(QueryCommand).resolves({
+      Items: [
+        {
+          pk1: 'value1',
+        },
+      ],
+    });
+
+    const service = new DynamoDBRecordService<typeof schema2>(
+      { ...tableConfig, schema: schema2 },
+      ddbMock as unknown as DynamoDBDocumentClient,
+    );
+
+    const res = await service.queryByPkAndValidate('key_value_1', ['pk1']);
+
+    expect(res).toEqual([
+      {
+        pk1: 'value1',
+      },
+    ]);
+
+    expect(ddbMock).toHaveReceivedCommandWith(QueryCommand, {
+      TableName: 'test-table',
+      KeyConditionExpression: '#pk = :pk',
+      ExpressionAttributeNames: { '#pk': 'pk1' },
+      ExpressionAttributeValues: { ':pk': 'key_value_1' },
+    });
+  });
+
+  test('queryByPkAndValidate includedKeys missing required field', async () => {
+    const schema2 = schema.safeExtend({
+      requiredKey: z.string(),
+    });
+
+    ddbMock.on(QueryCommand).resolves({
+      Items: [
+        {
+          pk1: 'value1',
+        },
+      ],
+    });
+
+    const service = new DynamoDBRecordService<typeof schema2>(
+      { ...tableConfig, schema: schema2 },
+      ddbMock as unknown as DynamoDBDocumentClient,
+    );
+
+    await expect(service.queryByPkAndValidate('key_value_1', ['pk1', 'requiredKey'])).rejects.toThrow(ZodError);
+
+    expect(ddbMock).toHaveReceivedCommandWith(QueryCommand, {
+      TableName: 'test-table',
+      KeyConditionExpression: '#pk = :pk',
+      ExpressionAttributeNames: { '#pk': 'pk1' },
+      ExpressionAttributeValues: { ':pk': 'key_value_1' },
+    });
+  });
+
   test('queryByPkAndValidate empty', async () => {
     ddbMock.on(QueryCommand).resolves({
       Items: [],
@@ -145,16 +207,19 @@ describe('DynamoDBRecordService', () => {
       Items: [
         {
           pk1: 'value1',
+          isAccountDeleted: true,
+          abc: 1234,
         },
       ],
     });
 
     const service = new DynamoDBRecordService<typeof schema>(tableConfig, ddbMock as unknown as DynamoDBDocumentClient);
 
-    const res = await service.getByPkAndValidate('key_value_1', ['pk1']);
+    const res = await service.getByPkAndValidate('key_value_1', ['pk1', 'isAccountDeleted']);
 
     expect(res).toEqual({
       pk1: 'value1',
+      isAccountDeleted: true,
     });
 
     expect(ddbMock).toHaveReceivedCommandWith(QueryCommand, {
@@ -162,6 +227,7 @@ describe('DynamoDBRecordService', () => {
       KeyConditionExpression: '#pk = :pk',
       ExpressionAttributeNames: { '#pk': 'pk1' },
       ExpressionAttributeValues: { ':pk': 'key_value_1' },
+      ProjectionExpression: 'pk1,isAccountDeleted',
     });
   });
 
@@ -187,11 +253,15 @@ describe('DynamoDBRecordService', () => {
   test('batchWrite', async () => {
     const service = new DynamoDBRecordService<typeof schema>(tableConfig, ddbMock as unknown as DynamoDBDocumentClient);
 
-    await service.batchWrite([
+    ddbMock.on(BatchWriteCommand).resolves({});
+
+    const res = await service.batchWrite([
       {
         pk1: 'value1',
       },
     ]);
+
+    expect(res).toEqual({});
 
     expect(ddbMock).toHaveReceivedCommandWith(BatchWriteCommand, {
       RequestItems: {

--- a/src/services/test/dynamo-db-record-service.test.ts
+++ b/src/services/test/dynamo-db-record-service.test.ts
@@ -9,6 +9,7 @@ const ddbMock = mockClient(DynamoDBDocumentClient);
 
 const schema = z.object({
   pk1: z.string(),
+  isAccountDeleted: z.boolean().optional(),
 });
 
 const tableConfig: TableConfig<typeof schema> = {
@@ -207,17 +208,11 @@ describe('DynamoDBRecordService', () => {
     });
   });
 
-  test('update', async () => {
+  test('basic update', async () => {
     const service = new DynamoDBRecordService<typeof schema>(tableConfig, ddbMock as unknown as DynamoDBDocumentClient);
 
     await service.update('1234', {
-      UpdateExpression: 'SET #isAccountDeleted = :isAccountDeleted',
-      ExpressionAttributeNames: {
-        '#isAccountDeleted': 'isAccountDeleted',
-      },
-      ExpressionAttributeValues: {
-        ':isAccountDeleted': true,
-      },
+      isAccountDeleted: true,
     });
 
     expect(ddbMock).toHaveReceivedCommandWith(UpdateCommand, {
@@ -233,5 +228,49 @@ describe('DynamoDBRecordService', () => {
         ':isAccountDeleted': true,
       },
     });
+  });
+
+  test('update with ConditionExpression and RemoveKeys', async () => {
+    const service = new DynamoDBRecordService<typeof schema>(tableConfig, ddbMock as unknown as DynamoDBDocumentClient);
+
+    await service.update(
+      '1234',
+      {
+        isAccountDeleted: true,
+      },
+      {
+        RemoveKeys: ['pk1'],
+        ConditionExpression:
+          'attribute_exists(pk) AND (attribute_not_exists(isAccountDeleted) OR isAccountDeleted = :false)',
+        ExpressionAttributeValues: {
+          ':false': false,
+        },
+      },
+    );
+
+    expect(ddbMock).toHaveReceivedCommandWith(UpdateCommand, {
+      TableName: 'test-table',
+      Key: {
+        pk1: '1234',
+      },
+      UpdateExpression: 'SET #isAccountDeleted = :isAccountDeleted REMOVE pk1',
+      ExpressionAttributeNames: {
+        '#isAccountDeleted': 'isAccountDeleted',
+      },
+      ExpressionAttributeValues: {
+        ':isAccountDeleted': true,
+        ':false': false,
+      },
+      ConditionExpression:
+        'attribute_exists(pk) AND (attribute_not_exists(isAccountDeleted) OR isAccountDeleted = :false)',
+    });
+  });
+
+  test('update with empty object', async () => {
+    const service = new DynamoDBRecordService<typeof schema>(tableConfig, ddbMock as unknown as DynamoDBDocumentClient);
+
+    await service.update('1234', {});
+
+    expect(ddbMock).not.toHaveReceivedAnyCommand();
   });
 });

--- a/src/services/test/persist-intervention-events.test.ts
+++ b/src/services/test/persist-intervention-events.test.ts
@@ -3,6 +3,7 @@ import { EventsEnum, InterventionState, TriggerEventsEnum } from '../../data-typ
 import { InterventionName } from '../../data-types/intervention-name';
 import { InMemoryInterventionEventsService } from '../../tables/intervention-events';
 import persistInterventionEvents, {
+  enrichEvents,
   generateEventsToAppend,
   persistIgnoredInterventionEvent,
   setTtlOnInactiveEvents,
@@ -27,16 +28,16 @@ const baseMessage: InterventionEventMessage = {
 
 const FIXED_TIMESTAMP = 1781253284370;
 
+beforeAll(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(FIXED_TIMESTAMP);
+});
+
+afterAll(() => {
+  vi.useRealTimers();
+});
+
 describe('persistInterventionEvents', () => {
-  beforeAll(() => {
-    vi.useFakeTimers();
-    vi.setSystemTime(FIXED_TIMESTAMP);
-  });
-
-  afterAll(() => {
-    vi.useRealTimers();
-  });
-
   test('persists a new intervention event when no existing events are present', async () => {
     const service = new InMemoryInterventionEventsService([]);
     const fetchEventsSpy = vi.spyOn(service, 'fetchEventsForAccount');
@@ -66,15 +67,6 @@ describe('persistInterventionEvents', () => {
 });
 
 describe('generateEventsToAppend', () => {
-  beforeAll(() => {
-    vi.useFakeTimers();
-    vi.setSystemTime(FIXED_TIMESTAMP);
-  });
-
-  afterAll(() => {
-    vi.useRealTimers();
-  });
-
   test('add one intervention', () => {
     const response = generateEventsToAppend(
       [
@@ -190,15 +182,6 @@ describe('generateEventsToAppend', () => {
 });
 
 describe('persistIgnoredInterventionEvent', () => {
-  beforeAll(() => {
-    vi.useFakeTimers();
-    vi.setSystemTime(FIXED_TIMESTAMP);
-  });
-
-  afterAll(() => {
-    vi.useRealTimers();
-  });
-
   test('persists exactly one ignored row when attempted intervention matches the active intervention', async () => {
     const service = new InMemoryInterventionEventsService([
       {
@@ -278,15 +261,6 @@ describe('setTtlOnInactiveEvents', () => {
   const FIXED_TIMESTAMP = 1781253284370;
   const HISTORY_RETENTION_SECONDS = 1000;
   const EXPECTED_TTL = Math.floor(FIXED_TIMESTAMP / 1000) + HISTORY_RETENTION_SECONDS;
-
-  beforeAll(() => {
-    vi.useFakeTimers();
-    vi.setSystemTime(FIXED_TIMESTAMP);
-  });
-
-  afterAll(() => {
-    vi.useRealTimers();
-  });
 
   test('sets ttl on inactive events that do not already have a ttl', async () => {
     const service = new InMemoryInterventionEventsService([
@@ -433,6 +407,169 @@ describe('setTtlOnInactiveEvents', () => {
     expect(appendEventsSpy).toHaveBeenCalledExactlyOnceWith([
       expect.objectContaining({ eventId: 'event-1', ttl: EXPECTED_TTL }),
       expect.objectContaining({ eventId: 'event-2', ttl: EXPECTED_TTL }),
+    ]);
+  });
+});
+
+const ticfAccountInterventionEvent: InterventionEventMessage = {
+  event_name: TriggerEventsEnum.TICF_ACCOUNT_INTERVENTION,
+  extensions: {
+    intervention: { intervention_code: '01', intervention_reason: 'Lost' },
+  },
+  component_id: 'TEST',
+  timestamp: 123,
+  event_timestamp_ms: 123,
+  user: { user_id: 'abc123' },
+};
+
+describe('enrichEvents', () => {
+  test('empty event list', () => {
+    const result = enrichEvents([], ticfAccountInterventionEvent);
+
+    expect(result).toEqual([]);
+  });
+
+  test('single event', () => {
+    const result = enrichEvents(
+      [
+        {
+          interventionName: InterventionName.PERMANENT_SUSPENSION,
+          interventionState: InterventionState.ACTIVE,
+        },
+      ],
+      ticfAccountInterventionEvent,
+    );
+
+    expect(result).toEqual([
+      {
+        accountId: 'abc123',
+        componentId: 'TEST',
+        createdAt: FIXED_TIMESTAMP,
+        eventId: expect.any(String) as string,
+        interventionName: 'PERMANENT_SUSPENSION',
+        interventionReason: 'Lost',
+        interventionState: 'ACTIVE',
+        originatingComponentId: undefined,
+        originatorReferenceId: undefined,
+        requesterId: undefined,
+        sentAt: 123,
+        transactionId: expect.any(String) as string,
+      },
+    ]);
+  });
+
+  test('message with more extensions', () => {
+    const result = enrichEvents(
+      [
+        {
+          interventionName: InterventionName.PERMANENT_SUSPENSION,
+          interventionState: InterventionState.ACTIVE,
+        },
+      ],
+      {
+        ...ticfAccountInterventionEvent,
+        extensions: {
+          ...ticfAccountInterventionEvent.extensions,
+          intervention: {
+            ...ticfAccountInterventionEvent.extensions.intervention,
+            originating_component_id: 'TEST',
+            requester_id: 'req1234',
+            originator_reference_id: 'ref1',
+          },
+        },
+      },
+    );
+
+    expect(result).toEqual([
+      {
+        accountId: 'abc123',
+        componentId: 'TEST',
+        createdAt: FIXED_TIMESTAMP,
+        eventId: expect.any(String) as string,
+        interventionName: 'PERMANENT_SUSPENSION',
+        interventionReason: 'Lost',
+        interventionState: 'ACTIVE',
+        originatingComponentId: 'TEST',
+        originatorReferenceId: 'ref1',
+        requesterId: 'req1234',
+        sentAt: 123,
+        transactionId: expect.any(String) as string,
+      },
+    ]);
+  });
+
+  test('message without extensions', () => {
+    const result = enrichEvents(
+      [
+        {
+          interventionName: InterventionName.PERMANENT_SUSPENSION,
+          interventionState: InterventionState.ACTIVE,
+        },
+      ],
+      {
+        event_name: EventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL,
+        component_id: '',
+        timestamp: 0,
+        event_timestamp_ms: 1234,
+        user: {
+          user_id: 'abc1234',
+        },
+      },
+    );
+
+    expect(result).toEqual([
+      {
+        accountId: 'abc1234',
+        componentId: '',
+        createdAt: FIXED_TIMESTAMP,
+        eventId: expect.any(String) as string,
+        interventionName: 'PERMANENT_SUSPENSION',
+        interventionReason: '',
+        interventionState: 'ACTIVE',
+        originatingComponentId: undefined,
+        originatorReferenceId: undefined,
+        requesterId: undefined,
+        sentAt: 1234,
+        transactionId: expect.any(String) as string,
+      },
+    ]);
+  });
+
+  test('message with other extensions', () => {
+    const result = enrichEvents(
+      [
+        {
+          interventionName: InterventionName.PERMANENT_SUSPENSION,
+          interventionState: InterventionState.ACTIVE,
+        },
+      ],
+      {
+        event_name: EventsEnum.AUTH_PASSWORD_RESET_SUCCESSFUL,
+        component_id: '',
+        timestamp: 0,
+        event_timestamp_ms: 1234,
+        user: {
+          user_id: 'abc1234',
+        },
+        extensions: {},
+      } as InterventionEventMessage,
+    );
+
+    expect(result).toEqual([
+      {
+        accountId: 'abc1234',
+        componentId: '',
+        createdAt: FIXED_TIMESTAMP,
+        eventId: expect.any(String) as string,
+        interventionName: 'PERMANENT_SUSPENSION',
+        interventionReason: '',
+        interventionState: 'ACTIVE',
+        originatingComponentId: undefined,
+        originatorReferenceId: undefined,
+        requesterId: undefined,
+        sentAt: 1234,
+        transactionId: expect.any(String) as string,
+      },
     ]);
   });
 });

--- a/src/tables/account-status.ts
+++ b/src/tables/account-status.ts
@@ -124,7 +124,9 @@ export class PersistentAccountStatusService implements AccountStatusService {
       statusResult.interventionName,
     );
     logger.debug(`${LOGS_PREFIX_SENSITIVE_INFO} Updating user status`, { userId: accountId, partialCommandInput });
-    await this.recordService.update(accountId, partialCommandInput);
+    await this.recordService.update(accountId, partialCommandInput.input, {
+      RemoveKeys: partialCommandInput.keysToRemove,
+    });
   }
 
   async updateDeleteStatus(accountId: string) {
@@ -132,23 +134,22 @@ export class PersistentAccountStatusService implements AccountStatusService {
     const ttl = now.seconds + appConfig.maxRetentionSeconds;
 
     try {
-      return await this.recordService.update(accountId, {
-        UpdateExpression: 'SET #isAccountDeleted = :isAccountDeleted, #ttl = :ttl, #deletedAt = :deletedAt',
-        ExpressionAttributeNames: {
-          '#isAccountDeleted': 'isAccountDeleted',
-          '#ttl': 'ttl',
-          '#deletedAt': 'deletedAt',
+      return await this.recordService.update(
+        accountId,
+        {
+          isAccountDeleted: true,
+          ttl: ttl,
+          deletedAt: now.milliseconds,
         },
-        ExpressionAttributeValues: {
-          ':isAccountDeleted': true,
-          ':ttl': ttl,
-          ':false': false,
-          ':deletedAt': now.milliseconds,
+        {
+          ReturnValues: 'ALL_NEW',
+          ExpressionAttributeValues: {
+            ':false': false,
+          },
+          ConditionExpression:
+            'attribute_exists(pk) AND (attribute_not_exists(isAccountDeleted) OR isAccountDeleted = :false)',
         },
-        ReturnValues: 'ALL_NEW',
-        ConditionExpression:
-          'attribute_exists(pk) AND (attribute_not_exists(isAccountDeleted) OR isAccountDeleted = :false)',
-      });
+      );
     } catch (error) {
       if (error instanceof ConditionalCheckFailedException) {
         logger.info(`${LOGS_PREFIX_SENSITIVE_INFO} No intervention exists for this account.`, {

--- a/src/tables/intervention-events.ts
+++ b/src/tables/intervention-events.ts
@@ -5,6 +5,7 @@ import TableConfig from './table-config';
 import { getDBDocumentClient } from '../services/database-client';
 import { InterventionState } from '../data-types/constants';
 import { InterventionName } from '../data-types/intervention-name';
+import { BatchWriteCommandOutput } from '@aws-sdk/lib-dynamodb';
 
 const appConfig = AppConfigService.getInstance();
 
@@ -36,7 +37,7 @@ export type InterventionEvent = z.infer<typeof schema>;
 
 export interface InterventionEventsService {
   fetchEventsForAccount(accountId: string): Promise<InterventionEvent[]>;
-  appendEvents(events: InterventionEvent[]): Promise<void>;
+  appendEvents(events: InterventionEvent[]): Promise<BatchWriteCommandOutput>;
 }
 
 export class InMemoryInterventionEventsService implements InterventionEventsService {
@@ -46,8 +47,10 @@ export class InMemoryInterventionEventsService implements InterventionEventsServ
     return Promise.resolve(this.events);
   }
 
-  async appendEvents() {
-    await Promise.resolve();
+  appendEvents() {
+    return Promise.resolve({
+      $metadata: {},
+    });
   }
 }
 
@@ -58,8 +61,8 @@ export class PersistentInterventionEventsService implements InterventionEventsSe
     return this.recordService.queryByPkAndValidate(accountId);
   }
 
-  async appendEvents(events: InterventionEvent[]) {
-    await this.recordService.batchWrite(events);
+  appendEvents(events: InterventionEvent[]) {
+    return this.recordService.batchWrite(events);
   }
 }
 

--- a/src/tables/test/account-status.test.ts
+++ b/src/tables/test/account-status.test.ts
@@ -142,7 +142,9 @@ describe('PersistentAccountStatusService', () => {
 
     const res = await service.updateDeleteStatus('1234');
 
-    expect(res).toEqual(undefined);
+    expect(res).toEqual({
+      $metadata: {},
+    });
 
     expect(recordServiceUpdateSpy).toHaveBeenLastCalledWith(
       '1234',

--- a/src/tables/test/account-status.test.ts
+++ b/src/tables/test/account-status.test.ts
@@ -114,32 +114,23 @@ describe('PersistentAccountStatusService', () => {
       [],
     );
 
-    expect(recordServiceUpdateSpy).toHaveBeenLastCalledWith('1234', {
-      ExpressionAttributeNames: {
-        '#AA': 'appliedAt',
-        '#B': 'blocked',
-        '#H': 'history',
-        '#INT': 'intervention',
-        '#RI': 'reproveIdentity',
-        '#RP': 'resetPassword',
-        '#S': 'suspended',
-        '#SA': 'sentAt',
-        '#UA': 'updatedAt',
+    expect(recordServiceUpdateSpy).toHaveBeenLastCalledWith(
+      '1234',
+      {
+        appliedAt: 1678665600000,
+        blocked: false,
+        history: ['12345|TEST|01||||'],
+        intervention: 'AIS_ACCOUNT_SUSPENDED',
+        reproveIdentity: false,
+        resetPassword: false,
+        suspended: true,
+        sentAt: 12345,
+        updatedAt: 1678665600000,
       },
-      ExpressionAttributeValues: {
-        ':aa': 1678665600000,
-        ':b': false,
-        ':h': ['12345|TEST|01||||'],
-        ':int': 'AIS_ACCOUNT_SUSPENDED',
-        ':ri': false,
-        ':rp': false,
-        ':s': true,
-        ':sa': 12345,
-        ':ua': 1678665600000,
+      {
+        RemoveKeys: [],
       },
-      UpdateExpression:
-        'SET #B = :b, #S = :s, #RP = :rp, #RI = :ri, #UA = :ua, #INT = :int, #SA = :sa, #AA = :aa, #H = :h',
-    });
+    );
   });
 
   test('updateDeleteStatus', async () => {
@@ -153,23 +144,22 @@ describe('PersistentAccountStatusService', () => {
 
     expect(res).toEqual(undefined);
 
-    expect(recordServiceUpdateSpy).toHaveBeenLastCalledWith('1234', {
-      ConditionExpression:
-        'attribute_exists(pk) AND (attribute_not_exists(isAccountDeleted) OR isAccountDeleted = :false)',
-      ExpressionAttributeNames: {
-        '#deletedAt': 'deletedAt',
-        '#isAccountDeleted': 'isAccountDeleted',
-        '#ttl': 'ttl',
+    expect(recordServiceUpdateSpy).toHaveBeenLastCalledWith(
+      '1234',
+      {
+        deletedAt: 1678665600000,
+        isAccountDeleted: true,
+        ttl: 1678677945,
       },
-      ExpressionAttributeValues: {
-        ':deletedAt': 1678665600000,
-        ':false': false,
-        ':isAccountDeleted': true,
-        ':ttl': 1678677945,
+      {
+        ConditionExpression:
+          'attribute_exists(pk) AND (attribute_not_exists(isAccountDeleted) OR isAccountDeleted = :false)',
+        ExpressionAttributeValues: {
+          ':false': false,
+        },
+        ReturnValues: 'ALL_NEW',
       },
-      ReturnValues: 'ALL_NEW',
-      UpdateExpression: 'SET #isAccountDeleted = :isAccountDeleted, #ttl = :ttl, #deletedAt = :deletedAt',
-    });
+    );
   });
 });
 

--- a/src/tables/test/intervention-events.test.ts
+++ b/src/tables/test/intervention-events.test.ts
@@ -43,7 +43,13 @@ describe('PersistentInterventionEventsService', () => {
     const batchWriteSpy = vi.spyOn(recordService, 'batchWrite');
     const service = new PersistentInterventionEventsService(recordService);
 
-    await service.appendEvents([event]);
+    const result = await service.appendEvents([event]);
+
+    expect(result).toEqual({
+      $metadata: {
+        attempts: 1,
+      },
+    });
 
     expect(batchWriteSpy).toHaveBeenCalledWith([event]);
   });


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Move DynamoDB aspects to dynamo-db-record-service

## Why

Collecting the DynamoDB aspects in one place makes it easier to swap out different components.

As changes to DynamoDB queries is higher risk, we want to reduce these changes and in future we can have test coverage for these methods against a proper DynamoDB mock.

## Notes

If `ConditionExpression` contains any variables these need to be manually set with `ExpressionAttributeValues`.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-8429](https://govukverify.atlassian.net/browse/FPAD-8429)

[FPAD-8429]: https://govukverify.atlassian.net/browse/FPAD-8429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ