### PR TITLE
FPAD-8587: Extend app config class to return static config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -62,6 +62,7 @@ export default defineConfig(
       'unicorn/prefer-spread': ['error'],
       'unicorn/prefer-ternary': ['error'],
       'unicorn/no-unreadable-new-expression': ['off'],
+      'unicorn/consistent-boolean-name': ['off'],
       'unicorn/consistent-class-member-order': ['off'],
       'unicorn/name-replacements': ['off'],
       'tsdoc/syntax': ['error'],

--- a/src/commons/metrics.ts
+++ b/src/commons/metrics.ts
@@ -1,8 +1,8 @@
 import { AppConfigService } from '../services/app-config-service';
 import { Metrics, MetricUnit } from '@aws-lambda-powertools/metrics';
 
-const namespace = AppConfigService.getInstance().cloudWatchMetricsWorkSpace ?? 'unset';
-const service = AppConfigService.getInstance().metricServiceName ?? 'unset';
+const namespace = AppConfigService.getInstance().cloudWatchMetricsWorkSpace;
+const service = AppConfigService.getInstance().metricServiceName;
 
 /**
  * Metric utility which instantiate a Metrics object from aws-lambda-powertools/metrics.

--- a/src/commons/metrics.ts
+++ b/src/commons/metrics.ts
@@ -1,8 +1,8 @@
 import { AppConfigService } from '../services/app-config-service';
 import { Metrics, MetricUnit } from '@aws-lambda-powertools/metrics';
 
-const namespace = AppConfigService.getInstance().cloudWatchMetricsWorkSpace;
-const service = AppConfigService.getInstance().metricServiceName;
+const namespace = AppConfigService.getInstance().cloudWatchMetricsWorkSpace ?? 'unset';
+const service = AppConfigService.getInstance().metricServiceName ?? 'unset';
 
 /**
  * Metric utility which instantiate a Metrics object from aws-lambda-powertools/metrics.

--- a/src/services/app-config-service.ts
+++ b/src/services/app-config-service.ts
@@ -152,11 +152,12 @@ export class AppConfigService {
     return this.instance;
   }
 
-  public get metricServiceName(): string | undefined {
+  public get metricServiceName(): string {
     try {
       return this.validateConfiguration('METRIC_SERVICE_NAME');
     } catch {
       logger.warn('Unable to retrieve metrics config, METRIC_SERVICE_NAME not set');
+      return 'unset';
     }
   }
 
@@ -168,11 +169,12 @@ export class AppConfigService {
     return this.validateConfiguration('INTERVENTION_EVENTS_TABLE_NAME');
   }
 
-  public get cloudWatchMetricsWorkSpace(): string | undefined {
+  public get cloudWatchMetricsWorkSpace(): string {
     try {
       return this.validateConfiguration('CLOUDWATCH_METRICS_NAMESPACE');
     } catch {
       logger.warn('Unable to retrieve metrics config, CLOUDWATCH_METRICS_NAMESPACE not set');
+      return 'unset';
     }
   }
 

--- a/src/services/app-config-service.ts
+++ b/src/services/app-config-service.ts
@@ -19,8 +19,12 @@ export class AppConfigService {
     return this.instance;
   }
 
-  public get metricServiceName(): string {
-    return this.validateConfiguration('METRIC_SERVICE_NAME');
+  public get metricServiceName(): string | undefined {
+    try {
+      return this.validateConfiguration('METRIC_SERVICE_NAME');
+    } catch {
+      logger.warn('Unable to retrieve metrics config, METRIC_SERVICE_NAME not set');
+    }
   }
 
   public get tableName(): string {
@@ -31,9 +35,14 @@ export class AppConfigService {
     return this.validateConfiguration('INTERVENTION_EVENTS_TABLE_NAME');
   }
 
-  public get cloudWatchMetricsWorkSpace(): string {
-    return this.validateConfiguration('CLOUDWATCH_METRICS_NAMESPACE');
+  public get cloudWatchMetricsWorkSpace(): string | undefined {
+    try {
+      return this.validateConfiguration('CLOUDWATCH_METRICS_NAMESPACE');
+    } catch {
+      logger.warn('Unable to retrieve metrics config, CLOUDWATCH_METRICS_NAMESPACE not set');
+    }
   }
+
   public get awsRegion(): string {
     return this.validateConfiguration('AWS_REGION');
   }

--- a/src/services/app-config-service.ts
+++ b/src/services/app-config-service.ts
@@ -2,11 +2,144 @@ import { InvalidEnvironmentVariableError } from '../data-types/errors';
 import logger from '../commons/logger';
 import { LOGS_PREFIX_INVALID_CONFIG } from '../data-types/constants';
 
+interface ConfigDefinition {
+  envVar: string;
+  type: string;
+  optional?: boolean;
+}
+
 /**
- * A service for setting the app configuration.
+ * Maps config names to their corresponding environment variable and validation type.
+ *
+ * - `envVar`: the environment variable name to read from process.env.
+ * - `type`: determines how the value is validated ('string', 'number', or 'url').
+ * - `optional`: if true, returns undefined with a warning instead of throwing when the env var is missing.
+ *
+ * To add a new config value, add an entry here and it will be available via getConfigObject.
+ * Uses `satisfies` (not a type annotation) to preserve literal types for the conditional type inference.
+ */
+const CONFIG_ENVIRONMENT_MAPPING = {
+  metricServiceName: {
+    envVar: 'METRIC_SERVICE_NAME',
+    type: 'string' as const,
+    optional: true,
+  },
+  tableName: {
+    envVar: 'TABLE_NAME',
+    type: 'string' as const,
+  },
+  interventionEventsTableName: {
+    envVar: 'INTERVENTION_EVENTS_TABLE_NAME',
+    type: 'string' as const,
+  },
+  cloudWatchMetricsWorkSpace: {
+    envVar: 'CLOUDWATCH_METRICS_NAMESPACE',
+    type: 'string' as const,
+    optional: true,
+  },
+  awsRegion: {
+    envVar: 'AWS_REGION',
+    type: 'string' as const,
+  },
+  maxRetentionSeconds: {
+    envVar: 'DELETED_ACCOUNT_RETENTION_SECONDS',
+    type: 'number' as const,
+  },
+  txmaEgressQueueUrl: {
+    envVar: 'TXMA_QUEUE_URL',
+    type: 'url' as const,
+  },
+  historyRetentionSeconds: {
+    envVar: 'HISTORY_RETENTION_SECONDS',
+    type: 'number' as const,
+  },
+} satisfies Record<string, ConfigDefinition>;
+
+/** The valid keys of CONFIG_ENVIRONMENT_MAPPING, used to constrain getConfigObject input. */
+type ConfigName = keyof typeof CONFIG_ENVIRONMENT_MAPPING;
+
+/** Resolves whether a config entry is optional (returns undefined on failure instead of throwing). */
+type IsOptional<T extends ConfigName> = (typeof CONFIG_ENVIRONMENT_MAPPING)[T] extends { optional: true }
+  ? true
+  : false;
+
+/**
+ * Maps a config entry to its runtime value type.
+ * - 'number' entries resolve to `number` (or `number | undefined` if optional).
+ * - 'string' and 'url' entries resolve to `string` (or `string | undefined` if optional).
+ */
+type ConfigValueType<T extends ConfigName> = (typeof CONFIG_ENVIRONMENT_MAPPING)[T]['type'] extends 'number'
+  ? IsOptional<T> extends true
+    ? number | undefined
+    : number
+  : IsOptional<T> extends true
+    ? string | undefined
+    : string;
+
+/**
+ * The return type of getConfigObject — an object keyed by the requested config names,
+ * with each value typed according to its entry in CONFIG_ENVIRONMENT_MAPPING.
+ */
+type ConfigObject<T extends ConfigName[]> = {
+  [K in T[number]]: ConfigValueType<K>;
+};
+
+/**
+ * Service for accessing validated application configuration from environment variables.
+ * Use getConfigObject to retrieve multiple config values as a typed object,
+ * or the individual getters for backwards compatibility.
  */
 export class AppConfigService {
   private static instance: AppConfigService;
+
+  /**
+   * Returns a typed object containing the requested config values, validated and parsed
+   * according to their type definitions in CONFIG_ENVIRONMENT_MAPPING.
+   *
+   * @param keys - an array of config names to retrieve
+   * @returns an object keyed by the requested names, with values typed as string, number, or undefined (for optional configs)
+   * @throws {@link InvalidEnvironmentVariableError} if a required config value is missing or invalid
+   *
+   * @example
+   * const config = AppConfigService.getInstance().getConfigObject(['tableName', 'maxRetentionSeconds']);
+   * // config.tableName → string
+   * // config.maxRetentionSeconds → number
+   */
+  public getConfigObject<T extends ConfigName[]>(keys: [...T]): ConfigObject<T> {
+    const result = {} as ConfigObject<T>;
+    for (const key of keys) {
+      const config = CONFIG_ENVIRONMENT_MAPPING[key];
+      const optional = 'optional' in config ? config.optional : false;
+      (result as Record<string, unknown>)[key] = this.resolveConfigValue(config.envVar, config.type, optional);
+    }
+    return result;
+  }
+
+  private resolveConfigValue(
+    envVar: string,
+    type: 'string' | 'number' | 'url',
+    optional: boolean,
+  ): string | number | undefined {
+    try {
+      switch (type) {
+        case 'number': {
+          return this.validateNumberEnvVars(envVar);
+        }
+        case 'url': {
+          return this.validateIsHTTPSUrl(envVar);
+        }
+        case 'string': {
+          return this.validateConfiguration(envVar);
+        }
+      }
+    } catch (error) {
+      if (optional) {
+        logger.warn(`Unable to retrieve config, ${envVar} not set`);
+        return undefined;
+      }
+      throw error;
+    }
+  }
 
   /**
    * A static method which creates a single instance of the AppConfigService class and returns it.

--- a/src/services/test/app-config-service.test.ts
+++ b/src/services/test/app-config-service.test.ts
@@ -49,15 +49,12 @@ describe('AppConfigService', () => {
     expect(logger.error).toHaveBeenCalledWith(expectedMessage);
   });
 
-  it('should throw an error if the environment variable CLOUDWATCH_METRICS_NAMESPACE is equal to an empty string', () => {
+  it('should return undefined if the environment variable CLOUDWATCH_METRICS_NAMESPACE is equal to an empty string', () => {
     vi.stubEnv('CLOUDWATCH_METRICS_NAMESPACE', '');
     const appConfig = AppConfigService.getInstance();
-    const expectedMessage = 'Invalid configuration - Environment variable CLOUDWATCH_METRICS_NAMESPACE is not defined.';
-    expect(() => appConfig.cloudWatchMetricsWorkSpace).toThrow(new InvalidEnvironmentVariableError(expectedMessage));
+    expect(appConfig.cloudWatchMetricsWorkSpace).toBeUndefined();
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(logger.error).toHaveBeenCalledTimes(1);
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(logger.error).toHaveBeenCalledWith(expectedMessage);
+    expect(logger.warn).toHaveBeenCalledWith('Unable to retrieve metrics config, CLOUDWATCH_METRICS_NAMESPACE not set');
   });
 
   it('should throw an error if the environment variable TXMA_QUEUE_URL is not a url', () => {
@@ -92,5 +89,105 @@ describe('AppConfigService', () => {
     expect(logger.error).toHaveBeenCalledTimes(1);
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(logger.error).toHaveBeenCalledWith(expectedMessage);
+  });
+
+  describe('getConfigObject', () => {
+    it('should return an object with the requested string config values', () => {
+      vi.stubEnv('TABLE_NAME', 'my-table');
+      vi.stubEnv('AWS_REGION', 'eu-west-2');
+      const appConfig = AppConfigService.getInstance();
+      const config = appConfig.getConfigObject(['tableName', 'awsRegion']);
+      expect(config).toEqual({
+        tableName: 'my-table',
+        awsRegion: 'eu-west-2',
+      });
+    });
+
+    it('should return an object with number config values correctly parsed', () => {
+      vi.stubEnv('DELETED_ACCOUNT_RETENTION_SECONDS', '86400');
+      vi.stubEnv('HISTORY_RETENTION_SECONDS', '172800');
+      const appConfig = AppConfigService.getInstance();
+      const config = appConfig.getConfigObject(['maxRetentionSeconds', 'historyRetentionSeconds']);
+      expect(config).toEqual({
+        maxRetentionSeconds: 86400,
+        historyRetentionSeconds: 172800,
+      });
+    });
+
+    it('should return an object with url config values validated', () => {
+      vi.stubEnv('TXMA_QUEUE_URL', 'https://sqs.eu-west-2.amazonaws.com/123456789/MyQueue');
+      const appConfig = AppConfigService.getInstance();
+      const config = appConfig.getConfigObject(['txmaEgressQueueUrl']);
+      expect(config).toEqual({
+        txmaEgressQueueUrl: 'https://sqs.eu-west-2.amazonaws.com/123456789/MyQueue',
+      });
+    });
+
+    it('should return an object with mixed config types', () => {
+      vi.stubEnv('TABLE_NAME', 'my-table');
+      vi.stubEnv('DELETED_ACCOUNT_RETENTION_SECONDS', '86400');
+      vi.stubEnv('TXMA_QUEUE_URL', 'https://sqs.eu-west-2.amazonaws.com/123456789/MyQueue');
+      const appConfig = AppConfigService.getInstance();
+      const config = appConfig.getConfigObject(['tableName', 'maxRetentionSeconds', 'txmaEgressQueueUrl']);
+      expect(config).toEqual({
+        tableName: 'my-table',
+        maxRetentionSeconds: 86400,
+        txmaEgressQueueUrl: 'https://sqs.eu-west-2.amazonaws.com/123456789/MyQueue',
+      });
+    });
+
+    it('should return undefined for optional config values when env var is not set', () => {
+      vi.stubEnv('METRIC_SERVICE_NAME', '');
+      vi.stubEnv('TABLE_NAME', 'my-table');
+      const appConfig = AppConfigService.getInstance();
+      const config = appConfig.getConfigObject(['metricServiceName', 'tableName']);
+      expect(config).toEqual({
+        metricServiceName: undefined,
+        tableName: 'my-table',
+      });
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(logger.warn).toHaveBeenCalledWith('Unable to retrieve config, METRIC_SERVICE_NAME not set');
+    });
+
+    it('should return undefined for optional cloudWatchMetricsWorkSpace when env var is not set', () => {
+      vi.stubEnv('CLOUDWATCH_METRICS_NAMESPACE', '');
+      const appConfig = AppConfigService.getInstance();
+      const config = appConfig.getConfigObject(['cloudWatchMetricsWorkSpace']);
+      expect(config).toEqual({
+        cloudWatchMetricsWorkSpace: undefined,
+      });
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(logger.warn).toHaveBeenCalledWith('Unable to retrieve config, CLOUDWATCH_METRICS_NAMESPACE not set');
+    });
+
+    it('should return optional config values when env var is set', () => {
+      vi.stubEnv('METRIC_SERVICE_NAME', 'my-service');
+      vi.stubEnv('CLOUDWATCH_METRICS_NAMESPACE', 'my-namespace');
+      const appConfig = AppConfigService.getInstance();
+      const config = appConfig.getConfigObject(['metricServiceName', 'cloudWatchMetricsWorkSpace']);
+      expect(config).toEqual({
+        metricServiceName: 'my-service',
+        cloudWatchMetricsWorkSpace: 'my-namespace',
+      });
+    });
+
+    it('should throw an error for required config values when env var is not set', () => {
+      vi.stubEnv('TABLE_NAME', '');
+      const appConfig = AppConfigService.getInstance();
+      expect(() => appConfig.getConfigObject(['tableName'])).toThrow(InvalidEnvironmentVariableError);
+    });
+
+    it('should throw an error when a url config value is not a valid HTTPS URL', () => {
+      // eslint-disable-next-line unicorn/prefer-https
+      vi.stubEnv('TXMA_QUEUE_URL', 'http://not-https.com');
+      const appConfig = AppConfigService.getInstance();
+      expect(() => appConfig.getConfigObject(['txmaEgressQueueUrl'])).toThrow(InvalidEnvironmentVariableError);
+    });
+
+    it('should throw an error when a number config value is not a valid number', () => {
+      vi.stubEnv('DELETED_ACCOUNT_RETENTION_SECONDS', 'not-a-number');
+      const appConfig = AppConfigService.getInstance();
+      expect(() => appConfig.getConfigObject(['maxRetentionSeconds'])).toThrow(InvalidEnvironmentVariableError);
+    });
   });
 });

--- a/src/services/test/app-config-service.test.ts
+++ b/src/services/test/app-config-service.test.ts
@@ -52,7 +52,7 @@ describe('AppConfigService', () => {
   it('should return undefined if the environment variable CLOUDWATCH_METRICS_NAMESPACE is equal to an empty string', () => {
     vi.stubEnv('CLOUDWATCH_METRICS_NAMESPACE', '');
     const appConfig = AppConfigService.getInstance();
-    expect(appConfig.cloudWatchMetricsWorkSpace).toBeUndefined();
+    expect(appConfig.cloudWatchMetricsWorkSpace).toEqual('unset');
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(logger.warn).toHaveBeenCalledWith('Unable to retrieve metrics config, CLOUDWATCH_METRICS_NAMESPACE not set');
   });


### PR DESCRIPTION
## What

Extends the app config class to create a static config object. The config object only contains config which you ask for, and the output is narrowly typed

## Why

The underlying config variables on a Lambda don't change after it's published ([see the docs](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html)) so there's no point in us referring to and validating config on every read. Instead I've extended the app-config class to let us build a statically typed config object at start time, checking and validating all the types then. We can deprecate the individual function calls for config variables as we start to roll this out on the handlers.

This has a few other benefits:

- Handlers and the functions they call can take static config objects so we don't need environment variables for testing, aside from for testing this stuff.
- We can only build the config with the values we need, so the config for a given handler is "safe".
- The config schema is totally data-driven, so to add a new config variable you don't need to add any code (assuming the type of the variable you're adding is already handled).

## Notes

### Issue tracking

- [FPAD-8587](https://govukverify.atlassian.net/browse/FPAD-8587)


[FPAD-8587]: https://govukverify.atlassian.net/browse/FPAD-8587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ