### PR TITLE
BAU: Fix pact ci conditions

### DIFF
--- a/.github/workflows/pact-test-api-provider.yaml
+++ b/.github/workflows/pact-test-api-provider.yaml
@@ -14,8 +14,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
     types:
       - opened
       - reopened

--- a/.github/workflows/pact-test-message-consumer.yaml
+++ b/.github/workflows/pact-test-message-consumer.yaml
@@ -13,8 +13,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
     types:
       - opened
       - reopened

--- a/.github/workflows/pact-test-message-consumer.yaml
+++ b/.github/workflows/pact-test-message-consumer.yaml
@@ -10,23 +10,9 @@ env:
 
 on:
   push:
-    paths:
-      - src/**
-      - package.json
-      - package-lock.json
-      - tsconfig.json
-      - .node-version
-      - .github/workflows/pact-test-message-consumer.yaml
     branches:
       - main
   pull_request:
-    paths:
-      - src/**
-      - package.json
-      - package-lock.json
-      - tsconfig.json
-      - .node-version
-      - .github/workflows/pact-test-message-consumer.yaml
     branches:
       - main
     types:


### PR DESCRIPTION
## What

Run all pact tests in every PR

## Why

To keep the `protect_main` branch ruleset happy, and make sure pact tests run in PRs for branches-on-branches for convenience
