### PR TITLE
BAU: Set ruleset to `active`

### DIFF
--- a/.github/rulesets/protect_main.json
+++ b/.github/rulesets/protect_main.json
@@ -1,7 +1,7 @@
 {
   "name": "Protect main",
   "target": "branch",
-  "enforcement": "evaluate",
+  "enforcement": "active",
   "conditions": {
     "ref_name": {
       "exclude": [],


### PR DESCRIPTION
## What

Set the Github `main` branch protection ruleset to `active` 

## Why

This is basically turning the ruleset on - when this gets applied via the API we can turn off the manual branch protection