### PR TITLE
BAU: Remove some required checks

### DIFF
--- a/.github/rulesets/protect_main.json
+++ b/.github/rulesets/protect_main.json
@@ -42,16 +42,7 @@
         "do_not_enforce_on_create": false,
         "required_status_checks": [
           {
-            "context": "Build, Test, Lint & Scan"
-          },
-          {
             "context": "CodeQL"
-          },
-          {
-            "context": "SonarCloud Code Analysis"
-          },
-          {
-            "context": "contract-testing"
           },
           {
             "context": "Analyze (actions)"


### PR DESCRIPTION
## What

Remove some required checks from the protect main ruleset

## Why

These checks are causing issues because they don't run on every PR. This is just a workaround until we figure out a way to require these checks only on the PRs where they'll run.

We will still only merge PRs where these checks pass
