### PR TITLE
FPAD-8547: Move baseUrl to SDK constructor first parameter

### DIFF
--- a/packages/ais-status-sdk/README.md
+++ b/packages/ais-status-sdk/README.md
@@ -19,7 +19,7 @@ Node.js ≥ 20 (uses native `fetch`).
 ```ts
 import { AisClient } from '@govuk-one-login/ais-status-sdk';
 
-const client = new AisClient({ baseUrl: 'https://your-ais-endpoint.example.com' });
+const client = new AisClient('https://your-ais-endpoint.example.com');
 
 const status = await client.getAccountStatus('urn:fdc:gov.uk:2022:user123');
 // { interventions: [{ name: 'RESET_PASSWORD' }] }
@@ -27,11 +27,12 @@ const status = await client.getAccountStatus('urn:fdc:gov.uk:2022:user123');
 
 ## API
 
-### `new AisClient(config)`
+### `new AisClient(baseUrl)`
 
 | Option    | Type     | Required | Description                  |
 | --------- | -------- | -------- | ---------------------------- |
 | `baseUrl` | `string` | ✓        | Base URL of the AIS endpoint |
+
 
 ### `client.getAccountStatus(userId)`
 

--- a/packages/ais-status-sdk/src/index.test.ts
+++ b/packages/ais-status-sdk/src/index.test.ts
@@ -38,7 +38,7 @@ describe('InterventionClient', () => {
 
   describe('getAccountStatus', () => {
     it('calls the v2 endpoint with the encoded userId', async () => {
-      const client = new InterventionClient({ baseUrl });
+      const client = new InterventionClient(baseUrl);
 
       const userId = 'urn:fdc:gov.uk:2022:user123';
       mockFetch.mockResolvedValue(mockResponse({ interventions: [] }));
@@ -51,7 +51,7 @@ describe('InterventionClient', () => {
     });
 
     it('returns the parsed AccountStatus', async () => {
-      const client = new InterventionClient({ baseUrl });
+      const client = new InterventionClient(baseUrl);
 
       const status = { interventions: [{ name: 'FRAUD_SUSPEND_ACCOUNT' }] };
       mockFetch.mockResolvedValue(mockResponse(status));
@@ -62,7 +62,7 @@ describe('InterventionClient', () => {
     });
 
     it('throws when the response is not ok', async () => {
-      const client = new InterventionClient({ baseUrl });
+      const client = new InterventionClient(baseUrl);
 
       mockFetch.mockResolvedValue(mockResponse({}, 404));
 
@@ -70,7 +70,7 @@ describe('InterventionClient', () => {
     });
 
     it('throws AisInvalidResponse when the response body does not match the schema', async () => {
-      const client = new InterventionClient({ baseUrl });
+      const client = new InterventionClient(baseUrl);
 
       mockFetch.mockResolvedValue(mockResponse({ unexpected: 'shape' }));
 
@@ -78,7 +78,7 @@ describe('InterventionClient', () => {
     });
 
     it('strips trailing slash from baseUrl', async () => {
-      const clientWithSlash = new InterventionClient({ baseUrl: 'https://example.com/' });
+      const clientWithSlash = new InterventionClient('https://example.com/');
       mockFetch.mockResolvedValue(mockResponse({ interventions: [] }));
 
       await clientWithSlash.getAccountStatus('user-1');
@@ -89,7 +89,7 @@ describe('InterventionClient', () => {
 
   describe('getAccountHistory', () => {
     it('calls the v2 history endpoint with the encoded userId', async () => {
-      const client = new InterventionClient({ baseUrl });
+      const client = new InterventionClient(baseUrl);
 
       const userId = 'urn:fdc:gov.uk:2022:user123';
       mockFetch.mockResolvedValue(mockResponse({ lines: [] }));
@@ -102,7 +102,7 @@ describe('InterventionClient', () => {
     });
 
     it('returns an empty history array when there are no history entries', async () => {
-      const client = new InterventionClient({ baseUrl });
+      const client = new InterventionClient(baseUrl);
 
       mockFetch.mockResolvedValue(mockResponse({ lines: [] }));
 
@@ -112,7 +112,7 @@ describe('InterventionClient', () => {
     });
 
     it('returns the parsed AccountHistory with a single entry', async () => {
-      const client = new InterventionClient({ baseUrl });
+      const client = new InterventionClient(baseUrl);
 
       const historyEntry = makeHistoryObject();
       mockFetch.mockResolvedValue(mockResponse({ lines: [historyEntry] }));
@@ -123,7 +123,7 @@ describe('InterventionClient', () => {
     });
 
     it('returns history with multiple entries in order', async () => {
-      const client = new InterventionClient({ baseUrl });
+      const client = new InterventionClient(baseUrl);
 
       const entries = [
         makeHistoryObject({ sentAt: 1_696_869_003_000, interventionName: InterventionName.PERMANENT_SUSPENSION }),
@@ -139,7 +139,7 @@ describe('InterventionClient', () => {
     });
 
     it('returns history entries with all optional fields present', async () => {
-      const client = new InterventionClient({ baseUrl });
+      const client = new InterventionClient(baseUrl);
 
       const fullEntry = makeHistoryObject({
         interventionCode: '01',
@@ -157,7 +157,7 @@ describe('InterventionClient', () => {
     });
 
     it('returns history entries where originatorReferenceId is an array', async () => {
-      const client = new InterventionClient({ baseUrl });
+      const client = new InterventionClient(baseUrl);
 
       const entry = makeHistoryObject({ originatorReferenceId: ['ref-1', 'ref-2'] });
       mockFetch.mockResolvedValue(mockResponse({ lines: [entry] }));
@@ -168,7 +168,7 @@ describe('InterventionClient', () => {
     });
 
     it('returns history entries with all known interventionState values', async () => {
-      const client = new InterventionClient({ baseUrl });
+      const client = new InterventionClient(baseUrl);
 
       const entries = Object.values(InterventionState).map((state) => makeHistoryObject({ interventionState: state }));
       mockFetch.mockResolvedValue(mockResponse({ lines: entries }));
@@ -180,7 +180,7 @@ describe('InterventionClient', () => {
     });
 
     it('throws InterventionRequestFailed when the response is not ok (404)', async () => {
-      const client = new InterventionClient({ baseUrl });
+      const client = new InterventionClient(baseUrl);
 
       mockFetch.mockResolvedValue(mockResponse({}, 404));
 
@@ -188,7 +188,7 @@ describe('InterventionClient', () => {
     });
 
     it('throws InterventionRequestFailed when the response is not ok (500)', async () => {
-      const client = new InterventionClient({ baseUrl });
+      const client = new InterventionClient(baseUrl);
 
       mockFetch.mockResolvedValue(mockResponse({}, 500));
 
@@ -196,7 +196,7 @@ describe('InterventionClient', () => {
     });
 
     it('throws InterventionInvalidResponse when the response body is missing the history key', async () => {
-      const client = new InterventionClient({ baseUrl });
+      const client = new InterventionClient(baseUrl);
 
       mockFetch.mockResolvedValue(mockResponse({ unexpected: 'shape' }));
 
@@ -204,7 +204,7 @@ describe('InterventionClient', () => {
     });
 
     it('throws InterventionInvalidResponse when a history entry is missing a required field', async () => {
-      const client = new InterventionClient({ baseUrl });
+      const client = new InterventionClient(baseUrl);
 
       // Missing required `interventionReason`
       const invalidEntry = { sentAt: 1_696_869_003_456, componentId: 'TICF_CRI' };
@@ -214,7 +214,7 @@ describe('InterventionClient', () => {
     });
 
     it('throws InterventionInvalidResponse when a history entry has an invalid interventionName', async () => {
-      const client = new InterventionClient({ baseUrl });
+      const client = new InterventionClient(baseUrl);
 
       const invalidEntry = makeHistoryObject({ interventionName: 'NOT_A_VALID_INTERVENTION' as InterventionName });
       mockFetch.mockResolvedValue(mockResponse({ lines: [invalidEntry] }));
@@ -223,7 +223,7 @@ describe('InterventionClient', () => {
     });
 
     it('throws InterventionInvalidResponse when a history entry has an invalid interventionState', async () => {
-      const client = new InterventionClient({ baseUrl });
+      const client = new InterventionClient(baseUrl);
 
       const invalidEntry = makeHistoryObject({ interventionState: 'NOT_A_VALID_STATE' as InterventionState });
       mockFetch.mockResolvedValue(mockResponse({ lines: [invalidEntry] }));
@@ -233,7 +233,7 @@ describe('InterventionClient', () => {
 
     it('logs the error when the response is not ok', async () => {
       const logger = { error: vi.fn() };
-      const client = new InterventionClient({ baseUrl, logger });
+      const client = new InterventionClient(baseUrl, { logger });
 
       mockFetch.mockResolvedValue(mockResponse({}, 503));
 
@@ -243,7 +243,7 @@ describe('InterventionClient', () => {
 
     it('logs the error when the response body does not match the schema', async () => {
       const logger = { error: vi.fn() };
-      const client = new InterventionClient({ baseUrl, logger });
+      const client = new InterventionClient(baseUrl, { logger });
 
       mockFetch.mockResolvedValue(mockResponse({ unexpected: 'shape' }));
 
@@ -255,7 +255,7 @@ describe('InterventionClient', () => {
     });
 
     it('strips trailing slash from baseUrl on history requests', async () => {
-      const clientWithSlash = new InterventionClient({ baseUrl: 'https://example.com/' });
+      const clientWithSlash = new InterventionClient('https://example.com/');
       mockFetch.mockResolvedValue(mockResponse({ lines: [] }));
 
       await clientWithSlash.getAccountHistory('user-1');

--- a/packages/ais-status-sdk/src/index.ts
+++ b/packages/ais-status-sdk/src/index.ts
@@ -23,10 +23,13 @@ export class InterventionClient implements InterventionClientInterface {
   private readonly baseUrl: string;
   private readonly headers: Record<string, string>;
 
-  constructor(readonly config: InterventionClientConfig) {
-    if (!config.baseUrl) throw new InterventionMissingBaseUrl('Missing required baseUrl');
+  constructor(
+    baseUrl: string | undefined,
+    readonly config?: InterventionClientConfig,
+  ) {
+    if (!baseUrl) throw new InterventionMissingBaseUrl('Missing required baseUrl');
 
-    this.baseUrl = config.baseUrl.replace(/\/$/, '');
+    this.baseUrl = baseUrl.replace(/\/$/, '');
     this.headers = { 'Content-Type': 'application/json' };
   }
 
@@ -34,7 +37,7 @@ export class InterventionClient implements InterventionClientInterface {
     const response = await fetch(url, { headers: this.headers });
 
     if (!response.ok) {
-      this.config.logger?.error(`AIS request failed: ${response.status.toString()} ${response.statusText}`);
+      this.config?.logger?.error(`AIS request failed: ${response.status.toString()} ${response.statusText}`);
       throw new InterventionRequestFailed(`AIS request failed: ${response.status.toString()} ${response.statusText}`);
     }
 
@@ -44,7 +47,7 @@ export class InterventionClient implements InterventionClientInterface {
   }
 
   protected handleInvalidResponse(parseResult: ZodSafeParseError<object>): never {
-    this.config.logger?.error('AIS Invalid Response', { cause: parseResult.error });
+    this.config?.logger?.error('AIS Invalid Response', { cause: parseResult.error });
     throw new InterventionInvalidResponse('AIS Invalid Response', { cause: parseResult.error });
   }
 

--- a/packages/ais-status-sdk/src/types.ts
+++ b/packages/ais-status-sdk/src/types.ts
@@ -54,7 +54,6 @@ interface Logger {
 }
 
 export interface InterventionClientConfig {
-  baseUrl: string | undefined;
   logger?: Logger;
 }
 

--- a/src/frontend/app.ts
+++ b/src/frontend/app.ts
@@ -43,8 +43,7 @@ function formatDate(value: string | number): string {
 }
 
 export function init(
-  interventionClient: InterventionClientInterface = new InterventionClient({
-    baseUrl: statusApiUrl,
+  interventionClient: InterventionClientInterface = new InterventionClient(statusApiUrl, {
     logger,
   }),
   featureFlags: FeatureFlags = FeatureFlagsFromEnvironmentVariables.getInstance(),


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Move `baseUrl` to SDK constructor first parameter

## Why

Always required

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-8547](https://govukverify.atlassian.net/browse/FPAD-8547)

[FPAD-8547]: https://govukverify.atlassian.net/browse/FPAD-8547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ