### PR TITLE
FPAD-8585: Fix config errors

### DIFF
--- a/src/handlers/interventions-processor.ts
+++ b/src/handlers/interventions-processor.ts
@@ -121,7 +121,7 @@ async function processSQSRecord(
   try {
     await persistInterventionEvents(result, eventName, itemFromDB, interventionEventsService);
   } catch (error) {
-    logger.error('Error caught during fetch intervention events.', { errorMessage: (error as Error).message });
+    logger.error('Error caught while persisting intervention events.', { errorMessage: (error as Error).message });
     addMetric(MetricNames.PERSIST_INTERVENTION_EVENTS_ERROR);
   }
 }

--- a/src/services/persist-intervention-events.ts
+++ b/src/services/persist-intervention-events.ts
@@ -145,7 +145,7 @@ export async function setTtlOnInactiveEvents(
 ) {
   const allEvents = await interventionEventsService.fetchEventsForAccount(accountId);
   const now = getCurrentTimestamp();
-  const ttl = now.seconds + appConfig.maxRetentionSeconds;
+  const ttl = now.seconds + appConfig.historyRetentionSeconds;
 
   const eventsNeedingTtl = allEvents.filter(
     (event) => closedInterventionNames.includes(event.interventionName) && !event.ttl,

--- a/src/services/test/persist-intervention-events.test.ts
+++ b/src/services/test/persist-intervention-events.test.ts
@@ -276,7 +276,7 @@ describe('persistIgnoredInterventionEvent', () => {
 
 describe('setTtlOnInactiveEvents', () => {
   const FIXED_TIMESTAMP = 1781253284370;
-  const EXPECTED_TTL = Math.floor(FIXED_TIMESTAMP / 1000) + 12345;
+  const EXPECTED_TTL = Math.floor(FIXED_TIMESTAMP / 1000) + 63072000;
 
   beforeAll(() => {
     vi.useFakeTimers();


### PR DESCRIPTION
## What

Use `historyRetentionSeconds` when setting TTLs on intervention event rows instead of `maxRetentionSeconds`, which is used in the deletion processor and isn't available in the intervention processor.

## Why

This is causing our history table to be wrong.

## Notes

There's probably more work here around passing in only the config that's needed to a given handler function, and possibly splitting this actual value out into a third variable (even if it just inherits from this for now)

### Issue tracking

- [FPAD-8585](https://govukverify.atlassian.net/browse/FPAD-8585)


[FPAD-8585]: https://govukverify.atlassian.net/browse/FPAD-8585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ