### PR TITLE
Feature-flags: Fix for incorrect boolean logic

### DIFF
--- a/src/services/feature-flags.ts
+++ b/src/services/feature-flags.ts
@@ -54,5 +54,5 @@ export class FeatureFlagsStub implements FeatureFlags {
 function getEnvironmentVariableAsBoolean(name: string): boolean | undefined {
   const value = process.env[name];
   if (!value) return undefined;
-  return Boolean(value);
+  return value.toLowerCase() === 'true';
 }


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Feature-flags: Fix for incorrect boolean logic

## Why

Otherwise `"false"` doesn't unset the feature flag