### PR TITLE
FPAD-8587: Explicit intervention processor config

### DIFF
--- a/src/handlers/interventions-processor-handler.ts
+++ b/src/handlers/interventions-processor-handler.ts
@@ -7,11 +7,21 @@ import { getPersistentAccountStatusService } from '../tables/account-status';
 import { processInterventions } from './interventions-processor';
 import { AccountStateEngine } from '../services/account-states/account-state-engine';
 import { AppConfigService } from '../services/app-config-service';
+import tracer from '../commons/tracer';
+import { NodeHttpHandler } from '@smithy/node-http-handler';
+import { SQSClient } from '@aws-sdk/client-sqs';
 
 const accountStatusService = getPersistentAccountStatusService();
 const interventionEventsService = getPersistentInterventionEventsService();
 const accountStateEngine = AccountStateEngine.getInstance();
-const config = AppConfigService.getInstance().getConfigObject(['historyRetentionSeconds']);
+const config = AppConfigService.getInstance().getConfigObject(['historyRetentionSeconds', 'txmaEgressQueueUrl', 'awsRegion']);
+const sqsClient = tracer.captureAWSv3Client(
+  new SQSClient({
+    region: config.awsRegion,
+    maxAttempts: 2,
+    requestHandler: new NodeHttpHandler({ requestTimeout: 5000 }),
+  }),
+);
 
 /**
  * Main handler method for Intervention Processor Lambda
@@ -25,7 +35,7 @@ export async function handler(
   context: Context,
 ): Promise<SQSBatchResponse> {
   logger.addContext(context);
-  return processInterventions(event, accountStatusService, interventionEventsService, accountStateEngine, config);
+  return processInterventions(event, accountStatusService, interventionEventsService, accountStateEngine, config, sqsClient);
 }
 
 /* istanbul ignore stop */

--- a/src/handlers/interventions-processor-handler.ts
+++ b/src/handlers/interventions-processor-handler.ts
@@ -6,10 +6,12 @@ import { getPersistentInterventionEventsService } from '../tables/intervention-e
 import { getPersistentAccountStatusService } from '../tables/account-status';
 import { processInterventions } from './interventions-processor';
 import { AccountStateEngine } from '../services/account-states/account-state-engine';
+import { AppConfigService } from '../services/app-config-service';
 
 const accountStatusService = getPersistentAccountStatusService();
 const interventionEventsService = getPersistentInterventionEventsService();
 const accountStateEngine = AccountStateEngine.getInstance();
+const config = AppConfigService.getInstance().getConfigObject(['historyRetentionSeconds']);
 
 /**
  * Main handler method for Intervention Processor Lambda
@@ -23,11 +25,7 @@ export async function handler(
   context: Context,
 ): Promise<SQSBatchResponse> {
   logger.addContext(context);
-  return processInterventions(event, {
-    accountStatusService,
-    interventionEventsService,
-    accountStateEngine,
-  });
+  return processInterventions(event, accountStatusService, interventionEventsService, accountStateEngine, config);
 }
 
 /* istanbul ignore stop */

--- a/src/handlers/interventions-processor-handler.ts
+++ b/src/handlers/interventions-processor-handler.ts
@@ -35,7 +35,7 @@ export async function handler(
   context: Context,
 ): Promise<SQSBatchResponse> {
   logger.addContext(context);
-  return processInterventions(event, accountStatusService, interventionEventsService, accountStateEngine, config, sqsClient);
+  return processInterventions(event, { accountStatusService, interventionEventsService, accountStateEngine, config, sqsClient });
 }
 
 /* istanbul ignore stop */

--- a/src/handlers/interventions-processor.ts
+++ b/src/handlers/interventions-processor.ts
@@ -125,7 +125,7 @@ async function processSQSRecord(
 
   updateAccountStateCountMetric(currentAccountState, statusResult.stateResult);
   addMetric(MetricNames.INTERVENTION_EVENT_APPLIED, [], 1, { eventName });
-  await sendAuditEvent('AIS_EVENT_TRANSITION_APPLIED', eventName, result, statusResult, sqsClient, txmaEgressQueueUrl);
+  await sendAuditEvent('AIS_EVENT_TRANSITION_APPLIED', eventName, result, sqsClient, txmaEgressQueueUrl, statusResult);
 
   try {
     await persistInterventionEvents(result, eventName, itemFromDB, interventionEventsService, historyRetentionSeconds);
@@ -162,7 +162,7 @@ async function applyEventTransition(
     return accountStateEngine.applyEventTransition(event, initialState, interventionName);
   } catch (error) {
     if (error instanceof StateTransitionError) {
-      await sendAuditEvent('AIS_EVENT_TRANSITION_IGNORED', error.transition, result, error.output, sqsClient, txmaEgressQueueUrl);
+      await sendAuditEvent('AIS_EVENT_TRANSITION_IGNORED', error.transition, result, sqsClient, txmaEgressQueueUrl, error.output);
       try {
         await persistIgnoredInterventionEvent(result, event, initialState, interventionEventsService);
       } catch (error) {
@@ -236,11 +236,11 @@ async function validateAccountIsNotDeleted(
 
   logger.warn(`${LOGS_PREFIX_SENSITIVE_INFO} user ${userId} account has been deleted.`);
   addMetric(MetricNames.ACCOUNT_IS_MARKED_AS_DELETED);
-  await sendAuditEvent('AIS_EVENT_IGNORED_ACCOUNT_DELETED', intervention, record, {
+  await sendAuditEvent('AIS_EVENT_IGNORED_ACCOUNT_DELETED', intervention, record, sqsClient, txmaEgressQueueUrl, {
     stateResult: initialState,
     interventionName: AISInterventionTypes.AIS_NO_INTERVENTION,
     nextAllowableInterventions: AccountStateEngine.getInstance().determineNextAllowableInterventions(initialState),
-  }, sqsClient, txmaEgressQueueUrl);
+  });
   throw new ValidationError('Account is marked as deleted.');
 }
 

--- a/src/handlers/interventions-processor.ts
+++ b/src/handlers/interventions-processor.ts
@@ -28,13 +28,17 @@ import { InterventionEventsService } from '../tables/intervention-events';
 import { AccountStatusService } from '../tables/account-status';
 import { SQSClient } from '@aws-sdk/client-sqs';
 
+export interface ProcessInterventionsArgs {
+  accountStatusService: AccountStatusService;
+  interventionEventsService: InterventionEventsService;
+  accountStateEngine: AccountStateEngine;
+  config: { historyRetentionSeconds: number; txmaEgressQueueUrl: string };
+  sqsClient: SQSClient;
+}
+
 export async function processInterventions(
   event: SQSEvent,
-  accountStatusService: AccountStatusService,
-  interventionEventsService: InterventionEventsService,
-  accountStateEngine: AccountStateEngine,
-  config: { historyRetentionSeconds: number; txmaEgressQueueUrl: string },
-  sqsClient: SQSClient,
+  { accountStatusService, interventionEventsService, accountStateEngine, config, sqsClient }: ProcessInterventionsArgs,
 ): Promise<SQSBatchResponse> {
   if (event.Records.length === 0) {
     logger.warn('Received no records.');

--- a/src/handlers/interventions-processor.ts
+++ b/src/handlers/interventions-processor.ts
@@ -26,13 +26,15 @@ import { InterventionEventMessage } from '../contracts/intervention-events';
 import persistInterventionEvents, { persistIgnoredInterventionEvent } from '../services/persist-intervention-events';
 import { InterventionEventsService } from '../tables/intervention-events';
 import { AccountStatusService } from '../tables/account-status';
+import { SQSClient } from '@aws-sdk/client-sqs';
 
 export async function processInterventions(
   event: SQSEvent,
   accountStatusService: AccountStatusService,
   interventionEventsService: InterventionEventsService,
   accountStateEngine: AccountStateEngine,
-  config: { historyRetentionSeconds: number },
+  config: { historyRetentionSeconds: number; txmaEgressQueueUrl: string },
+  sqsClient: SQSClient,
 ): Promise<SQSBatchResponse> {
   if (event.Records.length === 0) {
     logger.warn('Received no records.');
@@ -47,7 +49,7 @@ export async function processInterventions(
 
   const promiseArray = event.Records.map(async (record: SQSRecord) => {
     try {
-      await processSQSRecord(record, accountStatusService, interventionEventsService, accountStateEngine, config.historyRetentionSeconds);
+      await processSQSRecord(record, accountStatusService, interventionEventsService, accountStateEngine, config.historyRetentionSeconds, sqsClient, config.txmaEgressQueueUrl);
     } catch (error: unknown) {
       const itemIdentifier = handleError(error, record);
       if (itemIdentifier) itemFailures.push({ itemIdentifier });
@@ -73,12 +75,14 @@ async function processSQSRecord(
   interventionEventsService: InterventionEventsService,
   accountStateEngine: AccountStateEngine,
   historyRetentionSeconds: number,
+  sqsClient: SQSClient,
+  txmaEgressQueueUrl: string,
 ) {
   const currentTimestamp = getCurrentTimestamp();
 
   const recordBody = attemptToParseJson(record.body);
 
-  const { result, eventName } = await validateRecord(recordBody, accountStateEngine);
+  const { result, eventName } = await validateRecord(recordBody, accountStateEngine, sqsClient, txmaEgressQueueUrl);
 
   const userId = result.user.user_id;
 
@@ -89,8 +93,8 @@ async function processSQSRecord(
   const currentAccountState = formCurrentAccountStateObject(itemFromDB);
 
   if (itemFromDB) {
-    await validateAccountIsNotDeleted(eventName, userId, result, currentAccountState, itemFromDB);
-    await validateEventIsNotStale(eventName, result, currentAccountState, itemFromDB);
+    await validateAccountIsNotDeleted(eventName, userId, result, currentAccountState, itemFromDB, sqsClient, txmaEgressQueueUrl);
+    await validateEventIsNotStale(eventName, result, currentAccountState, itemFromDB, sqsClient, txmaEgressQueueUrl);
   }
 
   const statusResult = await applyEventTransition(
@@ -100,6 +104,8 @@ async function processSQSRecord(
     result,
     interventionEventsService,
     accountStateEngine,
+    sqsClient,
+    txmaEgressQueueUrl,
   );
 
   await accountStatusService.updateUserStatus(
@@ -119,7 +125,7 @@ async function processSQSRecord(
 
   updateAccountStateCountMetric(currentAccountState, statusResult.stateResult);
   addMetric(MetricNames.INTERVENTION_EVENT_APPLIED, [], 1, { eventName });
-  await sendAuditEvent('AIS_EVENT_TRANSITION_APPLIED', eventName, result, statusResult);
+  await sendAuditEvent('AIS_EVENT_TRANSITION_APPLIED', eventName, result, statusResult, sqsClient, txmaEgressQueueUrl);
 
   try {
     await persistInterventionEvents(result, eventName, itemFromDB, interventionEventsService, historyRetentionSeconds);
@@ -129,12 +135,12 @@ async function processSQSRecord(
   }
 }
 
-async function validateRecord(recordBody: unknown, accountStateEngine: AccountStateEngine) {
+async function validateRecord(recordBody: unknown, accountStateEngine: AccountStateEngine, sqsClient: SQSClient, txmaEgressQueueUrl: string) {
   const result = validateEventAgainstSchema(recordBody);
   const eventName = getEventName(result, accountStateEngine);
   logger.debug('Intervention received.', { intervention: eventName });
   validateIfIdentityAcquired(result);
-  await validateEventIsNotInFuture(eventName, result);
+  await validateEventIsNotInFuture(eventName, result, sqsClient, txmaEgressQueueUrl);
 
   return {
     result,
@@ -149,12 +155,14 @@ async function applyEventTransition(
   result: InterventionEventMessage,
   interventionEventsService: InterventionEventsService,
   accountStateEngine: AccountStateEngine,
+  sqsClient: SQSClient,
+  txmaEgressQueueUrl: string,
 ) {
   try {
     return accountStateEngine.applyEventTransition(event, initialState, interventionName);
   } catch (error) {
     if (error instanceof StateTransitionError) {
-      await sendAuditEvent('AIS_EVENT_TRANSITION_IGNORED', error.transition, result, error.output);
+      await sendAuditEvent('AIS_EVENT_TRANSITION_IGNORED', error.transition, result, error.output, sqsClient, txmaEgressQueueUrl);
       try {
         await persistIgnoredInterventionEvent(result, event, initialState, interventionEventsService);
       } catch (error) {
@@ -221,6 +229,8 @@ async function validateAccountIsNotDeleted(
   record: InterventionEventMessage,
   initialState: StateDetails,
   itemFromDB: DynamoDBStateResult,
+  sqsClient: SQSClient,
+  txmaEgressQueueUrl: string,
 ) {
   if (!itemFromDB.isAccountDeleted) return;
 
@@ -230,7 +240,7 @@ async function validateAccountIsNotDeleted(
     stateResult: initialState,
     interventionName: AISInterventionTypes.AIS_NO_INTERVENTION,
     nextAllowableInterventions: AccountStateEngine.getInstance().determineNextAllowableInterventions(initialState),
-  });
+  }, sqsClient, txmaEgressQueueUrl);
   throw new ValidationError('Account is marked as deleted.');
 }
 

--- a/src/handlers/interventions-processor.ts
+++ b/src/handlers/interventions-processor.ts
@@ -26,15 +26,13 @@ import { InterventionEventMessage } from '../contracts/intervention-events';
 import persistInterventionEvents, { persistIgnoredInterventionEvent } from '../services/persist-intervention-events';
 import { InterventionEventsService } from '../tables/intervention-events';
 import { AccountStatusService } from '../tables/account-status';
-export interface Config {
-  accountStatusService: AccountStatusService,
-  interventionEventsService: InterventionEventsService,
-  accountStateEngine: AccountStateEngine,
-}
 
 export async function processInterventions(
   event: SQSEvent,
-  config: Config,
+  accountStatusService: AccountStatusService,
+  interventionEventsService: InterventionEventsService,
+  accountStateEngine: AccountStateEngine,
+  config: { historyRetentionSeconds: number },
 ): Promise<SQSBatchResponse> {
   if (event.Records.length === 0) {
     logger.warn('Received no records.');
@@ -49,7 +47,7 @@ export async function processInterventions(
 
   const promiseArray = event.Records.map(async (record: SQSRecord) => {
     try {
-      await processSQSRecord(record, config.accountStatusService, config.interventionEventsService, config.accountStateEngine);
+      await processSQSRecord(record, accountStatusService, interventionEventsService, accountStateEngine, config.historyRetentionSeconds);
     } catch (error: unknown) {
       const itemIdentifier = handleError(error, record);
       if (itemIdentifier) itemFailures.push({ itemIdentifier });
@@ -74,6 +72,7 @@ async function processSQSRecord(
   accountStatusService: AccountStatusService,
   interventionEventsService: InterventionEventsService,
   accountStateEngine: AccountStateEngine,
+  historyRetentionSeconds: number,
 ) {
   const currentTimestamp = getCurrentTimestamp();
 
@@ -123,7 +122,7 @@ async function processSQSRecord(
   await sendAuditEvent('AIS_EVENT_TRANSITION_APPLIED', eventName, result, statusResult);
 
   try {
-    await persistInterventionEvents(result, eventName, itemFromDB, interventionEventsService);
+    await persistInterventionEvents(result, eventName, itemFromDB, interventionEventsService, historyRetentionSeconds);
   } catch (error) {
     logger.error('Error caught while persisting intervention events.', { errorMessage: (error as Error).message });
     addMetric(MetricNames.PERSIST_INTERVENTION_EVENTS_ERROR);

--- a/src/handlers/interventions-processor.ts
+++ b/src/handlers/interventions-processor.ts
@@ -53,7 +53,15 @@ export async function processInterventions(
 
   const promiseArray = event.Records.map(async (record: SQSRecord) => {
     try {
-      await processSQSRecord(record, accountStatusService, interventionEventsService, accountStateEngine, config.historyRetentionSeconds, sqsClient, config.txmaEgressQueueUrl);
+      await processSQSRecord(
+        record,
+        accountStatusService,
+        interventionEventsService,
+        accountStateEngine,
+        config.historyRetentionSeconds,
+        sqsClient,
+        config.txmaEgressQueueUrl,
+      );
     } catch (error: unknown) {
       const itemIdentifier = handleError(error, record);
       if (itemIdentifier) itemFailures.push({ itemIdentifier });
@@ -97,7 +105,15 @@ async function processSQSRecord(
   const currentAccountState = formCurrentAccountStateObject(itemFromDB);
 
   if (itemFromDB) {
-    await validateAccountIsNotDeleted(eventName, userId, result, currentAccountState, itemFromDB, sqsClient, txmaEgressQueueUrl);
+    await validateAccountIsNotDeleted(
+      eventName,
+      userId,
+      result,
+      currentAccountState,
+      itemFromDB,
+      sqsClient,
+      txmaEgressQueueUrl,
+    );
     await validateEventIsNotStale(eventName, result, currentAccountState, itemFromDB, sqsClient, txmaEgressQueueUrl);
   }
 
@@ -108,8 +124,10 @@ async function processSQSRecord(
     result,
     interventionEventsService,
     accountStateEngine,
-    sqsClient,
-    txmaEgressQueueUrl,
+    {
+      sqsClient,
+      txmaEgressQueueUrl,
+    },
   );
 
   await accountStatusService.updateUserStatus(
@@ -139,7 +157,12 @@ async function processSQSRecord(
   }
 }
 
-async function validateRecord(recordBody: unknown, accountStateEngine: AccountStateEngine, sqsClient: SQSClient, txmaEgressQueueUrl: string) {
+async function validateRecord(
+  recordBody: unknown,
+  accountStateEngine: AccountStateEngine,
+  sqsClient: SQSClient,
+  txmaEgressQueueUrl: string,
+) {
   const result = validateEventAgainstSchema(recordBody);
   const eventName = getEventName(result, accountStateEngine);
   logger.debug('Intervention received.', { intervention: eventName });
@@ -159,14 +182,23 @@ async function applyEventTransition(
   result: InterventionEventMessage,
   interventionEventsService: InterventionEventsService,
   accountStateEngine: AccountStateEngine,
-  sqsClient: SQSClient,
-  txmaEgressQueueUrl: string,
+  sqs: {
+    sqsClient: SQSClient;
+    txmaEgressQueueUrl: string;
+  },
 ) {
   try {
     return accountStateEngine.applyEventTransition(event, initialState, interventionName);
   } catch (error) {
     if (error instanceof StateTransitionError) {
-      await sendAuditEvent('AIS_EVENT_TRANSITION_IGNORED', error.transition, result, sqsClient, txmaEgressQueueUrl, error.output);
+      await sendAuditEvent(
+        'AIS_EVENT_TRANSITION_IGNORED',
+        error.transition,
+        result,
+        sqs.sqsClient,
+        sqs.txmaEgressQueueUrl,
+        error.output,
+      );
       try {
         await persistIgnoredInterventionEvent(result, event, initialState, interventionEventsService);
       } catch (error) {

--- a/src/handlers/tests/interventions-processor.test.ts
+++ b/src/handlers/tests/interventions-processor.test.ts
@@ -113,23 +113,22 @@ describe('intervention processor handler', () => {
       const loggerWarnSpy = vi.spyOn(logger, 'warn');
       await processInterventions(
         { Records: [] },
-        {
-          accountStatusService: new InMemoryAccountStatusService({
-            baseStatus: {
-              blocked: false,
-              reproveIdentity: false,
-              resetPassword: false,
-              suspended: false,
-              sentAt: 1234,
-              appliedAt: 7890,
-              isAccountDeleted: false,
-              history: [],
-              intervention: '',
-            },
-          }),
-          interventionEventsService: emptyInterventionEventsService,
-          accountStateEngine
-        }
+        new InMemoryAccountStatusService({
+          baseStatus: {
+            blocked: false,
+            reproveIdentity: false,
+            resetPassword: false,
+            suspended: false,
+            sentAt: 1234,
+            appliedAt: 7890,
+            isAccountDeleted: false,
+            history: [],
+            intervention: '',
+          },
+        }),
+        emptyInterventionEventsService,
+        accountStateEngine,
+        { historyRetentionSeconds: 1000 },
       );
       expect(loggerWarnSpy).toHaveBeenCalledWith('Received no records.');
       expect(addMetric).toHaveBeenCalledWith('INVALID_EVENT_RECEIVED');
@@ -141,11 +140,10 @@ describe('intervention processor handler', () => {
       expect(
         await processInterventions(
           mockEvent,
-          {
-            accountStatusService: new InMemoryAccountStatusService(),
-            interventionEventsService: emptyInterventionEventsService,
-            accountStateEngine
-          }
+          new InMemoryAccountStatusService(),
+          emptyInterventionEventsService,
+          accountStateEngine,
+          { historyRetentionSeconds: 1000 },
         ),
       ).toEqual({
         batchItemFailures: [],
@@ -190,13 +188,12 @@ describe('intervention processor handler', () => {
       expect(
         await processInterventions(
           mockEvent,
-          {
-            accountStatusService: new InMemoryAccountStatusService({
-              baseStatus: blockedAccount,
-            }),
-            interventionEventsService: emptyInterventionEventsService,
-            accountStateEngine
-          }
+          new InMemoryAccountStatusService({
+            baseStatus: blockedAccount,
+          }),
+          emptyInterventionEventsService,
+          accountStateEngine,
+          { historyRetentionSeconds: 1000 },
         ),
       ).toEqual({
         batchItemFailures: [],
@@ -255,14 +252,13 @@ describe('intervention processor handler', () => {
       expect(
         await processInterventions(
           mockEvent,
-          {
-            accountStatusService: new InMemoryAccountStatusService({
-              baseStatus: suspendedAccount
-            }),
-            interventionEventsService: emptyInterventionEventsService,
-            accountStateEngine,
-          }
-        )
+          new InMemoryAccountStatusService({
+            baseStatus: suspendedAccount,
+          }),
+          emptyInterventionEventsService,
+          accountStateEngine,
+          { historyRetentionSeconds: 1000 },
+        ),
       ).toEqual({
         batchItemFailures: [],
       });
@@ -292,11 +288,10 @@ describe('intervention processor handler', () => {
       expect(
         await processInterventions(
           mockEvent,
-          {
-            accountStatusService: new InMemoryAccountStatusService(),
-            interventionEventsService: emptyInterventionEventsService,
-            accountStateEngine,
-          }
+          new InMemoryAccountStatusService(),
+          emptyInterventionEventsService,
+          accountStateEngine,
+          { historyRetentionSeconds: 1000 },
         ),
       ).toEqual({
         batchItemFailures: [],
@@ -341,12 +336,11 @@ describe('intervention processor handler', () => {
       expect(
         await processInterventions(
           mockEvent,
-          {
-            accountStatusService: new InMemoryAccountStatusService({ baseStatus: accountNeedingPasswordReset }),
-            interventionEventsService: emptyInterventionEventsService,
-            accountStateEngine
-          }
-        )
+          new InMemoryAccountStatusService({ baseStatus: accountNeedingPasswordReset }),
+          emptyInterventionEventsService,
+          accountStateEngine,
+          { historyRetentionSeconds: 1000 },
+        ),
       ).toEqual({
         batchItemFailures: [],
       });
@@ -393,15 +387,14 @@ describe('intervention processor handler', () => {
         isAccountDeleted: true,
         history: [],
         intervention: '',
-      }
+      };
       expect(
         await processInterventions(
           mockEvent,
-          {
-            accountStatusService: new InMemoryAccountStatusService({ baseStatus: deletedAccount }),
-            interventionEventsService: emptyInterventionEventsService,
-            accountStateEngine
-          }
+          new InMemoryAccountStatusService({ baseStatus: deletedAccount }),
+          emptyInterventionEventsService,
+          accountStateEngine,
+          { historyRetentionSeconds: 1000 },
         ),
       ).toEqual({
         batchItemFailures: [],
@@ -432,16 +425,14 @@ describe('intervention processor handler', () => {
     });
 
     it('should return message id to be retried if event is in the future', async () => {
-
       mockRecord.body = JSON.stringify(interventionEventBodyInTheFuture);
       expect(
         await processInterventions(
           { Records: [mockRecord] },
-          {
-            accountStatusService: new InMemoryAccountStatusService(),
-            interventionEventsService: emptyInterventionEventsService,
-            accountStateEngine
-          }
+          new InMemoryAccountStatusService(),
+          emptyInterventionEventsService,
+          accountStateEngine,
+          { historyRetentionSeconds: 1000 },
         ),
       ).toEqual({
         batchItemFailures: [
@@ -482,17 +473,16 @@ describe('intervention processor handler', () => {
             intervention_reason: 'reason',
           },
         },
-      }
+      };
       mockRecord.body = JSON.stringify(invalidBody);
       expect(
         await processInterventions(
           mockEvent,
-          {
-            accountStatusService: new InMemoryAccountStatusService(),
-            interventionEventsService: emptyInterventionEventsService,
-            accountStateEngine,
-          }
-        )
+          new InMemoryAccountStatusService(),
+          emptyInterventionEventsService,
+          accountStateEngine,
+          { historyRetentionSeconds: 1000 },
+        ),
       ).toEqual({
         batchItemFailures: [],
       });
@@ -504,11 +494,10 @@ describe('intervention processor handler', () => {
       expect(
         await processInterventions(
           mockEvent,
-          {
-            accountStatusService: new InMemoryAccountStatusService({ error }),
-            interventionEventsService: emptyInterventionEventsService,
-            accountStateEngine,
-          }
+          new InMemoryAccountStatusService({ error }),
+          emptyInterventionEventsService,
+          accountStateEngine,
+          { historyRetentionSeconds: 1000 },
         ),
       ).toEqual({
         batchItemFailures: [
@@ -526,23 +515,22 @@ describe('intervention processor handler', () => {
       expect(
         await processInterventions(
           { Records: [mockRecord] },
-          {
-            accountStatusService: new InMemoryAccountStatusService({
-              baseStatus: {
-                blocked: false,
-                reproveIdentity: false,
-                resetPassword: false,
-                suspended: false,
-                appliedAt: FIXED_TIME_MS + 10,
-                sentAt: FIXED_TIME_MS + 10000,
-                isAccountDeleted: false,
-                history: [],
-                intervention: '',
-              },
-            }),
-            interventionEventsService: emptyInterventionEventsService,
-            accountStateEngine,
-          }
+          new InMemoryAccountStatusService({
+            baseStatus: {
+              blocked: false,
+              reproveIdentity: false,
+              resetPassword: false,
+              suspended: false,
+              appliedAt: FIXED_TIME_MS + 10,
+              sentAt: FIXED_TIME_MS + 10000,
+              isAccountDeleted: false,
+              history: [],
+              intervention: '',
+            },
+          }),
+          emptyInterventionEventsService,
+          accountStateEngine,
+          { historyRetentionSeconds: 1000 },
         ),
       ).toEqual({
         batchItemFailures: [],
@@ -603,23 +591,22 @@ describe('intervention processor handler', () => {
       expect(
         await processInterventions(
           { Records: [mockRecord] },
-          {
-            accountStatusService: new InMemoryAccountStatusService({
-              baseStatus: {
-                blocked: false,
-                reproveIdentity: false,
-                resetPassword: false,
-                suspended: false,
-                sentAt: 1234,
-                appliedAt: 7890,
-                isAccountDeleted: false,
-                history: [],
-                intervention: '',
-              },
-            }),
-            interventionEventsService: emptyInterventionEventsService,
-            accountStateEngine
-          }
+          new InMemoryAccountStatusService({
+            baseStatus: {
+              blocked: false,
+              reproveIdentity: false,
+              resetPassword: false,
+              suspended: false,
+              sentAt: 1234,
+              appliedAt: 7890,
+              isAccountDeleted: false,
+              history: [],
+              intervention: '',
+            },
+          }),
+          emptyInterventionEventsService,
+          accountStateEngine,
+          { historyRetentionSeconds: 1000 },
         ),
       ).toEqual({
         batchItemFailures: [],
@@ -633,11 +620,10 @@ describe('intervention processor handler', () => {
       expect(
         await processInterventions(
           mockEvent,
-          {
-            accountStatusService: new InMemoryAccountStatusService({ error }),
-            interventionEventsService: emptyInterventionEventsService,
-            accountStateEngine,
-          }
+          new InMemoryAccountStatusService({ error }),
+          emptyInterventionEventsService,
+          accountStateEngine,
+          { historyRetentionSeconds: 1000 },
         ),
       ).toEqual({
         batchItemFailures: [],
@@ -683,11 +669,10 @@ describe('intervention processor handler', () => {
       expect(
         await processInterventions(
           { Records: [mockRecord] },
-          {
-            accountStatusService: new InMemoryAccountStatusService(),
-            interventionEventsService: emptyInterventionEventsService,
-            accountStateEngine,
-          }
+          new InMemoryAccountStatusService(),
+          emptyInterventionEventsService,
+          accountStateEngine,
+          { historyRetentionSeconds: 1000 },
         ),
       ).toEqual({
         batchItemFailures: [],
@@ -704,11 +689,10 @@ describe('intervention processor handler', () => {
     it('should log the expected error line when a message is retried - this line is used by a metric filter for canary deployment alarm', async () => {
       await processInterventions(
         mockEvent,
-        {
-          accountStatusService: new InMemoryAccountStatusService({ error: new Error('Error') }),
-          interventionEventsService: emptyInterventionEventsService,
-          accountStateEngine
-        }
+        new InMemoryAccountStatusService({ error: new Error('Error') }),
+        emptyInterventionEventsService,
+        accountStateEngine,
+        { historyRetentionSeconds: 1000 },
       );
       expect(publishTimeToResolveMetrics).not.toHaveBeenCalled();
       // eslint-disable-next-line @typescript-eslint/unbound-method

--- a/src/handlers/tests/interventions-processor.test.ts
+++ b/src/handlers/tests/interventions-processor.test.ts
@@ -116,25 +116,21 @@ describe('intervention processor handler', () => {
     it('does nothing if SQS event contains no record', async () => {
       const loggerWarnSpy = vi.spyOn(logger, 'warn');
       await processInterventions(
-        { Records: [] },
-        new InMemoryAccountStatusService({
-          baseStatus: {
-            blocked: false,
-            reproveIdentity: false,
-            resetPassword: false,
-            suspended: false,
-            sentAt: 1234,
-            appliedAt: 7890,
-            isAccountDeleted: false,
-            history: [],
-            intervention: '',
-          },
-        }),
-        emptyInterventionEventsService,
-        accountStateEngine,
-        config,
-        mockSqsClient,
-      );
+              { Records: [] },
+              { accountStatusService: new InMemoryAccountStatusService({
+                baseStatus: {
+                  blocked: false,
+                  reproveIdentity: false,
+                  resetPassword: false,
+                  suspended: false,
+                  sentAt: 1234,
+                  appliedAt: 7890,
+                  isAccountDeleted: false,
+                  history: [],
+                  intervention: '',
+                },
+              }), interventionEventsService: emptyInterventionEventsService, accountStateEngine: accountStateEngine, config: config, sqsClient: mockSqsClient },
+            );
       expect(loggerWarnSpy).toHaveBeenCalledWith('Received no records.');
       expect(addMetric).toHaveBeenCalledWith('INVALID_EVENT_RECEIVED');
       expect(publishTimeToResolveMetrics).not.toHaveBeenCalled();
@@ -144,13 +140,9 @@ describe('intervention processor handler', () => {
       mockRecord.body = ' ';
       expect(
         await processInterventions(
-          mockEvent,
-          new InMemoryAccountStatusService(),
-          emptyInterventionEventsService,
-          accountStateEngine,
-          config,
-          mockSqsClient,
-        ),
+                mockEvent,
+                { accountStatusService: new InMemoryAccountStatusService(), interventionEventsService: emptyInterventionEventsService, accountStateEngine: accountStateEngine, config: config, sqsClient: mockSqsClient },
+              ),
       ).toEqual({
         batchItemFailures: [],
       });
@@ -193,15 +185,11 @@ describe('intervention processor handler', () => {
       mockRecord.body = JSON.stringify(suspendEventBody);
       expect(
         await processInterventions(
-          mockEvent,
-          new InMemoryAccountStatusService({
-            baseStatus: blockedAccount,
-          }),
-          emptyInterventionEventsService,
-          accountStateEngine,
-          config,
-          mockSqsClient,
-        ),
+                mockEvent,
+                { accountStatusService: new InMemoryAccountStatusService({
+                  baseStatus: blockedAccount,
+                }), interventionEventsService: emptyInterventionEventsService, accountStateEngine: accountStateEngine, config: config, sqsClient: mockSqsClient },
+              ),
       ).toEqual({
         batchItemFailures: [],
       });
@@ -260,15 +248,11 @@ describe('intervention processor handler', () => {
       mockRecord.body = JSON.stringify(blockEventBody);
       expect(
         await processInterventions(
-          mockEvent,
-          new InMemoryAccountStatusService({
-            baseStatus: suspendedAccount,
-          }),
-          emptyInterventionEventsService,
-          accountStateEngine,
-          config,
-          mockSqsClient,
-        ),
+                mockEvent,
+                { accountStatusService: new InMemoryAccountStatusService({
+                  baseStatus: suspendedAccount,
+                }), interventionEventsService: emptyInterventionEventsService, accountStateEngine: accountStateEngine, config: config, sqsClient: mockSqsClient },
+              ),
       ).toEqual({
         batchItemFailures: [],
       });
@@ -299,13 +283,9 @@ describe('intervention processor handler', () => {
     it('should succeed when an intervention event is received for a non existing user', async () => {
       expect(
         await processInterventions(
-          mockEvent,
-          new InMemoryAccountStatusService(),
-          emptyInterventionEventsService,
-          accountStateEngine,
-          config,
-          mockSqsClient,
-        ),
+                mockEvent,
+                { accountStatusService: new InMemoryAccountStatusService(), interventionEventsService: emptyInterventionEventsService, accountStateEngine: accountStateEngine, config: config, sqsClient: mockSqsClient },
+              ),
       ).toEqual({
         batchItemFailures: [],
       });
@@ -350,13 +330,9 @@ describe('intervention processor handler', () => {
       mockEvent.Records = [mockRecord];
       expect(
         await processInterventions(
-          mockEvent,
-          new InMemoryAccountStatusService({ baseStatus: accountNeedingPasswordReset }),
-          emptyInterventionEventsService,
-          accountStateEngine,
-          config,
-          mockSqsClient,
-        ),
+                mockEvent,
+                { accountStatusService: new InMemoryAccountStatusService({ baseStatus: accountNeedingPasswordReset }), interventionEventsService: emptyInterventionEventsService, accountStateEngine: accountStateEngine, config: config, sqsClient: mockSqsClient },
+              ),
       ).toEqual({
         batchItemFailures: [],
       });
@@ -408,13 +384,9 @@ describe('intervention processor handler', () => {
       };
       expect(
         await processInterventions(
-          mockEvent,
-          new InMemoryAccountStatusService({ baseStatus: deletedAccount }),
-          emptyInterventionEventsService,
-          accountStateEngine,
-          config,
-          mockSqsClient,
-        ),
+                mockEvent,
+                { accountStatusService: new InMemoryAccountStatusService({ baseStatus: deletedAccount }), interventionEventsService: emptyInterventionEventsService, accountStateEngine: accountStateEngine, config: config, sqsClient: mockSqsClient },
+              ),
       ).toEqual({
         batchItemFailures: [],
       });
@@ -449,13 +421,9 @@ describe('intervention processor handler', () => {
       mockRecord.body = JSON.stringify(interventionEventBodyInTheFuture);
       expect(
         await processInterventions(
-          { Records: [mockRecord] },
-          new InMemoryAccountStatusService(),
-          emptyInterventionEventsService,
-          accountStateEngine,
-          config,
-          mockSqsClient,
-        ),
+                { Records: [mockRecord] },
+                { accountStatusService: new InMemoryAccountStatusService(), interventionEventsService: emptyInterventionEventsService, accountStateEngine: accountStateEngine, config: config, sqsClient: mockSqsClient },
+              ),
       ).toEqual({
         batchItemFailures: [
           {
@@ -501,13 +469,9 @@ describe('intervention processor handler', () => {
       mockRecord.body = JSON.stringify(invalidBody);
       expect(
         await processInterventions(
-          mockEvent,
-          new InMemoryAccountStatusService(),
-          emptyInterventionEventsService,
-          accountStateEngine,
-          config,
-          mockSqsClient,
-        ),
+                mockEvent,
+                { accountStatusService: new InMemoryAccountStatusService(), interventionEventsService: emptyInterventionEventsService, accountStateEngine: accountStateEngine, config: config, sqsClient: mockSqsClient },
+              ),
       ).toEqual({
         batchItemFailures: [],
       });
@@ -518,13 +482,9 @@ describe('intervention processor handler', () => {
       const error = new Error('Error');
       expect(
         await processInterventions(
-          mockEvent,
-          new InMemoryAccountStatusService({ error }),
-          emptyInterventionEventsService,
-          accountStateEngine,
-          config,
-          mockSqsClient,
-        ),
+                mockEvent,
+                { accountStatusService: new InMemoryAccountStatusService({ error }), interventionEventsService: emptyInterventionEventsService, accountStateEngine: accountStateEngine, config: config, sqsClient: mockSqsClient },
+              ),
       ).toEqual({
         batchItemFailures: [
           {
@@ -540,25 +500,21 @@ describe('intervention processor handler', () => {
     it('should not process the event and return if the event timestamp predates the latest applied intervention for the user ', async () => {
       expect(
         await processInterventions(
-          { Records: [mockRecord] },
-          new InMemoryAccountStatusService({
-            baseStatus: {
-              blocked: false,
-              reproveIdentity: false,
-              resetPassword: false,
-              suspended: false,
-              appliedAt: FIXED_TIME_MS + 10,
-              sentAt: FIXED_TIME_MS + 10000,
-              isAccountDeleted: false,
-              history: [],
-              intervention: '',
-            },
-          }),
-          emptyInterventionEventsService,
-          accountStateEngine,
-          config,
-          mockSqsClient,
-        ),
+                { Records: [mockRecord] },
+                { accountStatusService: new InMemoryAccountStatusService({
+                  baseStatus: {
+                    blocked: false,
+                    reproveIdentity: false,
+                    resetPassword: false,
+                    suspended: false,
+                    appliedAt: FIXED_TIME_MS + 10,
+                    sentAt: FIXED_TIME_MS + 10000,
+                    isAccountDeleted: false,
+                    history: [],
+                    intervention: '',
+                  },
+                }), interventionEventsService: emptyInterventionEventsService, accountStateEngine: accountStateEngine, config: config, sqsClient: mockSqsClient },
+              ),
       ).toEqual({
         batchItemFailures: [],
       });
@@ -619,25 +575,21 @@ describe('intervention processor handler', () => {
       };
       expect(
         await processInterventions(
-          { Records: [mockRecord] },
-          new InMemoryAccountStatusService({
-            baseStatus: {
-              blocked: false,
-              reproveIdentity: false,
-              resetPassword: false,
-              suspended: false,
-              sentAt: 1234,
-              appliedAt: 7890,
-              isAccountDeleted: false,
-              history: [],
-              intervention: '',
-            },
-          }),
-          emptyInterventionEventsService,
-          accountStateEngine,
-          config,
-          mockSqsClient,
-        ),
+                { Records: [mockRecord] },
+                { accountStatusService: new InMemoryAccountStatusService({
+                  baseStatus: {
+                    blocked: false,
+                    reproveIdentity: false,
+                    resetPassword: false,
+                    suspended: false,
+                    sentAt: 1234,
+                    appliedAt: 7890,
+                    isAccountDeleted: false,
+                    history: [],
+                    intervention: '',
+                  },
+                }), interventionEventsService: emptyInterventionEventsService, accountStateEngine: accountStateEngine, config: config, sqsClient: mockSqsClient },
+              ),
       ).toEqual({
         batchItemFailures: [],
       });
@@ -649,13 +601,9 @@ describe('intervention processor handler', () => {
 
       expect(
         await processInterventions(
-          mockEvent,
-          new InMemoryAccountStatusService({ error }),
-          emptyInterventionEventsService,
-          accountStateEngine,
-          config,
-          mockSqsClient,
-        ),
+                mockEvent,
+                { accountStatusService: new InMemoryAccountStatusService({ error }), interventionEventsService: emptyInterventionEventsService, accountStateEngine: accountStateEngine, config: config, sqsClient: mockSqsClient },
+              ),
       ).toEqual({
         batchItemFailures: [],
       });
@@ -699,13 +647,9 @@ describe('intervention processor handler', () => {
       };
       expect(
         await processInterventions(
-          { Records: [mockRecord] },
-          new InMemoryAccountStatusService(),
-          emptyInterventionEventsService,
-          accountStateEngine,
-          config,
-          mockSqsClient,
-        ),
+                { Records: [mockRecord] },
+                { accountStatusService: new InMemoryAccountStatusService(), interventionEventsService: emptyInterventionEventsService, accountStateEngine: accountStateEngine, config: config, sqsClient: mockSqsClient },
+              ),
       ).toEqual({
         batchItemFailures: [],
       });
@@ -720,13 +664,9 @@ describe('intervention processor handler', () => {
 
     it('should log the expected error line when a message is retried - this line is used by a metric filter for canary deployment alarm', async () => {
       await processInterventions(
-        mockEvent,
-        new InMemoryAccountStatusService({ error: new Error('Error') }),
-        emptyInterventionEventsService,
-        accountStateEngine,
-        config,
-        mockSqsClient,
-      );
+              mockEvent,
+              { accountStatusService: new InMemoryAccountStatusService({ error: new Error('Error') }), interventionEventsService: emptyInterventionEventsService, accountStateEngine: accountStateEngine, config: config, sqsClient: mockSqsClient },
+            );
       expect(publishTimeToResolveMetrics).not.toHaveBeenCalled();
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(logger.error).toHaveBeenCalledWith('Error caught, message will be retried.', { errorMessage: 'Error' });

--- a/src/handlers/tests/interventions-processor.test.ts
+++ b/src/handlers/tests/interventions-processor.test.ts
@@ -213,6 +213,8 @@ describe('intervention processor handler', () => {
         'AIS_EVENT_TRANSITION_IGNORED',
         EventsEnum.FRAUD_SUSPEND_ACCOUNT,
         interventionEventBody,
+        mockSqsClient,
+        config.txmaEgressQueueUrl,
         {
           stateResult: {
             blocked: true,
@@ -223,8 +225,6 @@ describe('intervention processor handler', () => {
           interventionName: 'AIS_NO_INTERVENTION',
           nextAllowableInterventions: ['07'],
         },
-        mockSqsClient,
-        config.txmaEgressQueueUrl,
       );
       expect(publishTimeToResolveMetrics).not.toHaveBeenCalled();
     });
@@ -276,6 +276,8 @@ describe('intervention processor handler', () => {
         'AIS_EVENT_TRANSITION_APPLIED',
         EventsEnum.FRAUD_BLOCK_ACCOUNT,
         blockEventBody,
+        mockSqsClient,
+        config.txmaEgressQueueUrl,
         {
           stateResult: {
             blocked: true,
@@ -286,8 +288,6 @@ describe('intervention processor handler', () => {
           interventionName: 'AIS_ACCOUNT_BLOCKED',
           nextAllowableInterventions: ['07'],
         },
-        mockSqsClient,
-        config.txmaEgressQueueUrl,
       );
       expect(addMetric).toHaveBeenCalledWith(MetricNames.EVENT_DELIVERY_LATENCY, [], 5000);
       expect(addMetric).toHaveBeenCalledWith(MetricNames.INTERVENTION_EVENT_APPLIED, [], 1, {
@@ -313,6 +313,8 @@ describe('intervention processor handler', () => {
         'AIS_EVENT_TRANSITION_APPLIED',
         EventsEnum.FRAUD_SUSPEND_ACCOUNT,
         interventionEventBody,
+        mockSqsClient,
+        config.txmaEgressQueueUrl,
         {
           stateResult: {
             blocked: false,
@@ -323,8 +325,6 @@ describe('intervention processor handler', () => {
           interventionName: 'AIS_ACCOUNT_SUSPENDED',
           nextAllowableInterventions: ['02', '03', '04', '05', '06'],
         },
-        mockSqsClient,
-        config.txmaEgressQueueUrl,
       );
       expect(addMetric).toHaveBeenCalledWith(MetricNames.EVENT_DELIVERY_LATENCY, [], 5000);
       expect(addMetric).toHaveBeenCalledWith(MetricNames.INTERVENTION_EVENT_APPLIED, [], 1, {
@@ -373,6 +373,8 @@ describe('intervention processor handler', () => {
             user_id: 'abc',
           },
         },
+        mockSqsClient,
+        config.txmaEgressQueueUrl,
         {
           stateResult: {
             blocked: false,
@@ -383,8 +385,6 @@ describe('intervention processor handler', () => {
           interventionName: undefined,
           nextAllowableInterventions: ['01', '03', '04', '05', '06'],
         },
-        mockSqsClient,
-        config.txmaEgressQueueUrl,
       );
 
       expect(addMetric).toHaveBeenCalledWith(MetricNames.EVENT_DELIVERY_LATENCY, [], 5000);
@@ -429,6 +429,8 @@ describe('intervention processor handler', () => {
         'AIS_EVENT_IGNORED_ACCOUNT_DELETED',
         EventsEnum.FRAUD_SUSPEND_ACCOUNT,
         interventionEventBody,
+        mockSqsClient,
+        config.txmaEgressQueueUrl,
         {
           stateResult: {
             blocked: false,
@@ -439,8 +441,6 @@ describe('intervention processor handler', () => {
           interventionName: 'AIS_NO_INTERVENTION',
           nextAllowableInterventions: ['01', '03', '04', '05', '06'],
         },
-        mockSqsClient,
-        config.txmaEgressQueueUrl,
       );
       expect(publishTimeToResolveMetrics).not.toHaveBeenCalled();
     });
@@ -468,7 +468,6 @@ describe('intervention processor handler', () => {
         'AIS_EVENT_IGNORED_IN_FUTURE',
         EventsEnum.FRAUD_SUSPEND_ACCOUNT,
         interventionEventBodyInTheFuture,
-        undefined,
         mockSqsClient,
         config.txmaEgressQueueUrl,
       );
@@ -570,6 +569,8 @@ describe('intervention processor handler', () => {
         'AIS_EVENT_IGNORED_STALE',
         EventsEnum.FRAUD_SUSPEND_ACCOUNT,
         interventionEventBody,
+        mockSqsClient,
+        config.txmaEgressQueueUrl,
         {
           stateResult: {
             blocked: false,
@@ -580,8 +581,6 @@ describe('intervention processor handler', () => {
           interventionName: 'AIS_NO_INTERVENTION',
           nextAllowableInterventions: ['01', '03', '04', '05', '06'],
         },
-        mockSqsClient,
-        config.txmaEgressQueueUrl,
       );
       expect(publishTimeToResolveMetrics).not.toHaveBeenCalled();
     });

--- a/src/handlers/tests/interventions-processor.test.ts
+++ b/src/handlers/tests/interventions-processor.test.ts
@@ -12,6 +12,7 @@ import { InterventionEventMessage, TicfAccountIntervention } from '../../contrac
 import { InMemoryInterventionEventsService } from '../../tables/intervention-events';
 import { InMemoryAccountStatusService } from '../../tables/account-status';
 import { processInterventions } from '../interventions-processor';
+import { SQSClient } from '@aws-sdk/client-sqs';
 
 vi.mock('@aws-lambda-powertools/logger');
 vi.mock('../../commons/metrics');
@@ -20,6 +21,8 @@ vi.mock('../../commons/metrics-helper');
 
 const FIXED_TIME_MS = 1234567890;
 const FIXED_TIME_S = 1234567;
+
+const mockSqsClient = {} as SQSClient;
 
 const interventionEventBody: InterventionEventMessage = {
   component_id: '',
@@ -76,6 +79,7 @@ const resetPasswordEventBody = {
 const accountStateEngine = AccountStateEngine.getInstance();
 
 const emptyInterventionEventsService = new InMemoryInterventionEventsService([]);
+const config = { historyRetentionSeconds: 1000, txmaEgressQueueUrl: 'https://sqs.eu-west-2.amazonaws.com/123456789/txma-egress-queue' };
 
 describe('intervention processor handler', () => {
   let mockEvent: SQSEvent;
@@ -128,7 +132,8 @@ describe('intervention processor handler', () => {
         }),
         emptyInterventionEventsService,
         accountStateEngine,
-        { historyRetentionSeconds: 1000 },
+        config,
+        mockSqsClient,
       );
       expect(loggerWarnSpy).toHaveBeenCalledWith('Received no records.');
       expect(addMetric).toHaveBeenCalledWith('INVALID_EVENT_RECEIVED');
@@ -143,7 +148,8 @@ describe('intervention processor handler', () => {
           new InMemoryAccountStatusService(),
           emptyInterventionEventsService,
           accountStateEngine,
-          { historyRetentionSeconds: 1000 },
+          config,
+          mockSqsClient,
         ),
       ).toEqual({
         batchItemFailures: [],
@@ -193,7 +199,8 @@ describe('intervention processor handler', () => {
           }),
           emptyInterventionEventsService,
           accountStateEngine,
-          { historyRetentionSeconds: 1000 },
+          config,
+          mockSqsClient,
         ),
       ).toEqual({
         batchItemFailures: [],
@@ -216,6 +223,8 @@ describe('intervention processor handler', () => {
           interventionName: 'AIS_NO_INTERVENTION',
           nextAllowableInterventions: ['07'],
         },
+        mockSqsClient,
+        config.txmaEgressQueueUrl,
       );
       expect(publishTimeToResolveMetrics).not.toHaveBeenCalled();
     });
@@ -257,7 +266,8 @@ describe('intervention processor handler', () => {
           }),
           emptyInterventionEventsService,
           accountStateEngine,
-          { historyRetentionSeconds: 1000 },
+          config,
+          mockSqsClient,
         ),
       ).toEqual({
         batchItemFailures: [],
@@ -276,6 +286,8 @@ describe('intervention processor handler', () => {
           interventionName: 'AIS_ACCOUNT_BLOCKED',
           nextAllowableInterventions: ['07'],
         },
+        mockSqsClient,
+        config.txmaEgressQueueUrl,
       );
       expect(addMetric).toHaveBeenCalledWith(MetricNames.EVENT_DELIVERY_LATENCY, [], 5000);
       expect(addMetric).toHaveBeenCalledWith(MetricNames.INTERVENTION_EVENT_APPLIED, [], 1, {
@@ -291,7 +303,8 @@ describe('intervention processor handler', () => {
           new InMemoryAccountStatusService(),
           emptyInterventionEventsService,
           accountStateEngine,
-          { historyRetentionSeconds: 1000 },
+          config,
+          mockSqsClient,
         ),
       ).toEqual({
         batchItemFailures: [],
@@ -310,6 +323,8 @@ describe('intervention processor handler', () => {
           interventionName: 'AIS_ACCOUNT_SUSPENDED',
           nextAllowableInterventions: ['02', '03', '04', '05', '06'],
         },
+        mockSqsClient,
+        config.txmaEgressQueueUrl,
       );
       expect(addMetric).toHaveBeenCalledWith(MetricNames.EVENT_DELIVERY_LATENCY, [], 5000);
       expect(addMetric).toHaveBeenCalledWith(MetricNames.INTERVENTION_EVENT_APPLIED, [], 1, {
@@ -339,7 +354,8 @@ describe('intervention processor handler', () => {
           new InMemoryAccountStatusService({ baseStatus: accountNeedingPasswordReset }),
           emptyInterventionEventsService,
           accountStateEngine,
-          { historyRetentionSeconds: 1000 },
+          config,
+          mockSqsClient,
         ),
       ).toEqual({
         batchItemFailures: [],
@@ -367,6 +383,8 @@ describe('intervention processor handler', () => {
           interventionName: undefined,
           nextAllowableInterventions: ['01', '03', '04', '05', '06'],
         },
+        mockSqsClient,
+        config.txmaEgressQueueUrl,
       );
 
       expect(addMetric).toHaveBeenCalledWith(MetricNames.EVENT_DELIVERY_LATENCY, [], 5000);
@@ -394,7 +412,8 @@ describe('intervention processor handler', () => {
           new InMemoryAccountStatusService({ baseStatus: deletedAccount }),
           emptyInterventionEventsService,
           accountStateEngine,
-          { historyRetentionSeconds: 1000 },
+          config,
+          mockSqsClient,
         ),
       ).toEqual({
         batchItemFailures: [],
@@ -420,6 +439,8 @@ describe('intervention processor handler', () => {
           interventionName: 'AIS_NO_INTERVENTION',
           nextAllowableInterventions: ['01', '03', '04', '05', '06'],
         },
+        mockSqsClient,
+        config.txmaEgressQueueUrl,
       );
       expect(publishTimeToResolveMetrics).not.toHaveBeenCalled();
     });
@@ -432,7 +453,8 @@ describe('intervention processor handler', () => {
           new InMemoryAccountStatusService(),
           emptyInterventionEventsService,
           accountStateEngine,
-          { historyRetentionSeconds: 1000 },
+          config,
+          mockSqsClient,
         ),
       ).toEqual({
         batchItemFailures: [
@@ -446,6 +468,9 @@ describe('intervention processor handler', () => {
         'AIS_EVENT_IGNORED_IN_FUTURE',
         EventsEnum.FRAUD_SUSPEND_ACCOUNT,
         interventionEventBodyInTheFuture,
+        undefined,
+        mockSqsClient,
+        config.txmaEgressQueueUrl,
       );
       expect(publishTimeToResolveMetrics).not.toHaveBeenCalled();
       // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -481,7 +506,8 @@ describe('intervention processor handler', () => {
           new InMemoryAccountStatusService(),
           emptyInterventionEventsService,
           accountStateEngine,
-          { historyRetentionSeconds: 1000 },
+          config,
+          mockSqsClient,
         ),
       ).toEqual({
         batchItemFailures: [],
@@ -497,7 +523,8 @@ describe('intervention processor handler', () => {
           new InMemoryAccountStatusService({ error }),
           emptyInterventionEventsService,
           accountStateEngine,
-          { historyRetentionSeconds: 1000 },
+          config,
+          mockSqsClient,
         ),
       ).toEqual({
         batchItemFailures: [
@@ -530,7 +557,8 @@ describe('intervention processor handler', () => {
           }),
           emptyInterventionEventsService,
           accountStateEngine,
-          { historyRetentionSeconds: 1000 },
+          config,
+          mockSqsClient,
         ),
       ).toEqual({
         batchItemFailures: [],
@@ -552,6 +580,8 @@ describe('intervention processor handler', () => {
           interventionName: 'AIS_NO_INTERVENTION',
           nextAllowableInterventions: ['01', '03', '04', '05', '06'],
         },
+        mockSqsClient,
+        config.txmaEgressQueueUrl,
       );
       expect(publishTimeToResolveMetrics).not.toHaveBeenCalled();
     });
@@ -606,7 +636,8 @@ describe('intervention processor handler', () => {
           }),
           emptyInterventionEventsService,
           accountStateEngine,
-          { historyRetentionSeconds: 1000 },
+          config,
+          mockSqsClient,
         ),
       ).toEqual({
         batchItemFailures: [],
@@ -623,7 +654,8 @@ describe('intervention processor handler', () => {
           new InMemoryAccountStatusService({ error }),
           emptyInterventionEventsService,
           accountStateEngine,
-          { historyRetentionSeconds: 1000 },
+          config,
+          mockSqsClient,
         ),
       ).toEqual({
         batchItemFailures: [],
@@ -672,7 +704,8 @@ describe('intervention processor handler', () => {
           new InMemoryAccountStatusService(),
           emptyInterventionEventsService,
           accountStateEngine,
-          { historyRetentionSeconds: 1000 },
+          config,
+          mockSqsClient,
         ),
       ).toEqual({
         batchItemFailures: [],
@@ -692,7 +725,8 @@ describe('intervention processor handler', () => {
         new InMemoryAccountStatusService({ error: new Error('Error') }),
         emptyInterventionEventsService,
         accountStateEngine,
-        { historyRetentionSeconds: 1000 },
+        config,
+        mockSqsClient,
       );
       expect(publishTimeToResolveMetrics).not.toHaveBeenCalled();
       // eslint-disable-next-line @typescript-eslint/unbound-method

--- a/src/services/persist-intervention-events.ts
+++ b/src/services/persist-intervention-events.ts
@@ -7,14 +7,11 @@ import { InterventionEvent, InterventionEventsService } from '../tables/interven
 import { randomUUID } from 'node:crypto';
 import getActiveInterventions from './active-interventions-service';
 import { InterventionName } from '../data-types/intervention-name';
-import { AppConfigService } from './app-config-service';
 
 interface InterventionUpdate {
   interventionName: InterventionName;
   interventionState: InterventionState;
 }
-
-const appConfig = AppConfigService.getInstance();
 
 /**
  * Generate and append intervention events based on the received txma message
@@ -28,6 +25,7 @@ async function persistInterventionEvents(
   event: EventsEnum,
   previousState: StateDetails | undefined,
   interventionEventsService: InterventionEventsService,
+  historyRetentionSeconds: number,
 ) {
   const updates: InterventionUpdate[] = config[event];
 
@@ -46,7 +44,7 @@ async function persistInterventionEvents(
   const closedNames = eventsToAppend
     .filter((event) => event.interventionState !== InterventionState.ACTIVE)
     .map((event) => event.interventionName);
-  await setTtlOnInactiveEvents(message.user.user_id, interventionEventsService, closedNames);
+  await setTtlOnInactiveEvents(message.user.user_id, interventionEventsService, closedNames, historyRetentionSeconds);
 }
 
 export async function persistIgnoredInterventionEvent(
@@ -142,10 +140,11 @@ export async function setTtlOnInactiveEvents(
   accountId: string,
   interventionEventsService: InterventionEventsService,
   closedInterventionNames: InterventionName[],
+  historyRetentionSeconds: number,
 ) {
   const allEvents = await interventionEventsService.fetchEventsForAccount(accountId);
   const now = getCurrentTimestamp();
-  const ttl = now.seconds + appConfig.historyRetentionSeconds;
+  const ttl = now.seconds + historyRetentionSeconds;
 
   const eventsNeedingTtl = allEvents.filter(
     (event) => closedInterventionNames.includes(event.interventionName) && !event.ttl,

--- a/src/services/send-audit-events.ts
+++ b/src/services/send-audit-events.ts
@@ -1,6 +1,3 @@
-import { AppConfigService } from './app-config-service';
-import tracer from '../commons/tracer';
-import { NodeHttpHandler } from '@smithy/node-http-handler';
 import { SendMessageCommand, SendMessageCommandOutput, SQSClient } from '@aws-sdk/client-sqs';
 import { AccountStateEngineOutput, TxMAEgressEvent, TxMAEgressInterventionEventName } from '../data-types/interfaces';
 import logger from '../commons/logger';
@@ -19,16 +16,6 @@ import { transitionConfig } from './account-states/config';
 import { AisEventIgnoredStaleBasicExtensions, AisEventIgnoredStaleExtensions } from '../events/ais-event-ignored-stale';
 import { InterventionEventMessage } from '../contracts/intervention-events';
 
-const appConfig = AppConfigService.getInstance();
-
-const sqsClient = tracer.captureAWSv3Client(
-  new SQSClient({
-    region: appConfig.awsRegion,
-    maxAttempts: 2,
-    requestHandler: new NodeHttpHandler({ requestTimeout: 5000 }),
-  }),
-);
-
 /**
  * Function that sends Audit Events to the TxMA Egress queue.
  * @param egressEventName - The event name used for sending off the event to identify the action taken.
@@ -41,9 +28,9 @@ export async function sendAuditEvent(
   egressEventName: TxMAEgressInterventionEventName,
   ingressEventName: EventsEnum,
   ingressTxMAEvent: InterventionEventMessage,
+  client: SQSClient,
+  queueUrl: string,
   accountStateEngineOutput?: AccountStateEngineOutput,
-  client: SQSClient = sqsClient,
-  queueUrl: string = appConfig.txmaEgressQueueUrl,
 ): Promise<SendMessageCommandOutput | undefined> {
   logger.debug('sendAuditEvent function.');
 

--- a/src/services/send-audit-events.ts
+++ b/src/services/send-audit-events.ts
@@ -42,6 +42,8 @@ export async function sendAuditEvent(
   ingressEventName: EventsEnum,
   ingressTxMAEvent: InterventionEventMessage,
   accountStateEngineOutput?: AccountStateEngineOutput,
+  client: SQSClient = sqsClient,
+  queueUrl: string = appConfig.txmaEgressQueueUrl,
 ): Promise<SendMessageCommandOutput | undefined> {
   logger.debug('sendAuditEvent function.');
 
@@ -60,11 +62,11 @@ export async function sendAuditEvent(
     extensions: buildExtensions(ingressTxMAEvent, ingressEventName, egressEventName, accountStateEngineOutput),
   };
 
-  const input = { MessageBody: JSON.stringify(txmaEvent), QueueUrl: appConfig.txmaEgressQueueUrl };
+  const input = { MessageBody: JSON.stringify(txmaEvent), QueueUrl: queueUrl };
 
   try {
     logger.debug('Attempting to send TxMA event to the queue.');
-    const response = await sqsClient.send(new SendMessageCommand(input));
+    const response = await client.send(new SendMessageCommand(input));
     addMetric(MetricNames.PUBLISHED_EVENT_TO_TXMA);
     return response;
   } catch (error) {

--- a/src/services/test/persist-intervention-events.test.ts
+++ b/src/services/test/persist-intervention-events.test.ts
@@ -42,7 +42,7 @@ describe('persistInterventionEvents', () => {
     const fetchEventsSpy = vi.spyOn(service, 'fetchEventsForAccount');
     const appendEventsSpy = vi.spyOn(service, 'appendEvents');
 
-    await persistInterventionEvents(baseMessage, EventsEnum.FRAUD_SUSPEND_ACCOUNT, undefined, service);
+    await persistInterventionEvents(baseMessage, EventsEnum.FRAUD_SUSPEND_ACCOUNT, undefined, service, 1000);
 
     expect(fetchEventsSpy).toHaveBeenCalledTimes(2);
     expect(appendEventsSpy).toHaveBeenCalledExactlyOnceWith([
@@ -276,7 +276,8 @@ describe('persistIgnoredInterventionEvent', () => {
 
 describe('setTtlOnInactiveEvents', () => {
   const FIXED_TIMESTAMP = 1781253284370;
-  const EXPECTED_TTL = Math.floor(FIXED_TIMESTAMP / 1000) + 63072000;
+  const HISTORY_RETENTION_SECONDS = 1000;
+  const EXPECTED_TTL = Math.floor(FIXED_TIMESTAMP / 1000) + HISTORY_RETENTION_SECONDS;
 
   beforeAll(() => {
     vi.useFakeTimers();
@@ -302,7 +303,7 @@ describe('setTtlOnInactiveEvents', () => {
     ]);
     const appendEventsSpy = vi.spyOn(service, 'appendEvents');
 
-    await setTtlOnInactiveEvents('1', service, [InterventionName.TEMPORARY_SUSPENSION]);
+    await setTtlOnInactiveEvents('1', service, [InterventionName.TEMPORARY_SUSPENSION], 1000);
 
     expect(appendEventsSpy).toHaveBeenCalledExactlyOnceWith([
       expect.objectContaining({ eventId: 'event-1', ttl: EXPECTED_TTL }),
@@ -324,7 +325,7 @@ describe('setTtlOnInactiveEvents', () => {
     ]);
     const appendEventsSpy = vi.spyOn(service, 'appendEvents');
 
-    await setTtlOnInactiveEvents('1', service, [InterventionName.TEMPORARY_SUSPENSION]);
+    await setTtlOnInactiveEvents('1', service, [InterventionName.TEMPORARY_SUSPENSION], 1000);
 
     expect(appendEventsSpy).not.toHaveBeenCalled();
   });
@@ -345,7 +346,7 @@ describe('setTtlOnInactiveEvents', () => {
     ]);
     const appendEventsSpy = vi.spyOn(service, 'appendEvents');
 
-    await setTtlOnInactiveEvents('1', service, [InterventionName.TEMPORARY_SUSPENSION]);
+    await setTtlOnInactiveEvents('1', service, [InterventionName.TEMPORARY_SUSPENSION], 1000);
 
     expect(appendEventsSpy).not.toHaveBeenCalled();
   });
@@ -354,7 +355,7 @@ describe('setTtlOnInactiveEvents', () => {
     const service = new InMemoryInterventionEventsService([]);
     const appendEventsSpy = vi.spyOn(service, 'appendEvents');
 
-    await setTtlOnInactiveEvents('1', service, [InterventionName.TEMPORARY_SUSPENSION]);
+    await setTtlOnInactiveEvents('1', service, [InterventionName.TEMPORARY_SUSPENSION], 1000);
 
     expect(appendEventsSpy).not.toHaveBeenCalled();
   });
@@ -384,7 +385,7 @@ describe('setTtlOnInactiveEvents', () => {
     ]);
     const appendEventsSpy = vi.spyOn(service, 'appendEvents');
 
-    await setTtlOnInactiveEvents('1', service, [InterventionName.TEMPORARY_SUSPENSION]);
+    await setTtlOnInactiveEvents('1', service, [InterventionName.TEMPORARY_SUSPENSION], 1000);
 
     expect(appendEventsSpy).toHaveBeenCalledExactlyOnceWith([
       expect.objectContaining({ eventId: 'event-1', ttl: EXPECTED_TTL }),
@@ -427,7 +428,7 @@ describe('setTtlOnInactiveEvents', () => {
 
     const appendEventsSpy = vi.spyOn(service, 'appendEvents');
 
-    await setTtlOnInactiveEvents('1', service, [InterventionName.TEMPORARY_SUSPENSION]);
+    await setTtlOnInactiveEvents('1', service, [InterventionName.TEMPORARY_SUSPENSION], 1000);
 
     expect(appendEventsSpy).toHaveBeenCalledExactlyOnceWith([
       expect.objectContaining({ eventId: 'event-1', ttl: EXPECTED_TTL }),

--- a/src/services/test/send-audit-events.test.ts
+++ b/src/services/test/send-audit-events.test.ts
@@ -12,7 +12,6 @@ import {
 } from '../../data-types/constants';
 import { addMetric } from '../../commons/metrics';
 import logger from '../../commons/logger';
-import { AppConfigService } from '../app-config-service';
 import 'aws-sdk-client-mock-vitest/extend';
 
 vi.mock('@aws-lambda-powertools/logger');
@@ -73,8 +72,10 @@ const ingressUserActionEvent = {
 };
 
 const sqsMock = mockClient(SQSClient);
+const testSqsClient = new SQSClient({});
+const testQueueUrl = 'https://test-queue';
 const sqsCommandInputForUserAction = {
-  QueueUrl: AppConfigService.getInstance().txmaEgressQueueUrl,
+  QueueUrl: testQueueUrl,
   MessageBody: JSON.stringify({
     timestamp: 1234567,
     event_timestamp_ms: 1234567890,
@@ -95,7 +96,7 @@ const sqsCommandInputForUserAction = {
 };
 
 const sqsCommandInputForBlockIntervention = {
-  QueueUrl: AppConfigService.getInstance().txmaEgressQueueUrl,
+  QueueUrl: testQueueUrl,
   MessageBody: JSON.stringify({
     timestamp: 1234567,
     event_timestamp_ms: 1234567890,
@@ -115,7 +116,7 @@ const sqsCommandInputForBlockIntervention = {
 };
 
 const sqsCommandInputForDeletedAccount = {
-  QueueUrl: AppConfigService.getInstance().txmaEgressQueueUrl,
+  QueueUrl: testQueueUrl,
   MessageBody: JSON.stringify({
     timestamp: 1234567,
     event_timestamp_ms: 1234567890,
@@ -135,7 +136,7 @@ const sqsCommandInputForDeletedAccount = {
 };
 
 const sqsCommandInputForSuspendIntervention = {
-  QueueUrl: AppConfigService.getInstance().txmaEgressQueueUrl,
+  QueueUrl: testQueueUrl,
   MessageBody: JSON.stringify({
     timestamp: 1234567,
     event_timestamp_ms: 1234567890,
@@ -155,7 +156,7 @@ const sqsCommandInputForSuspendIntervention = {
 };
 
 const sqsCommandInputForUnsuspendIntervention = {
-  QueueUrl: AppConfigService.getInstance().txmaEgressQueueUrl,
+  QueueUrl: testQueueUrl,
   MessageBody: JSON.stringify({
     timestamp: 1234567,
     event_timestamp_ms: 1234567890,
@@ -175,7 +176,7 @@ const sqsCommandInputForUnsuspendIntervention = {
 };
 
 const sqsCommandInputForFutureInterventions = {
-  QueueUrl: AppConfigService.getInstance().txmaEgressQueueUrl,
+  QueueUrl: testQueueUrl,
   MessageBody: JSON.stringify({
     timestamp: 1234567,
     event_timestamp_ms: 1234567890,
@@ -192,7 +193,7 @@ const sqsCommandInputForFutureInterventions = {
 };
 
 const sqsCommandInputForSuspendUserAction = {
-  QueueUrl: AppConfigService.getInstance().txmaEgressQueueUrl,
+  QueueUrl: testQueueUrl,
   MessageBody: JSON.stringify({
     timestamp: 1234567,
     event_timestamp_ms: 1234567890,
@@ -213,7 +214,7 @@ const sqsCommandInputForSuspendUserAction = {
 };
 
 const sqsCommandInputForSuspendUserActionReproveIdentityAndResetPass = {
-  QueueUrl: AppConfigService.getInstance().txmaEgressQueueUrl,
+  QueueUrl: testQueueUrl,
   MessageBody: JSON.stringify({
     timestamp: 1234567,
     event_timestamp_ms: 1234567890,
@@ -234,7 +235,7 @@ const sqsCommandInputForSuspendUserActionReproveIdentityAndResetPass = {
 };
 
 const sqsInputWithExtraFields = {
-  QueueUrl: AppConfigService.getInstance().txmaEgressQueueUrl,
+  QueueUrl: testQueueUrl,
   MessageBody: JSON.stringify({
     timestamp: 1234567,
     event_timestamp_ms: 1234567890,
@@ -277,6 +278,8 @@ describe('send-audit-events', () => {
       'AIS_EVENT_TRANSITION_APPLIED',
       EventsEnum.FRAUD_FORCED_USER_PASSWORD_RESET,
       ingressUserActionEvent,
+      testSqsClient,
+      testQueueUrl,
       {
         nextAllowableInterventions: [],
         interventionName: AISInterventionTypes.AIS_FORCED_USER_PASSWORD_RESET,
@@ -296,6 +299,8 @@ describe('send-audit-events', () => {
       'AIS_EVENT_TRANSITION_APPLIED',
       EventsEnum.FRAUD_SUSPEND_ACCOUNT,
       ingressInterventionEvent,
+      testSqsClient,
+      testQueueUrl,
       {
         nextAllowableInterventions: [Codes.C01],
         interventionName: AISInterventionTypes.AIS_ACCOUNT_SUSPENDED,
@@ -315,6 +320,8 @@ describe('send-audit-events', () => {
       'AIS_EVENT_TRANSITION_APPLIED',
       EventsEnum.FRAUD_BLOCK_ACCOUNT,
       ingressInterventionEvent,
+      testSqsClient,
+      testQueueUrl,
       {
         nextAllowableInterventions: [],
         interventionName: AISInterventionTypes.AIS_ACCOUNT_BLOCKED,
@@ -334,6 +341,8 @@ describe('send-audit-events', () => {
       'AIS_EVENT_TRANSITION_APPLIED',
       EventsEnum.FRAUD_SUSPEND_ACCOUNT,
       ingressInterventionEvent,
+      testSqsClient,
+      testQueueUrl,
       {
         nextAllowableInterventions: [Codes.C01],
         interventionName: AISInterventionTypes.AIS_ACCOUNT_SUSPENDED,
@@ -356,6 +365,8 @@ describe('send-audit-events', () => {
       'AIS_EVENT_IGNORED_ACCOUNT_DELETED',
       EventsEnum.FRAUD_SUSPEND_ACCOUNT,
       ingressInterventionEvent,
+      testSqsClient,
+      testQueueUrl,
       {
         nextAllowableInterventions: [],
         interventionName: AISInterventionTypes.AIS_ACCOUNT_SUSPENDED,
@@ -375,6 +386,8 @@ describe('send-audit-events', () => {
       'AIS_EVENT_TRANSITION_APPLIED',
       EventsEnum.FRAUD_SUSPEND_ACCOUNT,
       ingressInterventionEvent,
+      testSqsClient,
+      testQueueUrl,
       {
         nextAllowableInterventions: [Codes.C01, Codes.C91],
         interventionName: AISInterventionTypes.AIS_ACCOUNT_SUSPENDED,
@@ -394,6 +407,8 @@ describe('send-audit-events', () => {
       'AIS_EVENT_TRANSITION_APPLIED',
       EventsEnum.FRAUD_FORCED_USER_IDENTITY_REVERIFICATION,
       ingressInterventionEvent,
+      testSqsClient,
+      testQueueUrl,
       {
         nextAllowableInterventions: [],
         interventionName: AISInterventionTypes.AIS_FORCED_USER_IDENTITY_VERIFY,
@@ -413,6 +428,8 @@ describe('send-audit-events', () => {
       'AIS_EVENT_TRANSITION_APPLIED',
       EventsEnum.FRAUD_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_REVERIFICATION,
       ingressInterventionEvent,
+      testSqsClient,
+      testQueueUrl,
       {
         nextAllowableInterventions: [],
         interventionName: AISInterventionTypes.AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY,
@@ -436,6 +453,8 @@ describe('send-audit-events', () => {
       'AIS_EVENT_TRANSITION_APPLIED',
       EventsEnum.FRAUD_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_REVERIFICATION,
       ingressEventWithExtraInterventionData,
+      testSqsClient,
+      testQueueUrl,
       {
         nextAllowableInterventions: [],
         interventionName: AISInterventionTypes.AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY,
@@ -452,7 +471,7 @@ describe('send-audit-events', () => {
   it('should successfully send the audit event with any extra fields from the intervention event when there is no state engine output', async () => {
     sqsMock.on(SendMessageCommand).resolves({ $metadata: { httpStatusCode: 200 } });
     const sqsCommandInput = {
-      QueueUrl: AppConfigService.getInstance().txmaEgressQueueUrl,
+      QueueUrl: testQueueUrl,
       MessageBody: JSON.stringify({
         timestamp: 1234567,
         event_timestamp_ms: 1234567890,
@@ -473,6 +492,8 @@ describe('send-audit-events', () => {
       'AIS_EVENT_TRANSITION_APPLIED',
       EventsEnum.FRAUD_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_REVERIFICATION,
       ingressEventWithExtraInterventionData,
+      testSqsClient,
+      testQueueUrl,
     );
     expect(response).toEqual({ $metadata: { httpStatusCode: 200 } });
     expect(addMetric).toHaveBeenCalledWith('PUBLISHED_EVENT_TO_TXMA');
@@ -487,6 +508,8 @@ describe('send-audit-events', () => {
       'AIS_EVENT_TRANSITION_APPLIED',
       EventsEnum.FRAUD_UNSUSPEND_ACCOUNT,
       ingressInterventionEvent,
+      testSqsClient,
+      testQueueUrl,
       {
         nextAllowableInterventions: [Codes.C01],
         interventionName: AISInterventionTypes.AIS_ACCOUNT_UNSUSPENDED,
@@ -506,6 +529,8 @@ describe('send-audit-events', () => {
       'AIS_EVENT_IGNORED_IN_FUTURE',
       EventsEnum.FRAUD_SUSPEND_ACCOUNT,
       ingressInterventionEvent,
+      testSqsClient,
+      testQueueUrl,
     );
     expect(response).toEqual({ $metadata: { httpStatusCode: 200 } });
     expect(addMetric).toHaveBeenCalledWith('PUBLISHED_EVENT_TO_TXMA');
@@ -520,6 +545,8 @@ describe('send-audit-events', () => {
       'AIS_EVENT_TRANSITION_IGNORED',
       EventsEnum.IPV_ACCOUNT_INTERVENTION_END,
       ingressUserActionEvent,
+      testSqsClient,
+      testQueueUrl,
       {
         interventionName: AISInterventionTypes.AIS_ACCOUNT_SUSPENDED,
         stateResult: {

--- a/src/services/test/validate-event.test.ts
+++ b/src/services/test/validate-event.test.ts
@@ -212,7 +212,7 @@ describe('validateEventAgainstSchema', () => {
       stateResult: { blocked: false, reproveIdentity: false, resetPassword: false, suspended: false },
       interventionName: 'AIS_NO_INTERVENTION',
       nextAllowableInterventions: ['01', '03', '04', '05', '06'],
-    });
+    }, undefined, undefined);
   });
 
   it('should throw an error if event is stale', async () => {
@@ -252,7 +252,7 @@ describe('validateEventAgainstSchema', () => {
       stateResult: { blocked: false, reproveIdentity: false, resetPassword: false, suspended: false },
       interventionName: 'AIS_NO_INTERVENTION',
       nextAllowableInterventions: ['01', '03', '04', '05', '06'],
-    });
+    }, undefined, undefined);
   });
 
   it('should not throw if event is not stale', async () => {
@@ -317,6 +317,9 @@ describe('validateEventAgainstSchema', () => {
       'AIS_EVENT_IGNORED_IN_FUTURE',
       'FRAUD_SUSPEND_ACCOUNT',
       eventInTheFuture,
+      undefined,
+      undefined,
+      undefined,
     );
   });
 

--- a/src/services/test/validate-event.test.ts
+++ b/src/services/test/validate-event.test.ts
@@ -214,11 +214,11 @@ describe('validateEventAgainstSchema', () => {
       );
     }).rejects.toThrow(new ValidationError('Event received predates last applied event for this user.'));
     expect(addMetric).toHaveBeenCalledWith(MetricNames.INTERVENTION_EVENT_STALE);
-    expect(sendAuditEvent).toHaveBeenCalledWith('AIS_EVENT_IGNORED_STALE', 'FRAUD_SUSPEND_ACCOUNT', staleEvent, {
+    expect(sendAuditEvent).toHaveBeenCalledWith('AIS_EVENT_IGNORED_STALE', 'FRAUD_SUSPEND_ACCOUNT', staleEvent, mockSqsClient, mockQueueUrl, {
       stateResult: { blocked: false, reproveIdentity: false, resetPassword: false, suspended: false },
       interventionName: 'AIS_NO_INTERVENTION',
       nextAllowableInterventions: ['01', '03', '04', '05', '06'],
-    }, mockSqsClient, mockQueueUrl);
+    });
   });
 
   it('should throw an error if event is stale', async () => {
@@ -256,11 +256,11 @@ describe('validateEventAgainstSchema', () => {
       );
     }).rejects.toThrow(new ValidationError('Event received predates last applied event for this user.'));
     expect(addMetric).toHaveBeenCalledWith(MetricNames.INTERVENTION_EVENT_STALE);
-    expect(sendAuditEvent).toHaveBeenCalledWith('AIS_EVENT_IGNORED_STALE', 'FRAUD_SUSPEND_ACCOUNT', staleEvent, {
+    expect(sendAuditEvent).toHaveBeenCalledWith('AIS_EVENT_IGNORED_STALE', 'FRAUD_SUSPEND_ACCOUNT', staleEvent, mockSqsClient, mockQueueUrl, {
       stateResult: { blocked: false, reproveIdentity: false, resetPassword: false, suspended: false },
       interventionName: 'AIS_NO_INTERVENTION',
       nextAllowableInterventions: ['01', '03', '04', '05', '06'],
-    }, mockSqsClient, mockQueueUrl);
+    });
   });
 
   it('should not throw if event is not stale', async () => {
@@ -327,7 +327,6 @@ describe('validateEventAgainstSchema', () => {
       'AIS_EVENT_IGNORED_IN_FUTURE',
       'FRAUD_SUSPEND_ACCOUNT',
       eventInTheFuture,
-      undefined,
       mockSqsClient,
       mockQueueUrl,
     );

--- a/src/services/test/validate-event.test.ts
+++ b/src/services/test/validate-event.test.ts
@@ -13,10 +13,14 @@ import { AISInterventionTypes, EventsEnum, MetricNames, TriggerEventsEnum } from
 import { sendAuditEvent } from '../send-audit-events';
 import { getCurrentTimestamp } from '../../commons/get-current-timestamp';
 import { TICF_ACCOUNT_INTERVENTION } from '@govuk-one-login/event-catalogue/TICF_ACCOUNT_INTERVENTION';
+import { SQSClient } from '@aws-sdk/client-sqs';
 
 vi.mock('../../commons/metrics');
 vi.mock('@aws-lambda-powertools/logger');
 vi.mock('../send-audit-events');
+
+const mockSqsClient = {} as SQSClient;
+const mockQueueUrl = 'https://test-queue';
 const FIXED_TIME_MS = 1234567890;
 
 const dynamoDBResult: DynamoDBStateResult = {
@@ -205,6 +209,8 @@ describe('validateEventAgainstSchema', () => {
           reproveIdentity: false,
         },
         dynamoDBResult,
+        mockSqsClient,
+        mockQueueUrl,
       );
     }).rejects.toThrow(new ValidationError('Event received predates last applied event for this user.'));
     expect(addMetric).toHaveBeenCalledWith(MetricNames.INTERVENTION_EVENT_STALE);
@@ -212,7 +218,7 @@ describe('validateEventAgainstSchema', () => {
       stateResult: { blocked: false, reproveIdentity: false, resetPassword: false, suspended: false },
       interventionName: 'AIS_NO_INTERVENTION',
       nextAllowableInterventions: ['01', '03', '04', '05', '06'],
-    }, undefined, undefined);
+    }, mockSqsClient, mockQueueUrl);
   });
 
   it('should throw an error if event is stale', async () => {
@@ -245,6 +251,8 @@ describe('validateEventAgainstSchema', () => {
           reproveIdentity: false,
         },
         dynamoDBResult,
+        mockSqsClient,
+        mockQueueUrl,
       );
     }).rejects.toThrow(new ValidationError('Event received predates last applied event for this user.'));
     expect(addMetric).toHaveBeenCalledWith(MetricNames.INTERVENTION_EVENT_STALE);
@@ -252,7 +260,7 @@ describe('validateEventAgainstSchema', () => {
       stateResult: { blocked: false, reproveIdentity: false, resetPassword: false, suspended: false },
       interventionName: 'AIS_NO_INTERVENTION',
       nextAllowableInterventions: ['01', '03', '04', '05', '06'],
-    }, undefined, undefined);
+    }, mockSqsClient, mockQueueUrl);
   });
 
   it('should not throw if event is not stale', async () => {
@@ -285,6 +293,8 @@ describe('validateEventAgainstSchema', () => {
           reproveIdentity: false,
         },
         dynamoDBResult,
+        mockSqsClient,
+        mockQueueUrl,
       ),
     ).resolves.toEqual(undefined);
     expect(addMetric).not.toHaveBeenCalled();
@@ -310,7 +320,7 @@ describe('validateEventAgainstSchema', () => {
       },
     };
     await expect(async () => {
-      await validateEventIsNotInFuture(EventsEnum.FRAUD_SUSPEND_ACCOUNT, eventInTheFuture);
+      await validateEventIsNotInFuture(EventsEnum.FRAUD_SUSPEND_ACCOUNT, eventInTheFuture, mockSqsClient, mockQueueUrl);
     }).rejects.toThrow('Event has timestamp that is in the future.');
     expect(addMetric).toHaveBeenCalledWith(MetricNames.INTERVENTION_IGNORED_IN_FUTURE);
     expect(sendAuditEvent).toHaveBeenCalledWith(
@@ -318,8 +328,8 @@ describe('validateEventAgainstSchema', () => {
       'FRAUD_SUSPEND_ACCOUNT',
       eventInTheFuture,
       undefined,
-      undefined,
-      undefined,
+      mockSqsClient,
+      mockQueueUrl,
     );
   });
 
@@ -341,7 +351,7 @@ describe('validateEventAgainstSchema', () => {
         },
       },
     };
-    await expect(validateEventIsNotInFuture(EventsEnum.FRAUD_SUSPEND_ACCOUNT, eventNotInTheFuture)).resolves.toEqual(
+    await expect(validateEventIsNotInFuture(EventsEnum.FRAUD_SUSPEND_ACCOUNT, eventNotInTheFuture, mockSqsClient, mockQueueUrl)).resolves.toEqual(
       undefined,
     );
     expect(addMetric).not.toHaveBeenCalled();

--- a/src/services/validate-event.ts
+++ b/src/services/validate-event.ts
@@ -83,7 +83,7 @@ export async function validateEventIsNotInFuture(
       event: eventEnum,
     });
     addMetric(MetricNames.INTERVENTION_IGNORED_IN_FUTURE);
-    await sendAuditEvent('AIS_EVENT_IGNORED_IN_FUTURE', eventEnum, event, undefined, sqsClient, txmaEgressQueueUrl);
+    await sendAuditEvent('AIS_EVENT_IGNORED_IN_FUTURE', eventEnum, event, sqsClient, txmaEgressQueueUrl);
     throw new RetryEventError('Event has timestamp that is in the future.');
   }
 }
@@ -108,11 +108,11 @@ export async function validateEventIsNotStale(
   if (!isEventAfterLastEvent(eventTimestampInMs, itemFromDB.sentAt, itemFromDB.appliedAt)) {
     logger.warn('Event received predates last applied event for this user.');
     addMetric(MetricNames.INTERVENTION_EVENT_STALE);
-    await sendAuditEvent('AIS_EVENT_IGNORED_STALE', intervention, event, {
+    await sendAuditEvent('AIS_EVENT_IGNORED_STALE', intervention, event, sqsClient, txmaEgressQueueUrl, {
       stateResult: initialState,
       interventionName: AISInterventionTypes.AIS_NO_INTERVENTION,
       nextAllowableInterventions: AccountStateEngine.getInstance().determineNextAllowableInterventions(initialState),
-    }, sqsClient, txmaEgressQueueUrl);
+    });
     throw new ValidationError('Event received predates last applied event for this user.');
   }
 }

--- a/src/services/validate-event.ts
+++ b/src/services/validate-event.ts
@@ -69,8 +69,8 @@ export function validateIfIdentityAcquired(event: InterventionEventMessage) {
 export async function validateEventIsNotInFuture(
   eventEnum: EventsEnum,
   event: InterventionEventMessage,
-  sqsClient?: SQSClient,
-  txmaEgressQueueUrl?: string,
+  sqsClient: SQSClient,
+  txmaEgressQueueUrl: string,
 ) {
   const eventTimestampInMs = event.event_timestamp_ms;
   const now = getCurrentTimestamp().milliseconds;
@@ -101,8 +101,8 @@ export async function validateEventIsNotStale(
   event: InterventionEventMessage,
   initialState: StateDetails,
   itemFromDB: DynamoDBStateResult,
-  sqsClient?: SQSClient,
-  txmaEgressQueueUrl?: string,
+  sqsClient: SQSClient,
+  txmaEgressQueueUrl: string,
 ) {
   const eventTimestampInMs = event.event_timestamp_ms;
   if (!isEventAfterLastEvent(eventTimestampInMs, itemFromDB.sentAt, itemFromDB.appliedAt)) {

--- a/src/services/validate-event.ts
+++ b/src/services/validate-event.ts
@@ -10,6 +10,7 @@ import { sendAuditEvent } from './send-audit-events';
 import { AccountStateEngine } from './account-states/account-state-engine';
 import jsonSafeParse from '../commons/json-safe-parse';
 import { InterventionEventMessage, interventionMessageSchema } from '../contracts/intervention-events';
+import { SQSClient } from '@aws-sdk/client-sqs';
 
 const validateEventCatalogue = compileSchema(EventCatalogueCombinedSchema);
 
@@ -65,7 +66,12 @@ export function validateIfIdentityAcquired(event: InterventionEventMessage) {
  * @param event - the event received
  * @throws RetryEventError - if the timestamp of the event is in the future
  */
-export async function validateEventIsNotInFuture(eventEnum: EventsEnum, event: InterventionEventMessage) {
+export async function validateEventIsNotInFuture(
+  eventEnum: EventsEnum,
+  event: InterventionEventMessage,
+  sqsClient?: SQSClient,
+  txmaEgressQueueUrl?: string,
+) {
   const eventTimestampInMs = event.event_timestamp_ms;
   const now = getCurrentTimestamp().milliseconds;
   if (now < eventTimestampInMs) {
@@ -77,7 +83,7 @@ export async function validateEventIsNotInFuture(eventEnum: EventsEnum, event: I
       event: eventEnum,
     });
     addMetric(MetricNames.INTERVENTION_IGNORED_IN_FUTURE);
-    await sendAuditEvent('AIS_EVENT_IGNORED_IN_FUTURE', eventEnum, event);
+    await sendAuditEvent('AIS_EVENT_IGNORED_IN_FUTURE', eventEnum, event, undefined, sqsClient, txmaEgressQueueUrl);
     throw new RetryEventError('Event has timestamp that is in the future.');
   }
 }
@@ -95,6 +101,8 @@ export async function validateEventIsNotStale(
   event: InterventionEventMessage,
   initialState: StateDetails,
   itemFromDB: DynamoDBStateResult,
+  sqsClient?: SQSClient,
+  txmaEgressQueueUrl?: string,
 ) {
   const eventTimestampInMs = event.event_timestamp_ms;
   if (!isEventAfterLastEvent(eventTimestampInMs, itemFromDB.sentAt, itemFromDB.appliedAt)) {
@@ -104,7 +112,7 @@ export async function validateEventIsNotStale(
       stateResult: initialState,
       interventionName: AISInterventionTypes.AIS_NO_INTERVENTION,
       nextAllowableInterventions: AccountStateEngine.getInstance().determineNextAllowableInterventions(initialState),
-    });
+    }, sqsClient, txmaEgressQueueUrl);
     throw new ValidationError('Event received predates last applied event for this user.');
   }
 }


### PR DESCRIPTION
## What

This updates the intervention processor handler to explicitly require config being passed in. Unfortunately, because part of the config was used in a bunch of modules to do run-time object construction (e.g making SQS queues to send audit events) this isn't just data, and includes a bunch of pass through changes.

## Why

This makes the config types much more robust and helps us avoid issues like the one we had recently where a dependency of the intervention processor handler was expecting some config that wasn't actually there. When this is properly rolled out it should also mean we can just pass around data in tests instead of faffing around with environment variables.

## Notes

This is on top of https://github.com/govuk-one-login/account-interventions-service/pull/1120 and you should review that first. This branch shouldn't be too bad for reviewing if you go commit-by-commit

### Issue tracking

- [FPAD-8587](https://govukverify.atlassian.net/browse/FPAD-8587)


[FPAD-8587]: https://govukverify.atlassian.net/browse/FPAD-8587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ