### PR TITLE
An example permissions.yaml for kiro-cli

### DIFF
--- a/docs/ai/kiro/permissions.yaml
+++ b/docs/ai/kiro/permissions.yaml
@@ -1,0 +1,22 @@
+# Example kiro-cli permissions.yaml
+# See https://kiro.dev/docs/cli/v3/permissions/
+# This needs to be copied to ~/.kiro/settings/permissions.yaml
+# To read this file kiro-cli needs to be started with --v3
+rules:
+  - capability: shell
+    effect: allow
+    match:
+      - ls *
+      - cd *
+      - cat *
+      - grep *
+      - head *
+      - tail *
+      - npm test *
+      - npm run test*
+      - npm run lint*
+      - git show*
+      - git log*
+      - git status*
+      - npx tsc*
+      - npx vitest*


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

An example permissions.yaml for kiro-cli

This file needs to be copied into the user's home folder and kiro-cli run with --v3

## Why

This gives kiro-cli some default permissions