### PR TITLE
FPAD-8586: Exclude ais-status-sdk integration-tests folder from coverage report

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
       reporter: ['text', 'lcov'],
       reportsDirectory: './coverage',
     },
-    exclude: ['**/node_modules/**', 'src/contract-testing/**', '.stryker-tmp/**', 'src/scripts/**'],
+    exclude: ['**/node_modules/**', 'src/contract-testing/**', '.stryker-tmp/**', 'src/scripts/**', 'packages/ais-status-sdk/integration-tests/**'],
     env: {
       CLOUDWATCH_METRICS_NAMESPACE: 'test_namespace',
       METRIC_SERVICE_NAME: 'test',


### PR DESCRIPTION


<!-- https://jml.io/posts/what-why-notes/ -->

## What
Exclude the contents of `packages/ais-status-sdk/integration-tests/` from coverage reports when `npm test` is run. The `test-server.ts` file should be excluded as this is simply a test harness, rather than code that needs testing.

## Why
We only want to show relevant files in the coverage report

## Notes

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-8586](https://govukverify.atlassian.net/browse/FPAD-8586)


[FPAD-8586]: https://govukverify.atlassian.net/browse/FPAD-8586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ