### PR TITLE
Update the templates to use assetPath

### DIFF
--- a/src/frontend/app.ts
+++ b/src/frontend/app.ts
@@ -38,7 +38,7 @@ export function init() {
     ],
   });
 
-  server.get('/', async (_request, reply) => reply.view('index.njk', { stagePrefix, assetPath: `${stagePrefix}/assets` }));
+  server.get('/', async (_request, reply) => reply.view('index.njk', { assetPath: `${stagePrefix}/assets` }));
 
   return server;
 }

--- a/src/frontend/views/base.njk
+++ b/src/frontend/views/base.njk
@@ -3,7 +3,7 @@
 {% set serviceName = "GOV.UK One Login Account Interventions Service" %}
 {% block pageTitle %}Account Interventions Service – GOV.UK{% endblock %}
 {% block head %}
-  <link rel="stylesheet" href="{{ stagePrefix }}/assets/govuk-frontend.min.css"/>
+  <link rel="stylesheet" href="{{ assetPath }}/govuk-frontend.min.css"/>
 {% endblock %}
 {% block header %}
   {{ govukHeader({
@@ -46,9 +46,9 @@
     }) }}
 {% endblock %}
 {% block bodyEnd %}
-  <script type="module" src="{{ stagePrefix }}/assets/govuk-frontend.min.js" nonce="{{ nonceValue }}"></script>
+  <script type="module" src="{{ assetPath }}/govuk-frontend.min.js" nonce="{{ nonceValue }}"></script>
   <script type="module" nonce="{{ nonceValue }}">
-    import {initAll} from '{{ stagePrefix }}/assets/govuk-frontend.min.js'
+    import {initAll} from '{{ assetPath }}/govuk-frontend.min.js'
     initAll()
   </script>
 {% endblock %}


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Update the templates to use assetPath

## Why

`assetPath` is required for the base template and removing `stagePrefix` simplifies things.