### PR TITLE
Rename HistoryObject to HistoryLine

### DIFF
--- a/packages/ais-status-sdk/src/index.test.ts
+++ b/packages/ais-status-sdk/src/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { InterventionClient } from './index';
 import { InterventionInvalidResponse } from './errors';
-import type { HistoryObject } from './types';
+import type { HistoryLine } from './types';
 import { InterventionName, InterventionState } from './types';
 import { ZodError } from 'zod';
 
@@ -17,7 +17,7 @@ function mockResponse(body: unknown, status = 200): Response {
   } as unknown as Response;
 }
 
-function makeHistoryObject(overrides: Partial<HistoryObject> = {}): HistoryObject {
+function makeHistoryObject(overrides: Partial<HistoryLine> = {}): HistoryLine {
   return {
     sentAt: 1_696_869_003_456,
     componentId: 'TICF_CRI',
@@ -91,7 +91,7 @@ describe('InterventionClient', () => {
       const client = new InterventionClient({ baseUrl });
 
       const userId = 'urn:fdc:gov.uk:2022:user123';
-      mockFetch.mockResolvedValue(mockResponse({ history: [] }));
+      mockFetch.mockResolvedValue(mockResponse({ lines: [] }));
 
       await client.getAccountHistory(userId);
 
@@ -103,22 +103,22 @@ describe('InterventionClient', () => {
     it('returns an empty history array when there are no history entries', async () => {
       const client = new InterventionClient({ baseUrl });
 
-      mockFetch.mockResolvedValue(mockResponse({ history: [] }));
+      mockFetch.mockResolvedValue(mockResponse({ lines: [] }));
 
       const result = await client.getAccountHistory('user-1');
 
-      expect(result).toEqual({ history: [] });
+      expect(result).toEqual({ lines: [] });
     });
 
     it('returns the parsed AccountHistory with a single entry', async () => {
       const client = new InterventionClient({ baseUrl });
 
       const historyEntry = makeHistoryObject();
-      mockFetch.mockResolvedValue(mockResponse({ history: [historyEntry] }));
+      mockFetch.mockResolvedValue(mockResponse({ lines: [historyEntry] }));
 
       const result = await client.getAccountHistory('user-1');
 
-      expect(result).toEqual({ history: [historyEntry] });
+      expect(result).toEqual({ lines: [historyEntry] });
     });
 
     it('returns history with multiple entries in order', async () => {
@@ -129,12 +129,12 @@ describe('InterventionClient', () => {
         makeHistoryObject({ sentAt: 1_696_869_004_000, interventionName: InterventionName.TEMPORARY_SUSPENSION }),
         makeHistoryObject({ sentAt: 1_696_869_005_000, interventionName: InterventionName.REPROVE_IDENTITY }),
       ];
-      mockFetch.mockResolvedValue(mockResponse({ history: entries }));
+      mockFetch.mockResolvedValue(mockResponse({ lines: entries }));
 
       const result = await client.getAccountHistory('user-1');
 
-      expect(result.history).toHaveLength(3);
-      expect(result.history).toEqual(entries);
+      expect(result.lines).toHaveLength(3);
+      expect(result.lines).toEqual(entries);
     });
 
     it('returns history entries with all optional fields present', async () => {
@@ -148,33 +148,33 @@ describe('InterventionClient', () => {
         transactionId: 'txn-456',
         messageEventId: 'msg-789',
       });
-      mockFetch.mockResolvedValue(mockResponse({ history: [fullEntry] }));
+      mockFetch.mockResolvedValue(mockResponse({ lines: [fullEntry] }));
 
       const result = await client.getAccountHistory('user-1');
 
-      expect(result.history[0]).toEqual(fullEntry);
+      expect(result.lines[0]).toEqual(fullEntry);
     });
 
     it('returns history entries where originatorReferenceId is an array', async () => {
       const client = new InterventionClient({ baseUrl });
 
       const entry = makeHistoryObject({ originatorReferenceId: ['ref-1', 'ref-2'] });
-      mockFetch.mockResolvedValue(mockResponse({ history: [entry] }));
+      mockFetch.mockResolvedValue(mockResponse({ lines: [entry] }));
 
       const result = await client.getAccountHistory('user-1');
 
-      expect(result.history[0]?.originatorReferenceId).toEqual(['ref-1', 'ref-2']);
+      expect(result.lines[0]?.originatorReferenceId).toEqual(['ref-1', 'ref-2']);
     });
 
     it('returns history entries with all known interventionState values', async () => {
       const client = new InterventionClient({ baseUrl });
 
       const entries = Object.values(InterventionState).map((state) => makeHistoryObject({ interventionState: state }));
-      mockFetch.mockResolvedValue(mockResponse({ history: entries }));
+      mockFetch.mockResolvedValue(mockResponse({ lines: entries }));
 
       const result = await client.getAccountHistory('user-1');
 
-      const returnedStates = result.history.map((h) => h.interventionState);
+      const returnedStates = result.lines.map((h) => h.interventionState);
       expect(returnedStates).toEqual(Object.values(InterventionState));
     });
 
@@ -207,7 +207,7 @@ describe('InterventionClient', () => {
 
       // Missing required `interventionReason`
       const invalidEntry = { sentAt: 1_696_869_003_456, componentId: 'TICF_CRI' };
-      mockFetch.mockResolvedValue(mockResponse({ history: [invalidEntry] }));
+      mockFetch.mockResolvedValue(mockResponse({ lines: [invalidEntry] }));
 
       await expect(client.getAccountHistory('user-1')).rejects.toThrow(InterventionInvalidResponse);
     });
@@ -216,7 +216,7 @@ describe('InterventionClient', () => {
       const client = new InterventionClient({ baseUrl });
 
       const invalidEntry = makeHistoryObject({ interventionName: 'NOT_A_VALID_INTERVENTION' as InterventionName });
-      mockFetch.mockResolvedValue(mockResponse({ history: [invalidEntry] }));
+      mockFetch.mockResolvedValue(mockResponse({ lines: [invalidEntry] }));
 
       await expect(client.getAccountHistory('user-1')).rejects.toThrow(InterventionInvalidResponse);
     });
@@ -225,7 +225,7 @@ describe('InterventionClient', () => {
       const client = new InterventionClient({ baseUrl });
 
       const invalidEntry = makeHistoryObject({ interventionState: 'NOT_A_VALID_STATE' as InterventionState });
-      mockFetch.mockResolvedValue(mockResponse({ history: [invalidEntry] }));
+      mockFetch.mockResolvedValue(mockResponse({ lines: [invalidEntry] }));
 
       await expect(client.getAccountHistory('user-1')).rejects.toThrow(InterventionInvalidResponse);
     });
@@ -255,7 +255,7 @@ describe('InterventionClient', () => {
 
     it('strips trailing slash from baseUrl on history requests', async () => {
       const clientWithSlash = new InterventionClient({ baseUrl: 'https://example.com/' });
-      mockFetch.mockResolvedValue(mockResponse({ history: [] }));
+      mockFetch.mockResolvedValue(mockResponse({ lines: [] }));
 
       await clientWithSlash.getAccountHistory('user-1');
 

--- a/packages/ais-status-sdk/src/index.ts
+++ b/packages/ais-status-sdk/src/index.ts
@@ -4,19 +4,14 @@ import {
   V2ResponseSchema,
   type V2Response,
 } from '../../../src/data-types/api-schemas-v2';
-import type {
-  AccountHistoryResult,
-  AccountStatusResult,
-  InterventionClientConfig,
-  InterventionClientInterface,
-} from './types';
+import type { AccountHistory, AccountStatus, InterventionClientConfig, InterventionClientInterface } from './types';
 export type {
-  AccountStatusResult,
+  AccountStatus,
   InterventionClientConfig,
   InterventionClientInterface,
   Intervention,
-  AccountHistoryResult,
-  HistoryObject,
+  AccountHistory,
+  HistoryLine,
 } from './types';
 export { InterventionName, InterventionState } from './types';
 import { InterventionInvalidResponse, InterventionMissingBaseUrl, InterventionRequestFailed } from './errors';
@@ -77,13 +72,13 @@ export class InterventionClient implements InterventionClientInterface {
     return parseResult.data;
   }
 
-  async getAccountStatus(userId: string): Promise<AccountStatusResult> {
+  async getAccountStatus(userId: string): Promise<AccountStatus> {
     const result = await this.fetchAccountStatus(userId);
 
     return result;
   }
 
-  async getAccountHistory(userId: string): Promise<AccountHistoryResult> {
+  async getAccountHistory(userId: string): Promise<AccountHistory> {
     const result = await this.fetchAccountHistory(userId);
 
     return result;

--- a/packages/ais-status-sdk/src/stub.ts
+++ b/packages/ais-status-sdk/src/stub.ts
@@ -1,16 +1,16 @@
 import { InterventionRequestFailed } from './errors';
-import { AccountHistoryResult, AccountStatusResult, InterventionClientInterface, InterventionName } from './types';
+import { AccountHistory, AccountStatus, InterventionClientInterface, InterventionName } from './types';
 
 export interface InterventionStubConfig {
-  result?: AccountStatusResult;
+  result?: AccountStatus;
   interventionNames?: InterventionName[];
-  historyResult?: AccountHistoryResult;
+  historyResult?: AccountHistory;
 }
 
 export class InterventionStub implements InterventionClientInterface {
   constructor(readonly config?: InterventionStubConfig) {}
 
-  getAccountStatus(): Promise<AccountStatusResult> {
+  getAccountStatus(): Promise<AccountStatus> {
     if (this.config?.result) return Promise.resolve(this.config.result);
 
     if (this.config?.interventionNames)
@@ -21,7 +21,7 @@ export class InterventionStub implements InterventionClientInterface {
     throw new InterventionRequestFailed();
   }
 
-  getAccountHistory(): Promise<AccountHistoryResult> {
+  getAccountHistory(): Promise<AccountHistory> {
     if (this.config?.historyResult) return Promise.resolve(this.config.historyResult);
 
     throw new InterventionRequestFailed();

--- a/packages/ais-status-sdk/src/types.ts
+++ b/packages/ais-status-sdk/src/types.ts
@@ -17,11 +17,11 @@ export interface Intervention {
   name: InterventionName | string;
 }
 
-export interface AccountStatusResult {
+export interface AccountStatus {
   interventions: Intervention[];
 }
 
-export interface HistoryObject {
+export interface HistoryLine {
   sentAt: number;
   componentId: string;
   interventionName: InterventionName;
@@ -35,8 +35,8 @@ export interface HistoryObject {
   messageEventId?: string | undefined;
 }
 
-export interface AccountHistoryResult {
-  history: HistoryObject[];
+export interface AccountHistory {
+  lines: HistoryLine[];
 }
 
 type LogAttributes = Record<string, unknown>;
@@ -53,6 +53,6 @@ export interface InterventionClientConfig {
 }
 
 export interface InterventionClientInterface {
-  getAccountStatus(userId: string): Promise<AccountStatusResult>;
-  getAccountHistory(userId: string): Promise<AccountHistoryResult>;
+  getAccountStatus(userId: string): Promise<AccountStatus>;
+  getAccountHistory(userId: string): Promise<AccountHistory>;
 }

--- a/src/data-types/api-schemas-v2.ts
+++ b/src/data-types/api-schemas-v2.ts
@@ -39,7 +39,7 @@ export const V2ResponseSchema = z
 export type V2Response = z.infer<typeof V2ResponseSchema>;
 
 /* eslint-disable unicorn/max-nested-calls */
-const HistoryObjectSchema = z
+const HistoryLineSchema = z
   .object({
     sentAt: z.number().int().meta({
       description: 'A timestamp (ms) when the Intervention was sent by Fraud Analyst/Risk Engine.',
@@ -62,24 +62,24 @@ const HistoryObjectSchema = z
     tagId: z.string().optional(),
   })
   .meta({
-    id: 'HistoryObject',
-    title: 'History Object Schema',
-    description: 'JSON object representing an intervention previously applied on the account',
+    id: 'HistoryLine',
+    title: 'History Line Schema',
+    description: 'A single update to the intervention state of an account',
     readOnly: true,
   });
 
-export type HistoryObject = z.infer<typeof HistoryObjectSchema>;
+export type HistoryLine = z.infer<typeof HistoryLineSchema>;
 
-const HistoryListSchema = z.array(HistoryObjectSchema).meta({
-  id: 'HistoryList',
-  title: 'History List',
+const HistoryLinesSchema = z.array(HistoryLineSchema).meta({
+  id: 'HistoryLines',
+  title: 'History Lines',
   description: 'History of interventions applied to an account',
   readOnly: true,
 });
 
 export const V2HistoryResponseSchema = z
   .object({
-    history: HistoryListSchema,
+    lines: HistoryLinesSchema,
   })
   .meta({
     id: 'AccountHistoryResponse',

--- a/src/frontend/app.ts
+++ b/src/frontend/app.ts
@@ -106,7 +106,7 @@ export function init(
       userId,
       accountHistory: {
         ...accountHistory,
-        history: accountHistory.history.map((line) => ({ ...line, sentAt: formatDate(line.sentAt) })),
+        history: accountHistory.lines.map((line) => ({ ...line, sentAt: formatDate(line.sentAt) })),
       },
       messageSent,
       aisSendTxMA: featureFlags.isEnabled('aisSendTxMA'),

--- a/src/frontend/local.ts
+++ b/src/frontend/local.ts
@@ -10,7 +10,7 @@ init(
   new InterventionStub({
     interventionNames: [InterventionName.RESET_PASSWORD],
     historyResult: {
-      history: [
+      lines: [
         {
           sentAt: 1784021279000,
           componentId: 'TEST',

--- a/src/frontend/tests/app.test.ts
+++ b/src/frontend/tests/app.test.ts
@@ -65,7 +65,7 @@ describe('frontend app', () => {
 
   describe('GET /user/:userId', () => {
     it('returns 200 and renders the details page when user is found', async () => {
-      const server = init(new InterventionStub({ result: { interventions: [] }, historyResult: { history: [] } }));
+      const server = init(new InterventionStub({ result: { interventions: [] }, historyResult: { lines: [] } }));
       const response = await server.inject({ method: 'GET', url: '/user/test-user-id' });
       expect(response.statusCode).toBe(200);
       expect(response.headers['content-type']).toMatch(/html/);
@@ -77,7 +77,7 @@ describe('frontend app', () => {
         new InterventionStub({
           result: { interventions: [] },
           historyResult: {
-            history: [
+            lines: [
               {
                 sentAt: 1784021279000,
                 componentId: 'TEST',
@@ -102,7 +102,7 @@ describe('frontend app', () => {
       const server = init(
         new InterventionStub({
           interventionNames: [InterventionName.PERMANENT_SUSPENSION],
-          historyResult: { history: [] },
+          historyResult: { lines: [] },
         }),
       );
       const response = await server.inject({ method: 'GET', url: '/user/test-user-id' });
@@ -111,7 +111,7 @@ describe('frontend app', () => {
     });
 
     it('displays a no interventions message when the account exists but has no interventions', async () => {
-      const server = init(new InterventionStub({ result: { interventions: [] }, historyResult: { history: [] } }));
+      const server = init(new InterventionStub({ result: { interventions: [] }, historyResult: { lines: [] } }));
       const response = await server.inject({ method: 'GET', url: '/user/test-user-id' });
       expect(response.statusCode).toBe(200);
       expect(response.body).toContain('There are no active interventions on this account.');
@@ -219,7 +219,7 @@ describe('frontend app', () => {
 
     it('shows the success banner on the subsequent GET and not on a second GET', async () => {
       const server = init(
-        new InterventionStub({ result: { interventions: [] }, historyResult: { history: [] } }),
+        new InterventionStub({ result: { interventions: [] }, historyResult: { lines: [] } }),
         new FeatureFlagsStub({ aisFrontend: true, aisSendTxMA: true }),
         new StubMessageService(successOutput),
       );

--- a/src/services/history-service.ts
+++ b/src/services/history-service.ts
@@ -2,9 +2,9 @@ import { randomUUID } from 'node:crypto';
 import { HistoryStringBuilder } from '../commons/history-string-builder';
 import logger from '../commons/logger';
 import { addMetric } from '../commons/metrics';
-import { HistoryObject, V2HistoryResponse } from '../data-types/api-schemas-v2';
+import { HistoryLine, V2HistoryResponse } from '../data-types/api-schemas-v2';
 import { MetricNames } from '../data-types/constants';
-import { HistoryObject as HistoryLine } from '../data-types/interfaces';
+import { HistoryObject } from '../data-types/interfaces';
 import { AccountStatusService } from '../tables/account-status';
 import { InterventionEventsService } from '../tables/intervention-events';
 import notEmpty from '../utils/not-empty';
@@ -16,9 +16,9 @@ export class HistoryService {
     readonly accountStatusService: AccountStatusService,
     readonly interventionEventsService: InterventionEventsService,
     readonly deduplicate: (
-      accountStatusHistory: HistoryObject[],
-      interventionEvents: HistoryObject[],
-    ) => HistoryObject[] = deduplicateEvents,
+      accountStatusHistory: HistoryLine[],
+      interventionEvents: HistoryLine[],
+    ) => HistoryLine[] = deduplicateEvents,
   ) {}
 
   async fetchHistory(accountId: string): Promise<V2HistoryResponse> {
@@ -27,11 +27,11 @@ export class HistoryService {
     const interventionEvents = await this.fetchInterventionEvents(accountId);
 
     return {
-      history: this.deduplicate(accountStatusHistory, interventionEvents),
+      lines: this.deduplicate(accountStatusHistory, interventionEvents),
     };
   }
 
-  private async fetchAccountStatus(accountId: string): Promise<HistoryObject[]> {
+  private async fetchAccountStatus(accountId: string): Promise<HistoryLine[]> {
     const response = await this.accountStatusService.getAccountStateInformation(accountId);
     if (!response) {
       logger.info('Query matched no records in DynamoDB.');
@@ -42,7 +42,7 @@ export class HistoryService {
     return this.constructHistoryObject(response.history);
   }
 
-  private constructHistoryObject(input: string[]): HistoryObject[] {
+  private constructHistoryObject(input: string[]): HistoryLine[] {
     const historyStringBuilder = new HistoryStringBuilder();
 
     const historyLines = input
@@ -56,13 +56,13 @@ export class HistoryService {
       })
       .filter(notEmpty);
 
-    return historyLines.reduce<HistoryObject[]>(
+    return historyLines.reduce<HistoryLine[]>(
       (result, historyLine) => [...result, ...this.mapHistoryObjectToInterventionEvents(historyLine)],
       [],
     );
   }
 
-  private mapHistoryObjectToInterventionEvents(input: HistoryLine): HistoryObject[] {
+  private mapHistoryObjectToInterventionEvents(input: HistoryObject): HistoryLine[] {
     const eventEdge = transitionConfig.edges[input.code];
 
     const stateChanges = config[eventEdge.name];

--- a/src/services/test/history-service.test.ts
+++ b/src/services/test/history-service.test.ts
@@ -1,11 +1,11 @@
-import { HistoryObject } from '../../data-types/api-schemas-v2';
+import { HistoryLine } from '../../data-types/api-schemas-v2';
 import { InterventionState } from '../../data-types/constants';
 import { InterventionName } from '../../data-types/intervention-name';
 import { InMemoryAccountStatusService } from '../../tables/account-status';
 import { InMemoryInterventionEventsService } from '../../tables/intervention-events';
 import { deduplicateEvents, HistoryIdentifier, HistoryService } from '../history-service';
 
-const markDeduplicated = (accountStatus: HistoryObject[], interventionEvents: HistoryObject[]): HistoryObject[] => [
+const markDeduplicated = (accountStatus: HistoryLine[], interventionEvents: HistoryLine[]): HistoryLine[] => [
   ...accountStatus.map((event) => ({ ...event, interventionReason: `deduplicated:${event.interventionReason}` })),
   ...interventionEvents.map((event) => ({ ...event, interventionReason: `deduplicated:${event.interventionReason}` })),
 ];
@@ -20,7 +20,7 @@ describe('History Service', () => {
 
     const result = await service.fetchHistory('user1234');
 
-    expect(result).toEqual({ history: [] });
+    expect(result).toEqual({ lines: [] });
   });
 
   it('returns expected result for a single account status history', async () => {
@@ -46,7 +46,7 @@ describe('History Service', () => {
     const result = await service.fetchHistory('user1234');
 
     expect(result).toEqual({
-      history: [
+      lines: [
         {
           componentId: 'TCIF',
           interventionCode: '01',
@@ -86,7 +86,7 @@ describe('History Service', () => {
       ],
     });
 
-    expect(result.history[0]?.transactionId).toBe(result.history[1]?.transactionId);
+    expect(result.lines[0]?.transactionId).toBe(result.lines[1]?.transactionId);
   });
 
   it('returns expected result for a single intervention event', async () => {
@@ -111,7 +111,7 @@ describe('History Service', () => {
     const result = await service.fetchHistory('user1234');
 
     expect(result).toEqual({
-      history: [
+      lines: [
         {
           accountId: 'user1234',
           componentId: 'TICF',
@@ -163,7 +163,7 @@ describe('History Service', () => {
     const result = await service.fetchHistory('user1234');
 
     expect(result).toEqual({
-      history: [
+      lines: [
         {
           componentId: 'TCIF',
           interventionCode: '01',
@@ -238,7 +238,7 @@ describe('History Service', () => {
 
     const result = await service.fetchHistory('user1234');
 
-    expect(result).toEqual({ history: [] });
+    expect(result).toEqual({ lines: [] });
   });
 
   it('handles a history string with an invalid intervention code', async () => {
@@ -263,7 +263,7 @@ describe('History Service', () => {
 
     const result = await service.fetchHistory('user1234');
 
-    expect(result).toEqual({ history: [] });
+    expect(result).toEqual({ lines: [] });
   });
 });
 


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Rename HistoryObject to HistoryLine

## Why

Each HistoryLine represents one InterventionEvent or part of the history associated with a row in the account-status table. 

## Notes

Includes updates to SDK to match.