### PR TITLE
FPAD-8493: History UI v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "precommit": "pre-commit run",
     "send-audit-event": "tsx src/scripts/send-audit-event.ts",
     "generate:spec:main": "tsx src/scripts/generate-main-spec.ts",
-    "ui:start": "tsx watch --watch-path src/frontend/views src/frontend/local.ts",
+    "ui:start": "tsx watch --include src/frontend/views src/frontend/local.ts",
     "ui:build": "node build-frontend.mjs && sam build -t src/infra/frontend/template.yaml",
     "ui:package": "npm run clean && npm run ui:build",
     "ui:deploy": "sam deploy --config-env frontend"

--- a/packages/ais-status-sdk/src/index.test.ts
+++ b/packages/ais-status-sdk/src/index.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { InterventionClient } from './index';
 import { InterventionInvalidResponse } from './errors';
+import type { HistoryObject } from './types';
+import { InterventionName, InterventionState } from './types';
+import { ZodError } from 'zod';
 
 const mockFetch = vi.fn<typeof fetch>();
 vi.stubGlobal('fetch', mockFetch);
@@ -12,6 +15,17 @@ function mockResponse(body: unknown, status = 200): Response {
     statusText: status === 200 ? 'OK' : 'Error',
     json: () => Promise.resolve(body),
   } as unknown as Response;
+}
+
+function makeHistoryObject(overrides: Partial<HistoryObject> = {}): HistoryObject {
+  return {
+    sentAt: 1_696_869_003_456,
+    componentId: 'TICF_CRI',
+    interventionName: InterventionName.PERMANENT_SUSPENSION,
+    interventionState: InterventionState.ACTIVE,
+    interventionReason: 'suspend account due to fraud',
+    ...overrides,
+  };
 }
 
 describe('InterventionClient', () => {
@@ -69,6 +83,183 @@ describe('InterventionClient', () => {
       await clientWithSlash.getAccountStatus('user-1');
 
       expect(mockFetch).toHaveBeenCalledWith('https://example.com/v2/ais/user-1', expect.anything());
+    });
+  });
+
+  describe('getAccountHistory', () => {
+    it('calls the v2 history endpoint with the encoded userId', async () => {
+      const client = new InterventionClient({ baseUrl });
+
+      const userId = 'urn:fdc:gov.uk:2022:user123';
+      mockFetch.mockResolvedValue(mockResponse({ history: [] }));
+
+      await client.getAccountHistory(userId);
+
+      const [calledUrl, calledOptions] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(calledUrl).toBe(`${baseUrl}/v2/ais/${encodeURIComponent(userId)}/history`);
+      expect(new Headers(calledOptions.headers).get('Content-Type')).toBe('application/json');
+    });
+
+    it('returns an empty history array when there are no history entries', async () => {
+      const client = new InterventionClient({ baseUrl });
+
+      mockFetch.mockResolvedValue(mockResponse({ history: [] }));
+
+      const result = await client.getAccountHistory('user-1');
+
+      expect(result).toEqual({ history: [] });
+    });
+
+    it('returns the parsed AccountHistory with a single entry', async () => {
+      const client = new InterventionClient({ baseUrl });
+
+      const historyEntry = makeHistoryObject();
+      mockFetch.mockResolvedValue(mockResponse({ history: [historyEntry] }));
+
+      const result = await client.getAccountHistory('user-1');
+
+      expect(result).toEqual({ history: [historyEntry] });
+    });
+
+    it('returns history with multiple entries in order', async () => {
+      const client = new InterventionClient({ baseUrl });
+
+      const entries = [
+        makeHistoryObject({ sentAt: 1_696_869_003_000, interventionName: InterventionName.PERMANENT_SUSPENSION }),
+        makeHistoryObject({ sentAt: 1_696_869_004_000, interventionName: InterventionName.TEMPORARY_SUSPENSION }),
+        makeHistoryObject({ sentAt: 1_696_869_005_000, interventionName: InterventionName.REPROVE_IDENTITY }),
+      ];
+      mockFetch.mockResolvedValue(mockResponse({ history: entries }));
+
+      const result = await client.getAccountHistory('user-1');
+
+      expect(result.history).toHaveLength(3);
+      expect(result.history).toEqual(entries);
+    });
+
+    it('returns history entries with all optional fields present', async () => {
+      const client = new InterventionClient({ baseUrl });
+
+      const fullEntry = makeHistoryObject({
+        interventionCode: '01',
+        originatingComponent: 'CMS',
+        originatorReferenceId: 'ref-abc-123',
+        requesterId: 'requester-xyz',
+        transactionId: 'txn-456',
+        messageEventId: 'msg-789',
+      });
+      mockFetch.mockResolvedValue(mockResponse({ history: [fullEntry] }));
+
+      const result = await client.getAccountHistory('user-1');
+
+      expect(result.history[0]).toEqual(fullEntry);
+    });
+
+    it('returns history entries where originatorReferenceId is an array', async () => {
+      const client = new InterventionClient({ baseUrl });
+
+      const entry = makeHistoryObject({ originatorReferenceId: ['ref-1', 'ref-2'] });
+      mockFetch.mockResolvedValue(mockResponse({ history: [entry] }));
+
+      const result = await client.getAccountHistory('user-1');
+
+      expect(result.history[0]?.originatorReferenceId).toEqual(['ref-1', 'ref-2']);
+    });
+
+    it('returns history entries with all known interventionState values', async () => {
+      const client = new InterventionClient({ baseUrl });
+
+      const entries = Object.values(InterventionState).map((state) => makeHistoryObject({ interventionState: state }));
+      mockFetch.mockResolvedValue(mockResponse({ history: entries }));
+
+      const result = await client.getAccountHistory('user-1');
+
+      const returnedStates = result.history.map((h) => h.interventionState);
+      expect(returnedStates).toEqual(Object.values(InterventionState));
+    });
+
+    it('throws InterventionRequestFailed when the response is not ok (404)', async () => {
+      const client = new InterventionClient({ baseUrl });
+
+      mockFetch.mockResolvedValue(mockResponse({}, 404));
+
+      await expect(client.getAccountHistory('user-1')).rejects.toThrow('AIS request failed: 404');
+    });
+
+    it('throws InterventionRequestFailed when the response is not ok (500)', async () => {
+      const client = new InterventionClient({ baseUrl });
+
+      mockFetch.mockResolvedValue(mockResponse({}, 500));
+
+      await expect(client.getAccountHistory('user-1')).rejects.toThrow('AIS request failed: 500');
+    });
+
+    it('throws InterventionInvalidResponse when the response body is missing the history key', async () => {
+      const client = new InterventionClient({ baseUrl });
+
+      mockFetch.mockResolvedValue(mockResponse({ unexpected: 'shape' }));
+
+      await expect(client.getAccountHistory('user-1')).rejects.toThrow(InterventionInvalidResponse);
+    });
+
+    it('throws InterventionInvalidResponse when a history entry is missing a required field', async () => {
+      const client = new InterventionClient({ baseUrl });
+
+      // Missing required `interventionReason`
+      const invalidEntry = { sentAt: 1_696_869_003_456, componentId: 'TICF_CRI' };
+      mockFetch.mockResolvedValue(mockResponse({ history: [invalidEntry] }));
+
+      await expect(client.getAccountHistory('user-1')).rejects.toThrow(InterventionInvalidResponse);
+    });
+
+    it('throws InterventionInvalidResponse when a history entry has an invalid interventionName', async () => {
+      const client = new InterventionClient({ baseUrl });
+
+      const invalidEntry = makeHistoryObject({ interventionName: 'NOT_A_VALID_INTERVENTION' as InterventionName });
+      mockFetch.mockResolvedValue(mockResponse({ history: [invalidEntry] }));
+
+      await expect(client.getAccountHistory('user-1')).rejects.toThrow(InterventionInvalidResponse);
+    });
+
+    it('throws InterventionInvalidResponse when a history entry has an invalid interventionState', async () => {
+      const client = new InterventionClient({ baseUrl });
+
+      const invalidEntry = makeHistoryObject({ interventionState: 'NOT_A_VALID_STATE' as InterventionState });
+      mockFetch.mockResolvedValue(mockResponse({ history: [invalidEntry] }));
+
+      await expect(client.getAccountHistory('user-1')).rejects.toThrow(InterventionInvalidResponse);
+    });
+
+    it('logs the error when the response is not ok', async () => {
+      const logger = { error: vi.fn() };
+      const client = new InterventionClient({ baseUrl, logger });
+
+      mockFetch.mockResolvedValue(mockResponse({}, 503));
+
+      await expect(client.getAccountHistory('user-1')).rejects.toThrow('AIS request failed: 503');
+      expect(logger.error).toHaveBeenCalledWith('AIS request failed: 503 Error');
+    });
+
+    it('logs the error when the response body does not match the schema', async () => {
+      const logger = { error: vi.fn() };
+      const client = new InterventionClient({ baseUrl, logger });
+
+      mockFetch.mockResolvedValue(mockResponse({ unexpected: 'shape' }));
+
+      await expect(client.getAccountHistory('user-1')).rejects.toThrow(InterventionInvalidResponse);
+      expect(logger.error).toHaveBeenCalledWith(
+        'AIS Invalid Response',
+        expect.objectContaining({ cause: expect.anything() as ZodError<object> }),
+      );
+    });
+
+    it('strips trailing slash from baseUrl on history requests', async () => {
+      const clientWithSlash = new InterventionClient({ baseUrl: 'https://example.com/' });
+      mockFetch.mockResolvedValue(mockResponse({ history: [] }));
+
+      await clientWithSlash.getAccountHistory('user-1');
+
+      expect(mockFetch).toHaveBeenCalledWith('https://example.com/v2/ais/user-1/history', expect.anything());
     });
   });
 });

--- a/packages/ais-status-sdk/src/index.ts
+++ b/packages/ais-status-sdk/src/index.ts
@@ -1,8 +1,26 @@
-import { V2ResponseSchema, type V2Response } from '../../../src/data-types/api-schemas-v2';
-import type { AccountStatusResult, InterventionClientConfig, InterventionClientInterface } from './types';
-export type { AccountStatusResult, InterventionClientConfig, InterventionClientInterface, Intervention } from './types';
-export { InterventionName } from './types';
+import {
+  V2HistoryResponse,
+  V2HistoryResponseSchema,
+  V2ResponseSchema,
+  type V2Response,
+} from '../../../src/data-types/api-schemas-v2';
+import type {
+  AccountHistoryResult,
+  AccountStatusResult,
+  InterventionClientConfig,
+  InterventionClientInterface,
+} from './types';
+export type {
+  AccountStatusResult,
+  InterventionClientConfig,
+  InterventionClientInterface,
+  Intervention,
+  AccountHistoryResult,
+  HistoryObject,
+} from './types';
+export { InterventionName, InterventionState } from './types';
 import { InterventionInvalidResponse, InterventionMissingBaseUrl, InterventionRequestFailed } from './errors';
+import { ZodSafeParseError } from 'zod';
 export type { InterventionInvalidResponse, InterventionRequestFailed, InterventionMissingBaseUrl } from './errors';
 export { InterventionStub } from './stub';
 
@@ -17,8 +35,7 @@ export class InterventionClient implements InterventionClientInterface {
     this.headers = { 'Content-Type': 'application/json' };
   }
 
-  private async fetchAccountStatus(userId: string): Promise<V2Response> {
-    const url = `${this.baseUrl}/v2/ais/${encodeURIComponent(userId)}`;
+  protected async fetch(url: string): Promise<unknown> {
     const response = await fetch(url, { headers: this.headers });
 
     if (!response.ok) {
@@ -28,18 +45,46 @@ export class InterventionClient implements InterventionClientInterface {
 
     const responseBody: unknown = await response.json();
 
-    const parseResult = V2ResponseSchema.safeParse(responseBody);
+    return responseBody;
+  }
 
-    if (!parseResult.success) {
-      this.config.logger?.error('AIS Invalid Response', { cause: parseResult.error });
-      throw new InterventionInvalidResponse('AIS Invalid Response', { cause: parseResult.error });
-    }
+  protected handleInvalidResponse(parseResult: ZodSafeParseError<object>): never {
+    this.config.logger?.error('AIS Invalid Response', { cause: parseResult.error });
+    throw new InterventionInvalidResponse('AIS Invalid Response', { cause: parseResult.error });
+  }
+
+  protected async fetchAccountStatus(userId: string): Promise<V2Response> {
+    const url = `${this.baseUrl}/v2/ais/${encodeURIComponent(userId)}`;
+
+    const response = await this.fetch(url);
+
+    const parseResult = V2ResponseSchema.safeParse(response);
+
+    if (!parseResult.success) this.handleInvalidResponse(parseResult);
+
+    return parseResult.data;
+  }
+
+  protected async fetchAccountHistory(userId: string): Promise<V2HistoryResponse> {
+    const url = `${this.baseUrl}/v2/ais/${encodeURIComponent(userId)}/history`;
+
+    const response = await this.fetch(url);
+
+    const parseResult = V2HistoryResponseSchema.safeParse(response);
+
+    if (!parseResult.success) this.handleInvalidResponse(parseResult);
 
     return parseResult.data;
   }
 
   async getAccountStatus(userId: string): Promise<AccountStatusResult> {
     const result = await this.fetchAccountStatus(userId);
+
+    return result;
+  }
+
+  async getAccountHistory(userId: string): Promise<AccountHistoryResult> {
+    const result = await this.fetchAccountHistory(userId);
 
     return result;
   }

--- a/packages/ais-status-sdk/src/stub.ts
+++ b/packages/ais-status-sdk/src/stub.ts
@@ -1,9 +1,10 @@
 import { InterventionRequestFailed } from './errors';
-import { AccountStatusResult, InterventionClientInterface, InterventionName } from './types';
+import { AccountHistoryResult, AccountStatusResult, InterventionClientInterface, InterventionName } from './types';
 
 export interface InterventionStubConfig {
   result?: AccountStatusResult;
   interventionNames?: InterventionName[];
+  historyResult?: AccountHistoryResult;
 }
 
 export class InterventionStub implements InterventionClientInterface {
@@ -16,6 +17,12 @@ export class InterventionStub implements InterventionClientInterface {
       return Promise.resolve({
         interventions: this.config.interventionNames.map((name) => ({ name })),
       });
+
+    throw new InterventionRequestFailed();
+  }
+
+  getAccountHistory(): Promise<AccountHistoryResult> {
+    if (this.config?.historyResult) return Promise.resolve(this.config.historyResult);
 
     throw new InterventionRequestFailed();
   }

--- a/packages/ais-status-sdk/src/types.ts
+++ b/packages/ais-status-sdk/src/types.ts
@@ -5,12 +5,38 @@ export enum InterventionName {
   REPROVE_IDENTITY = 'REPROVE_IDENTITY',
 }
 
+export enum InterventionState {
+  ACTIVE = 'ACTIVE',
+  IGNORED = 'IGNORED',
+  SUPERSEDED = 'SUPERSEDED',
+  MITIGATED = 'MITIGATED',
+  REMOVED = 'REMOVED',
+}
+
 export interface Intervention {
   name: InterventionName | string;
 }
 
 export interface AccountStatusResult {
   interventions: Intervention[];
+}
+
+export interface HistoryObject {
+  sentAt: number;
+  componentId: string;
+  interventionName: InterventionName;
+  interventionState: InterventionState;
+  interventionCode?: string | undefined;
+  interventionReason: string;
+  originatingComponent?: string | undefined;
+  originatorReferenceId?: string | string[] | undefined;
+  requesterId?: string | undefined;
+  transactionId?: string | undefined;
+  messageEventId?: string | undefined;
+}
+
+export interface AccountHistoryResult {
+  history: HistoryObject[];
 }
 
 type LogAttributes = Record<string, unknown>;
@@ -28,4 +54,5 @@ export interface InterventionClientConfig {
 
 export interface InterventionClientInterface {
   getAccountStatus(userId: string): Promise<AccountStatusResult>;
+  getAccountHistory(userId: string): Promise<AccountHistoryResult>;
 }

--- a/src/commons/history-string-builder.ts
+++ b/src/commons/history-string-builder.ts
@@ -1,5 +1,5 @@
 import { TicfAccountIntervention } from '../contracts/intervention-events';
-import { HistoryStringParts, expectedHistoryStringLength } from '../data-types/constants';
+import { HistoryStringParts, expectedHistoryStringLength, isCode } from '../data-types/constants';
 import { HistoryObject } from '../data-types/interfaces';
 import { AccountStateEngine } from '../services/account-states/account-state-engine';
 
@@ -83,6 +83,9 @@ export class HistoryStringBuilder {
   private buildHistoryObject(array: string[]): HistoryObject {
     const timestamp = array[HistoryStringParts.EVENT_TIMESTAMP_MS];
     const code = array[HistoryStringParts.INTERVENTION_CODE];
+    if (code !== undefined && !isCode(code)) {
+      throw new Error(`code: ${code} is not found in current configuration`);
+    }
     const component = array[HistoryStringParts.COMPONENT_ID];
     const reason = array[HistoryStringParts.INTERVENTION_REASON];
     if (!timestamp || !code || !component || !reason)

--- a/src/data-types/api-schemas-v2.ts
+++ b/src/data-types/api-schemas-v2.ts
@@ -1,6 +1,7 @@
 /* istanbul ignore file */
 import z from 'zod';
 import { InterventionName } from './intervention-name';
+import { InterventionState } from './constants';
 
 const InterventionNameSchema = z
   .enum(InterventionName)
@@ -36,3 +37,54 @@ export const V2ResponseSchema = z
   });
 
 export type V2Response = z.infer<typeof V2ResponseSchema>;
+
+/* eslint-disable unicorn/max-nested-calls */
+const HistoryObjectSchema = z
+  .object({
+    sentAt: z.number().int().meta({
+      description: 'A timestamp (ms) when the Intervention was sent by Fraud Analyst/Risk Engine.',
+      example: 1696869003456,
+      format: 'int64',
+    }),
+    componentId: z.string().meta({ example: 'TICF_CRI' }),
+    interventionName: z.enum(InterventionName),
+    interventionState: z.enum(InterventionState),
+    interventionCode: z.string().optional().meta({ example: '01' }),
+    interventionReason: z.string().meta({ example: 'FRAUD_SUSPEND_ACCOUNT' }),
+    originatingComponent: z.string().optional().meta({ example: 'CMS' }),
+    originatorReferenceId: z
+      .union([z.string(), z.array(z.string())])
+      .optional()
+      .meta({ example: '12345' }),
+    requesterId: z.string().optional().meta({ example: '12345' }),
+    transactionId: z.string().optional(),
+    messageEventId: z.string().optional(),
+  })
+  .meta({
+    id: 'HistoryObject',
+    title: 'History Object Schema',
+    description: 'JSON object representing an intervention previously applied on the account',
+    readOnly: true,
+  });
+
+export type HistoryObject = z.infer<typeof HistoryObjectSchema>;
+
+const HistoryListSchema = z.array(HistoryObjectSchema).meta({
+  id: 'HistoryList',
+  title: 'History List',
+  description: 'History of interventions applied to an account',
+  readOnly: true,
+});
+
+export const V2HistoryResponseSchema = z
+  .object({
+    history: HistoryListSchema,
+  })
+  .meta({
+    id: 'AccountHistoryResponse',
+    title: 'Account History Schema',
+    description: "The intervention history of the User's OneLogin Account",
+    readOnly: true,
+  });
+
+export type V2HistoryResponse = z.infer<typeof V2HistoryResponseSchema>;

--- a/src/data-types/api-schemas-v2.ts
+++ b/src/data-types/api-schemas-v2.ts
@@ -59,6 +59,7 @@ const HistoryObjectSchema = z
     requesterId: z.string().optional().meta({ example: '12345' }),
     transactionId: z.string().optional(),
     messageEventId: z.string().optional(),
+    tagId: z.string().optional(),
   })
   .meta({
     id: 'HistoryObject',

--- a/src/data-types/interfaces.ts
+++ b/src/data-types/interfaces.ts
@@ -39,10 +39,7 @@ export type TxMAEgressInterventionEventName =
   | 'AIS_EVENT_IGNORED_ACCOUNT_DELETED';
 
 export type TxMAEgressEvent =
-  | AIS_EVENT_TRANSITION_APPLIED
-  | AIS_EVENT_TRANSITION_IGNORED
-  | AIS_EVENT_IGNORED_STALE
-  | AUTH_DELETE_ACCOUNT;
+  AIS_EVENT_TRANSITION_APPLIED | AIS_EVENT_TRANSITION_IGNORED | AIS_EVENT_IGNORED_STALE | AUTH_DELETE_ACCOUNT;
 
 export interface TxmaUser {
   user_id: string;
@@ -99,7 +96,7 @@ export interface History {
 export interface HistoryObject {
   sentAt: string;
   component: string;
-  code: string;
+  code: Codes;
   intervention: string;
   reason: string;
   originatingComponent: string | undefined;

--- a/src/frontend/app.ts
+++ b/src/frontend/app.ts
@@ -18,6 +18,18 @@ const stagePrefix = process.env['STAGE_PREFIX'] ?? '';
 
 const statusApiUrl = process.env['STATUS_API_URL'];
 
+// Format an ISO date string or Unix timestamp (ms) into a human-readable UK date/time, e.g. "10 October 2023 at 20:22:02 UTC"
+function formatDate(value: string | number): string {
+  const date = new Date(value);
+
+  return (
+    date.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric', timeZone: 'UTC' }) +
+    ' at ' +
+    date.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', second: '2-digit', timeZone: 'UTC' }) +
+    ' UTC'
+  );
+}
+
 export function init(
   interventionClient: InterventionClientInterface = new InterventionClient({
     baseUrl: statusApiUrl,
@@ -67,8 +79,18 @@ export function init(
     if (!userId) return reply.code(400).send();
 
     const accountStatus = await interventionClient.getAccountStatus(userId);
+    const accountHistory = await interventionClient.getAccountHistory(userId);
 
-    return reply.view('user-details.njk', { stagePrefix, assetPath, accountStatus, userId });
+    return reply.view('user-details.njk', {
+      stagePrefix,
+      assetPath,
+      accountStatus,
+      userId,
+      accountHistory: {
+        ...accountHistory,
+        history: accountHistory.history.map((line) => ({ ...line, sentAt: formatDate(line.sentAt) })),
+      },
+    });
   });
 
   return server;

--- a/src/frontend/local.ts
+++ b/src/frontend/local.ts
@@ -3,10 +3,25 @@
 import { InterventionName, InterventionStub } from '@govuk-one-login/ais-status-sdk';
 import { FeatureFlagsStub } from '../services/feature-flags';
 import { init } from './app';
+import { InterventionState } from '../../packages/ais-status-sdk/src/types';
 
 init(
   new InterventionStub({
     interventionNames: [InterventionName.RESET_PASSWORD],
+    historyResult: {
+      history: [
+        {
+          sentAt: 1784021279000,
+          componentId: 'TEST',
+          interventionName: InterventionName.TEMPORARY_SUSPENSION,
+          interventionState: InterventionState.ACTIVE,
+          interventionReason: 'Reason',
+          interventionCode: '01',
+          originatingComponent: 'TICF',
+          requesterId: 'interventions@digital.cabinet-office.gov.uk',
+        },
+      ],
+    },
   }),
   new FeatureFlagsStub({ aisFrontend: true }),
 ).listen({ port: 3000 }, (error) => {

--- a/src/frontend/tests/app.test.ts
+++ b/src/frontend/tests/app.test.ts
@@ -1,5 +1,5 @@
 import { init } from '../app';
-import { InterventionStub, InterventionName } from '@govuk-one-login/ais-status-sdk';
+import { InterventionStub, InterventionName, InterventionState } from '@govuk-one-login/ais-status-sdk';
 
 describe('frontend app', () => {
   it('returns 200 for GET /', async () => {
@@ -62,7 +62,33 @@ describe('frontend app', () => {
 
   describe('GET /user/:userId', () => {
     it('returns 200 and renders the details page when user is found', async () => {
-      const server = init(new InterventionStub({ result: { interventions: [] } }));
+      const server = init(new InterventionStub({ result: { interventions: [] }, historyResult: { history: [] } }));
+      const response = await server.inject({ method: 'GET', url: '/user/test-user-id' });
+      expect(response.statusCode).toBe(200);
+      expect(response.headers['content-type']).toMatch(/html/);
+      expect(response.body).toContain('Account Status');
+    });
+
+    it('renders the history when user is found', async () => {
+      const server = init(
+        new InterventionStub({
+          result: { interventions: [] },
+          historyResult: {
+            history: [
+              {
+                sentAt: 1784021279000,
+                componentId: 'TEST',
+                interventionName: InterventionName.TEMPORARY_SUSPENSION,
+                interventionState: InterventionState.ACTIVE,
+                interventionReason: 'Reason',
+                interventionCode: '01',
+                originatingComponent: 'TICF',
+                requesterId: 'interventions@digital.cabinet-office.gov.uk',
+              },
+            ],
+          },
+        }),
+      );
       const response = await server.inject({ method: 'GET', url: '/user/test-user-id' });
       expect(response.statusCode).toBe(200);
       expect(response.headers['content-type']).toMatch(/html/);
@@ -70,14 +96,19 @@ describe('frontend app', () => {
     });
 
     it('displays active interventions when the account has them', async () => {
-      const server = init(new InterventionStub({ interventionNames: [InterventionName.PERMANENT_SUSPENSION] }));
+      const server = init(
+        new InterventionStub({
+          interventionNames: [InterventionName.PERMANENT_SUSPENSION],
+          historyResult: { history: [] },
+        }),
+      );
       const response = await server.inject({ method: 'GET', url: '/user/test-user-id' });
       expect(response.statusCode).toBe(200);
       expect(response.body).toContain('PERMANENT_SUSPENSION');
     });
 
     it('displays a no interventions message when the account exists but has no interventions', async () => {
-      const server = init(new InterventionStub({ result: { interventions: [] } }));
+      const server = init(new InterventionStub({ result: { interventions: [] }, historyResult: { history: [] } }));
       const response = await server.inject({ method: 'GET', url: '/user/test-user-id' });
       expect(response.statusCode).toBe(200);
       expect(response.body).toContain('There are no active interventions on this account.');
@@ -93,6 +124,7 @@ describe('frontend app', () => {
           queriedUserId = id;
           return Promise.resolve({ interventions: [] });
         },
+        getAccountHistory: () => Promise.reject(new Error('Blah')),
       };
 
       const server = init(mockClient);

--- a/src/frontend/views/user-details.njk
+++ b/src/frontend/views/user-details.njk
@@ -25,4 +25,50 @@
   {% else %}
     <p class="govuk-body">No account found for this identifier.</p>
   {% endif %}
+  <h2 class="govuk-heading-m">History</h2>
+  {% if accountHistory and accountHistory.history and accountHistory.history.length %}
+    {% for item in accountHistory.history %}
+      {% if item.interventionState == "ACTIVE" %}
+        {% set stateColour = "red" %}
+      {% elif item.interventionState == "MITIGATED" %}
+        {% set stateColour = "green" %}
+      {% elif item.interventionState == "REMOVED" %}
+        {% set stateColour = "grey" %}
+      {% elif item.interventionState == "SUPERSEDED" %}
+        {% set stateColour = "orange" %}
+      {% elif item.interventionState == "IGNORED" %}
+        {% set stateColour = "yellow" %}
+      {% else %}
+        {% set stateColour = "blue" %}
+      {% endif %}
+      {% set historyRows = [
+        { key: { text: "Component" },  value: { text: item.componentId } },
+        { key: { text: "Reason" },     value: { text: item.interventionReason } }
+      ] %}
+      {% if item.interventionCode %}
+        {% set historyRows = historyRows.concat([{ key: { text: "Code" }, value: { text: item.interventionCode } }]) %}
+      {% endif %}
+      {% if item.originatingComponent %}
+        {% set historyRows = historyRows.concat([{ key: { text: "Originating Component" }, value: { text: item.originatingComponent } }]) %}
+      {% endif %}
+      {% if item.originatorReferenceId %}
+        {% set historyRows = historyRows.concat([{ key: { text: "Originator Reference ID" }, value: { text: item.originatorReferenceId } }]) %}
+      {% endif %}
+      {% if item.requesterId %}
+        {% set historyRows = historyRows.concat([{ key: { text: "Requester ID" }, value: { text: item.requesterId } }]) %}
+      {% endif %}
+      <div class="govuk-inset-text govuk-!-margin-bottom-5">
+        <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
+          {{ item.interventionName }}
+          <strong class="govuk-tag govuk-tag--{{ stateColour }} govuk-!-margin-left-2">{{ item.interventionState }}</strong>
+        </h3>
+        <p class="govuk-body-xs govuk-hint govuk-!-margin-bottom-4">Sent:
+          <strong>{{ item.sentAt }}</strong>
+        </p>
+        {{ govukSummaryList({ classes: "govuk-!-margin-bottom-0 govuk-!-font-size-16", rows: historyRows }) }}
+      </div>
+    {% endfor %}
+  {% else %}
+    <p class="govuk-body-s">No history available for this account.</p>
+  {% endif %}
 {% endblock %}

--- a/src/handlers/status-retriever-handler.ts
+++ b/src/handlers/status-retriever-handler.ts
@@ -13,10 +13,7 @@ const interventionEventsService = getPersistentInterventionEventsService();
  * @param context - This object provides methods and properties that provide information about the invocation, function, and execution environment.
  * @returns - The status of the account when matched with the User ID. Returns a default object if unable to do so. Also returns the relevant status code.
  */
-export async function handle(
-  event: APIGatewayEvent,
-  context: Context
-): Promise<APIGatewayProxyResult> {
+export async function handle(event: APIGatewayEvent, context: Context): Promise<APIGatewayProxyResult> {
   logger.addContext(context);
   return retrieveStatus(event, accountStatusService, interventionEventsService);
 }

--- a/src/handlers/status-retriever.ts
+++ b/src/handlers/status-retriever.ts
@@ -10,6 +10,7 @@ import { InterventionEventsService } from '../tables/intervention-events';
 import { UserIdParameterSchema, V1QuerySchema } from '../data-types/api-parameters';
 import { AccountStatus, AccountStatusService } from '../tables/account-status';
 import { V1Response } from '../data-types/api-schemas-v1';
+import { HistoryService } from '../services/history-service';
 
 export async function retrieveStatus(
   event: APIGatewayEvent,
@@ -33,6 +34,9 @@ export async function retrieveStatus(
   try {
     if (event.resource === '/v2/ais/{userId}')
       return await v2StatusApiHandler(userId, accountStatusService, interventionEventsService);
+
+    if (event.resource === '/v2/ais/{userId}/history')
+      return await v2HistoryApiHandler(userId, accountStatusService, interventionEventsService);
 
     const { history: historyQuery } = V1QuerySchema.parse(event.queryStringParameters ?? {});
 
@@ -112,6 +116,21 @@ async function v2StatusApiHandler(
         name,
       })),
     }),
+  };
+}
+
+async function v2HistoryApiHandler(
+  userId: string,
+  accountStatusService: AccountStatusService,
+  interventionEventsService: InterventionEventsService,
+): Promise<APIGatewayProxyResult> {
+  const historyService = new HistoryService(accountStatusService, interventionEventsService);
+
+  const history = await historyService.fetchHistory(userId);
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify(history),
   };
 }
 

--- a/src/scripts/generate-main-spec.ts
+++ b/src/scripts/generate-main-spec.ts
@@ -6,7 +6,7 @@ import { ResponseObject } from 'openapi3-ts/oas30';
 import { stringify } from 'yaml';
 import { z } from 'zod';
 import { V1ResponseSchema } from '../data-types/api-schemas-v1';
-import { V2ResponseSchema } from '../data-types/api-schemas-v2';
+import { V2ResponseSchema, V2HistoryResponseSchema } from '../data-types/api-schemas-v2';
 import { UserIdParameterSchema, V1QuerySchema } from '../data-types/api-parameters';
 
 const registry = new OpenAPIRegistry();
@@ -68,6 +68,7 @@ const errorResponses = {
 
 registry.register('InterventionStatusResponse', V1ResponseSchema);
 registry.register('AccountStatusResponse', V2ResponseSchema);
+registry.register('AccountHistoryResponse', V2HistoryResponseSchema);
 
 registry.registerPath({
   method: 'get',
@@ -111,6 +112,33 @@ registry.registerPath({
     200: {
       description: 'Ok',
       content: { 'application/json': { schema: { $ref: '#/components/schemas/AccountStatusResponse' } } },
+    },
+    ...errorResponses,
+  }),
+  'x-amazon-apigateway-integration': {
+    httpMethod: 'POST',
+    type: 'aws_proxy',
+    uri: {
+      'Fn::Sub':
+        'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${StatusRetrieverFunction.Arn}:live/invocations',
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/v2/ais/{userId}/history',
+  operationId: 'aisV2History',
+  tags: ['Status'],
+  summary: 'Get User Account Intervention History',
+  description: "Returns the full intervention history for a user's account",
+  request: {
+    params: RegisteredUserIdParameterSchema,
+  },
+  responses: hoistResponses({
+    200: {
+      description: 'Ok',
+      content: { 'application/json': { schema: { $ref: '#/components/schemas/AccountHistoryResponse' } } },
     },
     ...errorResponses,
   }),

--- a/src/services/history-service.ts
+++ b/src/services/history-service.ts
@@ -27,7 +27,7 @@ export class HistoryService {
     };
   }
 
-  protected async fetchAccountStatus(accountId: string): Promise<HistoryObject[]> {
+  private async fetchAccountStatus(accountId: string): Promise<HistoryObject[]> {
     const response = await this.accountStatusService.getAccountStateInformation(accountId);
     if (!response) {
       logger.info('Query matched no records in DynamoDB.');
@@ -38,7 +38,7 @@ export class HistoryService {
     return this.constructHistoryObject(response.history);
   }
 
-  protected constructHistoryObject(input: string[]): HistoryObject[] {
+  private constructHistoryObject(input: string[]): HistoryObject[] {
     const historyStringBuilder = new HistoryStringBuilder();
 
     const historyLines = input
@@ -58,14 +58,14 @@ export class HistoryService {
     );
   }
 
-  protected mapHistoryObjectToInterventionEvents(input: HistoryLine): HistoryObject[] {
+  private mapHistoryObjectToInterventionEvents(input: HistoryLine): HistoryObject[] {
     if (!isCode(input.code)) throw new Error('Code not code');
 
     const eventEdge = transitionConfig.edges[input.code];
 
     const stateChanges = config[eventEdge.name];
 
-    const transactionId = randomUUID();
+    const tagId = randomUUID();
 
     return stateChanges.map((stateChange) => ({
       interventionName: stateChange.interventionName,
@@ -77,15 +77,17 @@ export class HistoryService {
       originatingComponent: input.originatingComponent,
       requesterId: input.requesterId,
       originatorReferenceId: input.originatorReferenceId,
-      transactionId,
+      tagId,
     }));
   }
 
-  protected async fetchInterventionEvents(accountId: string) {
-    return await this.interventionEventsService.fetchEventsForAccount(accountId);
+  private async fetchInterventionEvents(accountId: string) {
+    const interventionEvents = await this.interventionEventsService.fetchEventsForAccount(accountId);
+
+    return interventionEvents.map((event) => ({ ...event, tagId: event.transactionId }));
   }
 
-  protected deduplicateEvents(
+  private deduplicateEvents(
     accountStatusEvents: HistoryObject[],
     interventionEvents: HistoryObject[],
   ): HistoryObject[] {
@@ -96,7 +98,7 @@ export class HistoryService {
             (interventionEvent) =>
               interventionEvent.interventionName === event.interventionName &&
               interventionEvent.interventionState === event.interventionState &&
-              Math.abs(interventionEvent.sentAt - event.sentAt) < 10,
+              interventionEvent.sentAt === event.sentAt,
           ),
         )
         .map((event) => event.transactionId),

--- a/src/services/history-service.ts
+++ b/src/services/history-service.ts
@@ -15,6 +15,10 @@ export class HistoryService {
   constructor(
     readonly accountStatusService: AccountStatusService,
     readonly interventionEventsService: InterventionEventsService,
+    readonly deduplicate: (
+      accountStatusHistory: HistoryObject[],
+      interventionEvents: HistoryObject[],
+    ) => HistoryObject[] = deduplicateEvents,
   ) {}
 
   async fetchHistory(accountId: string): Promise<V2HistoryResponse> {
@@ -23,7 +27,7 @@ export class HistoryService {
     const interventionEvents = await this.fetchInterventionEvents(accountId);
 
     return {
-      history: this.deduplicateEvents(accountStatusHistory, interventionEvents),
+      history: this.deduplicate(accountStatusHistory, interventionEvents),
     };
   }
 
@@ -86,28 +90,33 @@ export class HistoryService {
 
     return interventionEvents.map((event) => ({ ...event, tagId: event.transactionId }));
   }
+}
 
-  private deduplicateEvents(
-    accountStatusEvents: HistoryObject[],
-    interventionEvents: HistoryObject[],
-  ): HistoryObject[] {
-    const transactionIdsToRemove = new Set(
-      accountStatusEvents
-        .filter((event) =>
-          interventionEvents.some(
-            (interventionEvent) =>
-              interventionEvent.interventionName === event.interventionName &&
-              interventionEvent.interventionState === event.interventionState &&
-              interventionEvent.sentAt === event.sentAt,
-          ),
-        )
-        .map((event) => event.transactionId),
-    );
+// Deduplicate data from v1 and v2 history
+export function deduplicateEvents<T extends HistoryIdentifier>(accountStatusEvents: T[], interventionEvents: T[]): T[] {
+  const transactionIdsToRemove = new Set(
+    accountStatusEvents
+      .filter((event) =>
+        interventionEvents.some(
+          (interventionEvent) =>
+            interventionEvent.interventionName === event.interventionName &&
+            interventionEvent.interventionState === event.interventionState &&
+            interventionEvent.sentAt === event.sentAt,
+        ),
+      )
+      .map((event) => event.transactionId),
+  );
 
-    const remainingAccountStatusEvents = accountStatusEvents.filter(
-      (event) => !transactionIdsToRemove.has(event.transactionId),
-    );
+  const remainingAccountStatusEvents = accountStatusEvents.filter(
+    (event) => !transactionIdsToRemove.has(event.transactionId),
+  );
 
-    return [...remainingAccountStatusEvents, ...interventionEvents];
-  }
+  return [...remainingAccountStatusEvents, ...interventionEvents];
+}
+
+export interface HistoryIdentifier {
+  interventionName: string;
+  interventionState: string;
+  sentAt: number;
+  transactionId?: string | undefined;
 }

--- a/src/services/history-service.ts
+++ b/src/services/history-service.ts
@@ -3,7 +3,7 @@ import { HistoryStringBuilder } from '../commons/history-string-builder';
 import logger from '../commons/logger';
 import { addMetric } from '../commons/metrics';
 import { HistoryObject, V2HistoryResponse } from '../data-types/api-schemas-v2';
-import { isCode, MetricNames } from '../data-types/constants';
+import { MetricNames } from '../data-types/constants';
 import { HistoryObject as HistoryLine } from '../data-types/interfaces';
 import { AccountStatusService } from '../tables/account-status';
 import { InterventionEventsService } from '../tables/intervention-events';
@@ -63,8 +63,6 @@ export class HistoryService {
   }
 
   private mapHistoryObjectToInterventionEvents(input: HistoryLine): HistoryObject[] {
-    if (!isCode(input.code)) throw new Error('Code not code');
-
     const eventEdge = transitionConfig.edges[input.code];
 
     const stateChanges = config[eventEdge.name];

--- a/src/services/history-service.ts
+++ b/src/services/history-service.ts
@@ -1,0 +1,111 @@
+import { randomUUID } from 'node:crypto';
+import { HistoryStringBuilder } from '../commons/history-string-builder';
+import logger from '../commons/logger';
+import { addMetric } from '../commons/metrics';
+import { HistoryObject, V2HistoryResponse } from '../data-types/api-schemas-v2';
+import { isCode, MetricNames } from '../data-types/constants';
+import { HistoryObject as HistoryLine } from '../data-types/interfaces';
+import { AccountStatusService } from '../tables/account-status';
+import { InterventionEventsService } from '../tables/intervention-events';
+import notEmpty from '../utils/not-empty';
+import { transitionConfig } from './account-states/config';
+import { config } from './persist-intervention-events';
+
+export class HistoryService {
+  constructor(
+    readonly accountStatusService: AccountStatusService,
+    readonly interventionEventsService: InterventionEventsService,
+  ) {}
+
+  async fetchHistory(accountId: string): Promise<V2HistoryResponse> {
+    const accountStatusHistory = await this.fetchAccountStatus(accountId);
+
+    const interventionEvents = await this.fetchInterventionEvents(accountId);
+
+    return {
+      history: this.deduplicateEvents(accountStatusHistory, interventionEvents),
+    };
+  }
+
+  protected async fetchAccountStatus(accountId: string): Promise<HistoryObject[]> {
+    const response = await this.accountStatusService.getAccountStateInformation(accountId);
+    if (!response) {
+      logger.info('Query matched no records in DynamoDB.');
+      addMetric(MetricNames.ACCOUNT_NOT_FOUND);
+      return [];
+    }
+
+    return this.constructHistoryObject(response.history);
+  }
+
+  protected constructHistoryObject(input: string[]): HistoryObject[] {
+    const historyStringBuilder = new HistoryStringBuilder();
+
+    const historyLines = input
+      .map((historyString) => {
+        try {
+          return historyStringBuilder.getHistoryObject(historyString);
+        } catch (error) {
+          logger.error('History string is malformed.', { error });
+          addMetric(MetricNames.INVALID_HISTORY_STRING);
+        }
+      })
+      .filter(notEmpty);
+
+    return historyLines.reduce<HistoryObject[]>(
+      (result, historyLine) => [...result, ...this.mapHistoryObjectToInterventionEvents(historyLine)],
+      [],
+    );
+  }
+
+  protected mapHistoryObjectToInterventionEvents(input: HistoryLine): HistoryObject[] {
+    if (!isCode(input.code)) throw new Error('Code not code');
+
+    const eventEdge = transitionConfig.edges[input.code];
+
+    const stateChanges = config[eventEdge.name];
+
+    const transactionId = randomUUID();
+
+    return stateChanges.map((stateChange) => ({
+      interventionName: stateChange.interventionName,
+      interventionState: stateChange.interventionState,
+      interventionCode: input.code,
+      interventionReason: input.reason,
+      sentAt: Number(new Date(input.sentAt)),
+      componentId: input.component,
+      originatingComponent: input.originatingComponent,
+      requesterId: input.requesterId,
+      originatorReferenceId: input.originatorReferenceId,
+      transactionId,
+    }));
+  }
+
+  protected async fetchInterventionEvents(accountId: string) {
+    return await this.interventionEventsService.fetchEventsForAccount(accountId);
+  }
+
+  protected deduplicateEvents(
+    accountStatusEvents: HistoryObject[],
+    interventionEvents: HistoryObject[],
+  ): HistoryObject[] {
+    const transactionIdsToRemove = new Set(
+      accountStatusEvents
+        .filter((event) =>
+          interventionEvents.some(
+            (interventionEvent) =>
+              interventionEvent.interventionName === event.interventionName &&
+              interventionEvent.interventionState === event.interventionState &&
+              Math.abs(interventionEvent.sentAt - event.sentAt) < 10,
+          ),
+        )
+        .map((event) => event.transactionId),
+    );
+
+    const remainingAccountStatusEvents = accountStatusEvents.filter(
+      (event) => !transactionIdsToRemove.has(event.transactionId),
+    );
+
+    return [...remainingAccountStatusEvents, ...interventionEvents];
+  }
+}

--- a/src/services/persist-intervention-events.ts
+++ b/src/services/persist-intervention-events.ts
@@ -160,7 +160,7 @@ export async function setTtlOnInactiveEvents(
 /**
  * Dictionary to turn EventsEnum into list of interventions to apply or remove
  */
-const config: Record<EventsEnum, InterventionUpdate[]> = {
+export const config: Record<EventsEnum, InterventionUpdate[]> = {
   [EventsEnum.FRAUD_SUSPEND_ACCOUNT]: [
     { interventionName: InterventionName.TEMPORARY_SUSPENSION, interventionState: InterventionState.ACTIVE },
     { interventionName: InterventionName.RESET_PASSWORD, interventionState: InterventionState.REMOVED },

--- a/src/services/test/history-service.test.ts
+++ b/src/services/test/history-service.test.ts
@@ -201,7 +201,7 @@ describe('History Service', () => {
     });
   });
 
-  it.only('deduplicates events', async () => {
+  it('deduplicates events', async () => {
     const service = new HistoryService(
       new InMemoryAccountStatusService({
         status: {
@@ -249,5 +249,33 @@ describe('History Service', () => {
         },
       ],
     });
+  });
+
+  it('handles invalid history string', async () => {
+    const service = new HistoryService(
+      new InMemoryAccountStatusService({
+        status: {
+          pk: 'user1234',
+          sentAt: 123456,
+          appliedAt: 123456789,
+          isAccountDeleted: false,
+          history: ['invalid'],
+          intervention: '01',
+          blocked: false,
+          suspended: true,
+          resetPassword: false,
+          reproveIdentity: false,
+        },
+      }),
+      new InMemoryInterventionEventsService([]),
+    );
+
+    const result = await service.fetchHistory('user1234');
+
+    expect(result).toEqual({
+      history: [],
+    });
+
+    expect(result.history[0]?.transactionId).toBe(result.history[1]?.transactionId);
   });
 });

--- a/src/services/test/history-service.test.ts
+++ b/src/services/test/history-service.test.ts
@@ -269,6 +269,34 @@ describe('History Service', () => {
       expect(() => service.callMapHistoryObjectToInterventionEvents(invalidHistoryObject)).toThrow('Code not code');
     });
   });
+
+  it('handles invalid history string', async () => {
+    const service = new HistoryService(
+      new InMemoryAccountStatusService({
+        status: {
+          pk: 'user1234',
+          sentAt: 123456,
+          appliedAt: 123456789,
+          isAccountDeleted: false,
+          history: ['invalid'],
+          intervention: '01',
+          blocked: false,
+          suspended: true,
+          resetPassword: false,
+          reproveIdentity: false,
+        },
+      }),
+      new InMemoryInterventionEventsService([]),
+    );
+
+    const result = await service.fetchHistory('user1234');
+
+    expect(result).toEqual({
+      history: [],
+    });
+
+    expect(result.history[0]?.transactionId).toBe(result.history[1]?.transactionId);
+  });
 });
 
 describe('deduplicateEvents', () => {

--- a/src/services/test/history-service.test.ts
+++ b/src/services/test/history-service.test.ts
@@ -216,7 +216,7 @@ describe('History Service', () => {
     });
   });
 
-  it('handles invalid history string', async () => {
+  it('handles invalid history string with mark duplicated', async () => {
     const service = new HistoryService(
       new InMemoryAccountStatusService({
         status: {

--- a/src/services/test/history-service.test.ts
+++ b/src/services/test/history-service.test.ts
@@ -1,0 +1,253 @@
+import { InterventionState } from '../../data-types/constants';
+import { InterventionName } from '../../data-types/intervention-name';
+import { InMemoryAccountStatusService } from '../../tables/account-status';
+import { InMemoryInterventionEventsService } from '../../tables/intervention-events';
+import { HistoryService } from '../history-service';
+
+describe('History Service', () => {
+  it('returns an empty array for no events', async () => {
+    const service = new HistoryService(new InMemoryAccountStatusService(), new InMemoryInterventionEventsService([]));
+
+    const result = await service.fetchHistory('user1234');
+
+    expect(result).toEqual({ history: [] });
+  });
+
+  it('returns expected result for a single account status history', async () => {
+    const service = new HistoryService(
+      new InMemoryAccountStatusService({
+        status: {
+          pk: 'user1234',
+          sentAt: 123456,
+          appliedAt: 123456789,
+          isAccountDeleted: false,
+          history: ['123456|TCIF|01|Reason1|TICF|123|abc'],
+          intervention: '01',
+          blocked: false,
+          suspended: true,
+          resetPassword: false,
+          reproveIdentity: false,
+        },
+      }),
+      new InMemoryInterventionEventsService([]),
+    );
+
+    const result = await service.fetchHistory('user1234');
+
+    expect(result).toEqual({
+      history: [
+        {
+          componentId: 'TCIF',
+          interventionCode: '01',
+          interventionName: 'TEMPORARY_SUSPENSION',
+          interventionReason: 'Reason1',
+          interventionState: 'ACTIVE',
+          originatingComponent: 'TICF',
+          originatorReferenceId: '123',
+          requesterId: 'abc',
+          sentAt: 123456,
+          transactionId: expect.any(String) as string,
+        },
+        {
+          componentId: 'TCIF',
+          interventionCode: '01',
+          interventionName: 'RESET_PASSWORD',
+          interventionReason: 'Reason1',
+          interventionState: 'REMOVED',
+          originatingComponent: 'TICF',
+          originatorReferenceId: '123',
+          requesterId: 'abc',
+          sentAt: 123456,
+          transactionId: expect.any(String) as string,
+        },
+        {
+          componentId: 'TCIF',
+          interventionCode: '01',
+          interventionName: 'REPROVE_IDENTITY',
+          interventionReason: 'Reason1',
+          interventionState: 'REMOVED',
+          originatingComponent: 'TICF',
+          originatorReferenceId: '123',
+          requesterId: 'abc',
+          sentAt: 123456,
+          transactionId: expect.any(String) as string,
+        },
+      ],
+    });
+
+    expect(result.history[0]?.transactionId).toBe(result.history[1]?.transactionId);
+  });
+
+  it('returns expected result for a single intervention event', async () => {
+    const service = new HistoryService(
+      new InMemoryAccountStatusService(),
+      new InMemoryInterventionEventsService([
+        {
+          eventId: '123456789',
+          accountId: 'user1234',
+          createdAt: 123456,
+          interventionState: InterventionState.ACTIVE,
+          interventionName: InterventionName.TEMPORARY_SUSPENSION,
+          interventionReason: 'Reason2',
+          sentAt: 12345,
+          componentId: 'TICF',
+          transactionId: 'abc1234',
+        },
+      ]),
+    );
+
+    const result = await service.fetchHistory('user1234');
+
+    expect(result).toEqual({
+      history: [
+        {
+          accountId: 'user1234',
+          componentId: 'TICF',
+          createdAt: 123456,
+          eventId: '123456789',
+          interventionName: 'TEMPORARY_SUSPENSION',
+          interventionReason: 'Reason2',
+          interventionState: 'ACTIVE',
+          sentAt: 12345,
+          transactionId: 'abc1234',
+        },
+      ],
+    });
+  });
+
+  it('returns expected result for a combination of account status history and intervention events with no overlap', async () => {
+    const service = new HistoryService(
+      new InMemoryAccountStatusService({
+        status: {
+          pk: 'user1234',
+          sentAt: 123456,
+          appliedAt: 123456789,
+          isAccountDeleted: false,
+          history: ['123456|TCIF|01|Reason1|TICF|123|abc'],
+          intervention: '01',
+          blocked: false,
+          suspended: true,
+          resetPassword: false,
+          reproveIdentity: false,
+        },
+      }),
+      new InMemoryInterventionEventsService([
+        {
+          eventId: '123456789',
+          accountId: 'user1234',
+          createdAt: 123456,
+          interventionState: InterventionState.ACTIVE,
+          interventionName: InterventionName.TEMPORARY_SUSPENSION,
+          interventionReason: 'Reason2',
+          sentAt: 12345,
+          componentId: 'TICF',
+          transactionId: 'abc1234',
+        },
+      ]),
+    );
+
+    const result = await service.fetchHistory('user1234');
+
+    expect(result).toEqual({
+      history: [
+        {
+          componentId: 'TCIF',
+          interventionCode: '01',
+          interventionName: 'TEMPORARY_SUSPENSION',
+          interventionReason: 'Reason1',
+          interventionState: 'ACTIVE',
+          originatingComponent: 'TICF',
+          originatorReferenceId: '123',
+          requesterId: 'abc',
+          sentAt: 123456,
+          transactionId: expect.any(String) as string,
+        },
+        {
+          componentId: 'TCIF',
+          interventionCode: '01',
+          interventionName: 'RESET_PASSWORD',
+          interventionReason: 'Reason1',
+          interventionState: 'REMOVED',
+          originatingComponent: 'TICF',
+          originatorReferenceId: '123',
+          requesterId: 'abc',
+          sentAt: 123456,
+          transactionId: expect.any(String) as string,
+        },
+        {
+          componentId: 'TCIF',
+          interventionCode: '01',
+          interventionName: 'REPROVE_IDENTITY',
+          interventionReason: 'Reason1',
+          interventionState: 'REMOVED',
+          originatingComponent: 'TICF',
+          originatorReferenceId: '123',
+          requesterId: 'abc',
+          sentAt: 123456,
+          transactionId: expect.any(String) as string,
+        },
+        {
+          accountId: 'user1234',
+          componentId: 'TICF',
+          createdAt: 123456,
+          eventId: '123456789',
+          interventionName: 'TEMPORARY_SUSPENSION',
+          interventionReason: 'Reason2',
+          interventionState: 'ACTIVE',
+          sentAt: 12345,
+          transactionId: 'abc1234',
+        },
+      ],
+    });
+  });
+
+  it.only('deduplicates events', async () => {
+    const service = new HistoryService(
+      new InMemoryAccountStatusService({
+        status: {
+          pk: 'user1234',
+          sentAt: 12345,
+          appliedAt: 123456789,
+          isAccountDeleted: false,
+          history: ['12346|TCIF|01|Reason1|TICF|123|abc'],
+          intervention: '01',
+          blocked: false,
+          suspended: true,
+          resetPassword: false,
+          reproveIdentity: false,
+        },
+      }),
+      new InMemoryInterventionEventsService([
+        {
+          eventId: '123456789',
+          accountId: 'user1234',
+          createdAt: 1234567,
+          interventionState: InterventionState.ACTIVE,
+          interventionName: InterventionName.TEMPORARY_SUSPENSION,
+          interventionReason: 'Reason2',
+          sentAt: 12345,
+          componentId: 'TICF',
+          transactionId: 'abc1234',
+        },
+      ]),
+    );
+
+    const result = await service.fetchHistory('user1234');
+
+    expect(result).toEqual({
+      history: [
+        {
+          accountId: 'user1234',
+          componentId: 'TICF',
+          createdAt: 1234567,
+          eventId: '123456789',
+          interventionName: 'TEMPORARY_SUSPENSION',
+          interventionReason: 'Reason2',
+          interventionState: 'ACTIVE',
+          sentAt: 12345,
+          transactionId: 'abc1234',
+        },
+      ],
+    });
+  });
+});

--- a/src/services/test/history-service.test.ts
+++ b/src/services/test/history-service.test.ts
@@ -46,7 +46,7 @@ describe('History Service', () => {
           originatorReferenceId: '123',
           requesterId: 'abc',
           sentAt: 123456,
-          transactionId: expect.any(String) as string,
+          tagId: expect.any(String) as string,
         },
         {
           componentId: 'TCIF',
@@ -58,7 +58,7 @@ describe('History Service', () => {
           originatorReferenceId: '123',
           requesterId: 'abc',
           sentAt: 123456,
-          transactionId: expect.any(String) as string,
+          tagId: expect.any(String) as string,
         },
         {
           componentId: 'TCIF',
@@ -70,7 +70,7 @@ describe('History Service', () => {
           originatorReferenceId: '123',
           requesterId: 'abc',
           sentAt: 123456,
-          transactionId: expect.any(String) as string,
+          tagId: expect.any(String) as string,
         },
       ],
     });
@@ -110,6 +110,7 @@ describe('History Service', () => {
           interventionState: 'ACTIVE',
           sentAt: 12345,
           transactionId: 'abc1234',
+          tagId: 'abc1234',
         },
       ],
     });
@@ -160,7 +161,7 @@ describe('History Service', () => {
           originatorReferenceId: '123',
           requesterId: 'abc',
           sentAt: 123456,
-          transactionId: expect.any(String) as string,
+          tagId: expect.any(String) as string,
         },
         {
           componentId: 'TCIF',
@@ -172,7 +173,7 @@ describe('History Service', () => {
           originatorReferenceId: '123',
           requesterId: 'abc',
           sentAt: 123456,
-          transactionId: expect.any(String) as string,
+          tagId: expect.any(String) as string,
         },
         {
           componentId: 'TCIF',
@@ -184,7 +185,7 @@ describe('History Service', () => {
           originatorReferenceId: '123',
           requesterId: 'abc',
           sentAt: 123456,
-          transactionId: expect.any(String) as string,
+          tagId: expect.any(String) as string,
         },
         {
           accountId: 'user1234',
@@ -196,6 +197,7 @@ describe('History Service', () => {
           interventionState: 'ACTIVE',
           sentAt: 12345,
           transactionId: 'abc1234',
+          tagId: 'abc1234',
         },
       ],
     });
@@ -209,7 +211,7 @@ describe('History Service', () => {
           sentAt: 12345,
           appliedAt: 123456789,
           isAccountDeleted: false,
-          history: ['12346|TCIF|01|Reason1|TICF|123|abc'],
+          history: ['12345|TCIF|01|Reason1|TICF|123|abc'],
           intervention: '01',
           blocked: false,
           suspended: true,
@@ -246,6 +248,7 @@ describe('History Service', () => {
           interventionState: 'ACTIVE',
           sentAt: 12345,
           transactionId: 'abc1234',
+          tagId: 'abc1234',
         },
       ],
     });

--- a/src/services/test/history-service.test.ts
+++ b/src/services/test/history-service.test.ts
@@ -5,9 +5,9 @@ import { InMemoryAccountStatusService } from '../../tables/account-status';
 import { InMemoryInterventionEventsService } from '../../tables/intervention-events';
 import { deduplicateEvents, HistoryIdentifier, HistoryService } from '../history-service';
 
-const noDeduplicate = (accountStatus: HistoryObject[], interventionEvents: HistoryObject[]): HistoryObject[] => [
-  ...accountStatus,
-  ...interventionEvents,
+const markDeduplicated = (accountStatus: HistoryObject[], interventionEvents: HistoryObject[]): HistoryObject[] => [
+  ...accountStatus.map((event) => ({ ...event, interventionReason: `deduplicated:${event.interventionReason}` })),
+  ...interventionEvents.map((event) => ({ ...event, interventionReason: `deduplicated:${event.interventionReason}` })),
 ];
 
 describe('History Service', () => {
@@ -15,7 +15,7 @@ describe('History Service', () => {
     const service = new HistoryService(
       new InMemoryAccountStatusService(),
       new InMemoryInterventionEventsService([]),
-      noDeduplicate,
+      markDeduplicated,
     );
 
     const result = await service.fetchHistory('user1234');
@@ -40,7 +40,7 @@ describe('History Service', () => {
         },
       }),
       new InMemoryInterventionEventsService([]),
-      noDeduplicate,
+      markDeduplicated,
     );
 
     const result = await service.fetchHistory('user1234');
@@ -51,7 +51,7 @@ describe('History Service', () => {
           componentId: 'TCIF',
           interventionCode: '01',
           interventionName: 'TEMPORARY_SUSPENSION',
-          interventionReason: 'Reason1',
+          interventionReason: 'deduplicated:Reason1',
           interventionState: 'ACTIVE',
           originatingComponent: 'TICF',
           originatorReferenceId: '123',
@@ -63,7 +63,7 @@ describe('History Service', () => {
           componentId: 'TCIF',
           interventionCode: '01',
           interventionName: 'RESET_PASSWORD',
-          interventionReason: 'Reason1',
+          interventionReason: 'deduplicated:Reason1',
           interventionState: 'REMOVED',
           originatingComponent: 'TICF',
           originatorReferenceId: '123',
@@ -75,7 +75,7 @@ describe('History Service', () => {
           componentId: 'TCIF',
           interventionCode: '01',
           interventionName: 'REPROVE_IDENTITY',
-          interventionReason: 'Reason1',
+          interventionReason: 'deduplicated:Reason1',
           interventionState: 'REMOVED',
           originatingComponent: 'TICF',
           originatorReferenceId: '123',
@@ -105,7 +105,7 @@ describe('History Service', () => {
           transactionId: 'abc1234',
         },
       ]),
-      noDeduplicate,
+      markDeduplicated,
     );
 
     const result = await service.fetchHistory('user1234');
@@ -118,7 +118,7 @@ describe('History Service', () => {
           createdAt: 123456,
           eventId: '123456789',
           interventionName: 'TEMPORARY_SUSPENSION',
-          interventionReason: 'Reason2',
+          interventionReason: 'deduplicated:Reason2',
           interventionState: 'ACTIVE',
           sentAt: 12345,
           transactionId: 'abc1234',
@@ -157,7 +157,7 @@ describe('History Service', () => {
           transactionId: 'abc1234',
         },
       ]),
-      noDeduplicate,
+      markDeduplicated,
     );
 
     const result = await service.fetchHistory('user1234');
@@ -168,7 +168,7 @@ describe('History Service', () => {
           componentId: 'TCIF',
           interventionCode: '01',
           interventionName: 'TEMPORARY_SUSPENSION',
-          interventionReason: 'Reason1',
+          interventionReason: 'deduplicated:Reason1',
           interventionState: 'ACTIVE',
           originatingComponent: 'TICF',
           originatorReferenceId: '123',
@@ -180,7 +180,7 @@ describe('History Service', () => {
           componentId: 'TCIF',
           interventionCode: '01',
           interventionName: 'RESET_PASSWORD',
-          interventionReason: 'Reason1',
+          interventionReason: 'deduplicated:Reason1',
           interventionState: 'REMOVED',
           originatingComponent: 'TICF',
           originatorReferenceId: '123',
@@ -192,7 +192,7 @@ describe('History Service', () => {
           componentId: 'TCIF',
           interventionCode: '01',
           interventionName: 'REPROVE_IDENTITY',
-          interventionReason: 'Reason1',
+          interventionReason: 'deduplicated:Reason1',
           interventionState: 'REMOVED',
           originatingComponent: 'TICF',
           originatorReferenceId: '123',
@@ -206,7 +206,7 @@ describe('History Service', () => {
           createdAt: 123456,
           eventId: '123456789',
           interventionName: 'TEMPORARY_SUSPENSION',
-          interventionReason: 'Reason2',
+          interventionReason: 'deduplicated:Reason2',
           interventionState: 'ACTIVE',
           sentAt: 12345,
           transactionId: 'abc1234',
@@ -233,7 +233,7 @@ describe('History Service', () => {
         },
       }),
       new InMemoryInterventionEventsService([]),
-      noDeduplicate,
+      markDeduplicated,
     );
 
     const result = await service.fetchHistory('user1234');
@@ -258,7 +258,7 @@ describe('History Service', () => {
         },
       }),
       new InMemoryInterventionEventsService([]),
-      noDeduplicate,
+      markDeduplicated,
     );
 
     const result = await service.fetchHistory('user1234');

--- a/src/services/test/history-service.test.ts
+++ b/src/services/test/history-service.test.ts
@@ -216,7 +216,7 @@ describe('History Service', () => {
     });
   });
 
-  it('handles invalid history string with mark duplicated', async () => {
+  it('handles invalid history string', async () => {
     const service = new HistoryService(
       new InMemoryAccountStatusService({
         status: {
@@ -264,34 +264,6 @@ describe('History Service', () => {
     const result = await service.fetchHistory('user1234');
 
     expect(result).toEqual({ history: [] });
-  });
-
-  it('handles invalid history string', async () => {
-    const service = new HistoryService(
-      new InMemoryAccountStatusService({
-        status: {
-          pk: 'user1234',
-          sentAt: 123456,
-          appliedAt: 123456789,
-          isAccountDeleted: false,
-          history: ['invalid'],
-          intervention: '01',
-          blocked: false,
-          suspended: true,
-          resetPassword: false,
-          reproveIdentity: false,
-        },
-      }),
-      new InMemoryInterventionEventsService([]),
-    );
-
-    const result = await service.fetchHistory('user1234');
-
-    expect(result).toEqual({
-      history: [],
-    });
-
-    expect(result.history[0]?.transactionId).toBe(result.history[1]?.transactionId);
   });
 });
 

--- a/src/services/test/history-service.test.ts
+++ b/src/services/test/history-service.test.ts
@@ -1,12 +1,28 @@
 import { InterventionState } from '../../data-types/constants';
 import { InterventionName } from '../../data-types/intervention-name';
+import { HistoryObject as HistoryLine } from '../../data-types/interfaces';
 import { InMemoryAccountStatusService } from '../../tables/account-status';
 import { InMemoryInterventionEventsService } from '../../tables/intervention-events';
-import { HistoryService } from '../history-service';
+import { deduplicateEvents, HistoryIdentifier, HistoryService } from '../history-service';
+
+class TestableHistoryService extends HistoryService {
+  public callMapHistoryObjectToInterventionEvents(input: HistoryLine) {
+    return this.mapHistoryObjectToInterventionEvents(input);
+  }
+}
+
+const noDeduplicate = (accountStatus: unknown[], interventionEvents: unknown[]) => [
+  ...accountStatus,
+  ...interventionEvents,
+];
 
 describe('History Service', () => {
   it('returns an empty array for no events', async () => {
-    const service = new HistoryService(new InMemoryAccountStatusService(), new InMemoryInterventionEventsService([]));
+    const service = new HistoryService(
+      new InMemoryAccountStatusService(),
+      new InMemoryInterventionEventsService([]),
+      noDeduplicate,
+    );
 
     const result = await service.fetchHistory('user1234');
 
@@ -30,6 +46,7 @@ describe('History Service', () => {
         },
       }),
       new InMemoryInterventionEventsService([]),
+      noDeduplicate,
     );
 
     const result = await service.fetchHistory('user1234');
@@ -94,6 +111,7 @@ describe('History Service', () => {
           transactionId: 'abc1234',
         },
       ]),
+      noDeduplicate,
     );
 
     const result = await service.fetchHistory('user1234');
@@ -116,7 +134,7 @@ describe('History Service', () => {
     });
   });
 
-  it('returns expected result for a combination of account status history and intervention events with no overlap', async () => {
+  it('returns expected result for a combination of account status history and intervention events', async () => {
     const service = new HistoryService(
       new InMemoryAccountStatusService({
         status: {
@@ -145,6 +163,7 @@ describe('History Service', () => {
           transactionId: 'abc1234',
         },
       ]),
+      noDeduplicate,
     );
 
     const result = await service.fetchHistory('user1234');
@@ -203,57 +222,6 @@ describe('History Service', () => {
     });
   });
 
-  it('deduplicates events', async () => {
-    const service = new HistoryService(
-      new InMemoryAccountStatusService({
-        status: {
-          pk: 'user1234',
-          sentAt: 12345,
-          appliedAt: 123456789,
-          isAccountDeleted: false,
-          history: ['12345|TCIF|01|Reason1|TICF|123|abc'],
-          intervention: '01',
-          blocked: false,
-          suspended: true,
-          resetPassword: false,
-          reproveIdentity: false,
-        },
-      }),
-      new InMemoryInterventionEventsService([
-        {
-          eventId: '123456789',
-          accountId: 'user1234',
-          createdAt: 1234567,
-          interventionState: InterventionState.ACTIVE,
-          interventionName: InterventionName.TEMPORARY_SUSPENSION,
-          interventionReason: 'Reason2',
-          sentAt: 12345,
-          componentId: 'TICF',
-          transactionId: 'abc1234',
-        },
-      ]),
-    );
-
-    const result = await service.fetchHistory('user1234');
-
-    expect(result).toEqual({
-      history: [
-        {
-          accountId: 'user1234',
-          componentId: 'TICF',
-          createdAt: 1234567,
-          eventId: '123456789',
-          interventionName: 'TEMPORARY_SUSPENSION',
-          interventionReason: 'Reason2',
-          interventionState: 'ACTIVE',
-          sentAt: 12345,
-          transactionId: 'abc1234',
-          tagId: 'abc1234',
-        },
-      ],
-    });
-  });
-
   it('handles invalid history string', async () => {
     const service = new HistoryService(
       new InMemoryAccountStatusService({
@@ -271,14 +239,114 @@ describe('History Service', () => {
         },
       }),
       new InMemoryInterventionEventsService([]),
+      noDeduplicate,
     );
 
     const result = await service.fetchHistory('user1234');
 
-    expect(result).toEqual({
-      history: [],
-    });
+    expect(result).toEqual({ history: [] });
+  });
 
-    expect(result.history[0]?.transactionId).toBe(result.history[1]?.transactionId);
+  describe('mapHistoryObjectToInterventionEvents', () => {
+    it('throws an error when the history object contains an invalid intervention code', () => {
+      const service = new TestableHistoryService(
+        new InMemoryAccountStatusService(),
+        new InMemoryInterventionEventsService([]),
+        noDeduplicate,
+      );
+
+      const invalidHistoryObject: HistoryLine = {
+        sentAt: '2023-10-09T12:30:03.456Z',
+        component: 'TCIF',
+        code: 'XX',
+        intervention: 'UNKNOWN',
+        reason: 'SomeReason',
+        originatingComponent: 'TICF',
+        originatorReferenceId: '123',
+        requesterId: 'abc',
+      };
+
+      expect(() => service.callMapHistoryObjectToInterventionEvents(invalidHistoryObject)).toThrow('Code not code');
+    });
+  });
+});
+
+describe('deduplicateEvents', () => {
+  const baseEvent: HistoryIdentifier = {
+    interventionName: 'TEMPORARY_SUSPENSION',
+    interventionState: 'ACTIVE',
+    sentAt: 1000,
+    transactionId: 'tx-account-status',
+  };
+
+  const matchingInterventionEvent: HistoryIdentifier = {
+    interventionName: 'TEMPORARY_SUSPENSION',
+    interventionState: 'ACTIVE',
+    sentAt: 1000,
+    transactionId: 'tx-intervention',
+  };
+
+  it('removes the account status event when all fields match an intervention event', () => {
+    const result = deduplicateEvents([baseEvent], [matchingInterventionEvent]);
+
+    expect(result).toEqual([matchingInterventionEvent]);
+  });
+
+  it('does not deduplicate when interventionName differs', () => {
+    const differentNameEvent: HistoryIdentifier = {
+      ...matchingInterventionEvent,
+      interventionName: 'RESET_PASSWORD',
+    };
+
+    const result = deduplicateEvents([baseEvent], [differentNameEvent]);
+
+    expect(result).toEqual([baseEvent, differentNameEvent]);
+  });
+
+  it('does not deduplicate when interventionState differs', () => {
+    const differentStateEvent: HistoryIdentifier = {
+      ...matchingInterventionEvent,
+      interventionState: 'REMOVED',
+    };
+
+    const result = deduplicateEvents([baseEvent], [differentStateEvent]);
+
+    expect(result).toEqual([baseEvent, differentStateEvent]);
+  });
+
+  it('does not deduplicate when sentAt differs', () => {
+    const differentSentAtEvent: HistoryIdentifier = {
+      ...matchingInterventionEvent,
+      sentAt: 2000,
+    };
+
+    const result = deduplicateEvents([baseEvent], [differentSentAtEvent]);
+
+    expect(result).toEqual([baseEvent, differentSentAtEvent]);
+  });
+
+  it('returns all intervention events even when no account status events exist', () => {
+    const result = deduplicateEvents([], [matchingInterventionEvent]);
+
+    expect(result).toEqual([matchingInterventionEvent]);
+  });
+
+  it('returns all account status events when no intervention events exist', () => {
+    const result = deduplicateEvents([baseEvent], []);
+
+    expect(result).toEqual([baseEvent]);
+  });
+
+  it('only removes account status events that match, keeping non-matching ones', () => {
+    const nonMatchingEvent: HistoryIdentifier = {
+      interventionName: 'REPROVE_IDENTITY',
+      interventionState: 'REMOVED',
+      sentAt: 5000,
+      transactionId: 'tx-other',
+    };
+
+    const result = deduplicateEvents([baseEvent, nonMatchingEvent], [matchingInterventionEvent]);
+
+    expect(result).toEqual([nonMatchingEvent, matchingInterventionEvent]);
   });
 });

--- a/src/services/test/history-service.test.ts
+++ b/src/services/test/history-service.test.ts
@@ -1,17 +1,11 @@
+import { HistoryObject } from '../../data-types/api-schemas-v2';
 import { InterventionState } from '../../data-types/constants';
 import { InterventionName } from '../../data-types/intervention-name';
-import { HistoryObject as HistoryLine } from '../../data-types/interfaces';
 import { InMemoryAccountStatusService } from '../../tables/account-status';
 import { InMemoryInterventionEventsService } from '../../tables/intervention-events';
 import { deduplicateEvents, HistoryIdentifier, HistoryService } from '../history-service';
 
-class TestableHistoryService extends HistoryService {
-  public callMapHistoryObjectToInterventionEvents(input: HistoryLine) {
-    return this.mapHistoryObjectToInterventionEvents(input);
-  }
-}
-
-const noDeduplicate = (accountStatus: unknown[], interventionEvents: unknown[]) => [
+const noDeduplicate = (accountStatus: HistoryObject[], interventionEvents: HistoryObject[]): HistoryObject[] => [
   ...accountStatus,
   ...interventionEvents,
 ];
@@ -247,27 +241,29 @@ describe('History Service', () => {
     expect(result).toEqual({ history: [] });
   });
 
-  describe('mapHistoryObjectToInterventionEvents', () => {
-    it('throws an error when the history object contains an invalid intervention code', () => {
-      const service = new TestableHistoryService(
-        new InMemoryAccountStatusService(),
-        new InMemoryInterventionEventsService([]),
-        noDeduplicate,
-      );
+  it('handles a history string with an invalid intervention code', async () => {
+    const service = new HistoryService(
+      new InMemoryAccountStatusService({
+        status: {
+          pk: 'user1234',
+          sentAt: 123456,
+          appliedAt: 123456789,
+          isAccountDeleted: false,
+          history: ['123456|TCIF|XX|SomeReason|TICF|123|abc'],
+          intervention: '01',
+          blocked: false,
+          suspended: true,
+          resetPassword: false,
+          reproveIdentity: false,
+        },
+      }),
+      new InMemoryInterventionEventsService([]),
+      noDeduplicate,
+    );
 
-      const invalidHistoryObject: HistoryLine = {
-        sentAt: '2023-10-09T12:30:03.456Z',
-        component: 'TCIF',
-        code: 'XX',
-        intervention: 'UNKNOWN',
-        reason: 'SomeReason',
-        originatingComponent: 'TICF',
-        originatorReferenceId: '123',
-        requesterId: 'abc',
-      };
+    const result = await service.fetchHistory('user1234');
 
-      expect(() => service.callMapHistoryObjectToInterventionEvents(invalidHistoryObject)).toThrow('Code not code');
-    });
+    expect(result).toEqual({ history: [] });
   });
 
   it('handles invalid history string', async () => {

--- a/src/specs/main.yaml
+++ b/src/specs/main.yaml
@@ -277,6 +277,18 @@ components:
         - RESET_PASSWORD
         - REPROVE_IDENTITY
       description: Enum of possible Intervention names
+    AccountHistoryResponse:
+      type: object
+      properties:
+        history:
+          allOf:
+            - $ref: "#/components/schemas/HistoryList"
+            - description: History of interventions applied to an account
+              readOnly: true
+      required:
+        - history
+      description: The intervention history of the User's OneLogin Account
+      readOnly: true
   parameters:
     UserId:
       schema:
@@ -349,6 +361,37 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AccountStatusResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/ServerError"
+        "502":
+          $ref: "#/components/responses/BadGateway"
+        "504":
+          $ref: "#/components/responses/GatewayTimeout"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
+  /v2/ais/{userId}/history:
+    get:
+      operationId: aisV2History
+      tags:
+        - Status
+      summary: Get User Account Intervention History
+      description: Returns the full intervention history for a user's account
+      x-amazon-apigateway-integration:
+        httpMethod: POST
+        type: aws_proxy
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${StatusRetrieverFunction.Arn}:live/invocations
+      parameters:
+        - $ref: "#/components/parameters/UserId"
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AccountHistoryResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
         "500":

--- a/src/utils/not-empty.test.ts
+++ b/src/utils/not-empty.test.ts
@@ -1,0 +1,16 @@
+import notEmpty from './not-empty';
+
+describe('notEmpty', () => {
+  it('not empty', () => {
+    expect(notEmpty('a')).toBe(true);
+  });
+
+  it('undefined', () => {
+    expect(notEmpty(undefined)).toBe(false);
+  });
+
+  it('null', () => {
+    // eslint-disable-next-line unicorn/no-null
+    expect(notEmpty(null)).toBe(false);
+  });
+});

--- a/src/utils/not-empty.ts
+++ b/src/utils/not-empty.ts
@@ -1,0 +1,3 @@
+const isNotEmpty = <T>(value: T | null | undefined): value is T => value !== undefined && value !== null;
+
+export default isNotEmpty;


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

History UI v2

Pull history information from both the `account-status` and `intervention-events` tables.  New v2 endpoint, including SDK updates.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-8493](https://govukverify.atlassian.net/browse/FPAD-8493)

[FPAD-8493]: https://govukverify.atlassian.net/browse/FPAD-8493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ