### PR TITLE
Fix for ais-status-sdk import order

### DIFF
--- a/packages/ais-status-sdk/package.json
+++ b/packages/ais-status-sdk/package.json
@@ -18,9 +18,9 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.cjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.cjs"
     }
   },
   "files": [


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Fix for ais-status-sdk import order

## Why

Without this order change there is a warning on import