### PR TITLE
Fix `Error caught whilst attempting to persist ignored event.` log lines

### DIFF
--- a/src/handlers/interventions-processor.ts
+++ b/src/handlers/interventions-processor.ts
@@ -94,11 +94,20 @@ async function processSQSRecord(
 
   const recordBody = attemptToParseJson(record.body);
 
-  const { result, eventName } = await validateRecord(recordBody, accountStateEngine, sqsClient, txmaEgressQueueUrl);
+  const { result: eventMessage, eventName } = await validateRecord(
+    recordBody,
+    accountStateEngine,
+    sqsClient,
+    txmaEgressQueueUrl,
+  );
 
-  const userId = result.user.user_id;
+  const userId = eventMessage.user.user_id;
 
-  addMetric(MetricNames.EVENT_DELIVERY_LATENCY, noMetadata, currentTimestamp.milliseconds - result.event_timestamp_ms);
+  addMetric(
+    MetricNames.EVENT_DELIVERY_LATENCY,
+    noMetadata,
+    currentTimestamp.milliseconds - eventMessage.event_timestamp_ms,
+  );
 
   const itemFromDB = await accountStatusService.getAccountStateInformation(userId);
 
@@ -108,20 +117,27 @@ async function processSQSRecord(
     await validateAccountIsNotDeleted(
       eventName,
       userId,
-      result,
+      eventMessage,
       currentAccountState,
       itemFromDB,
       sqsClient,
       txmaEgressQueueUrl,
     );
-    await validateEventIsNotStale(eventName, result, currentAccountState, itemFromDB, sqsClient, txmaEgressQueueUrl);
+    await validateEventIsNotStale(
+      eventName,
+      eventMessage,
+      currentAccountState,
+      itemFromDB,
+      sqsClient,
+      txmaEgressQueueUrl,
+    );
   }
 
   const statusResult = await applyEventTransition(
     eventName,
     currentAccountState,
     itemFromDB?.intervention,
-    result,
+    eventMessage,
     interventionEventsService,
     accountStateEngine,
     {
@@ -134,7 +150,7 @@ async function processSQSRecord(
     userId,
     statusResult,
     currentTimestamp,
-    result,
+    eventMessage,
     itemFromDB?.history ?? [],
   );
   publishTimeToResolveMetrics(
@@ -147,10 +163,23 @@ async function processSQSRecord(
 
   updateAccountStateCountMetric(currentAccountState, statusResult.stateResult);
   addMetric(MetricNames.INTERVENTION_EVENT_APPLIED, [], 1, { eventName });
-  await sendAuditEvent('AIS_EVENT_TRANSITION_APPLIED', eventName, result, sqsClient, txmaEgressQueueUrl, statusResult);
+  await sendAuditEvent(
+    'AIS_EVENT_TRANSITION_APPLIED',
+    eventName,
+    eventMessage,
+    sqsClient,
+    txmaEgressQueueUrl,
+    statusResult,
+  );
 
   try {
-    await persistInterventionEvents(result, eventName, itemFromDB, interventionEventsService, historyRetentionSeconds);
+    await persistInterventionEvents(
+      eventMessage,
+      eventName,
+      itemFromDB,
+      interventionEventsService,
+      historyRetentionSeconds,
+    );
   } catch (error) {
     logger.error('Error caught while persisting intervention events.', { errorMessage: (error as Error).message });
     addMetric(MetricNames.PERSIST_INTERVENTION_EVENTS_ERROR);
@@ -176,10 +205,10 @@ async function validateRecord(
 }
 
 async function applyEventTransition(
-  event: EventsEnum,
+  eventType: EventsEnum,
   initialState: StateDetails,
   interventionName: string | undefined,
-  result: InterventionEventMessage,
+  eventMessage: InterventionEventMessage,
   interventionEventsService: InterventionEventsService,
   accountStateEngine: AccountStateEngine,
   sqs: {
@@ -188,19 +217,19 @@ async function applyEventTransition(
   },
 ) {
   try {
-    return accountStateEngine.applyEventTransition(event, initialState, interventionName);
+    return accountStateEngine.applyEventTransition(eventType, initialState, interventionName);
   } catch (error) {
     if (error instanceof StateTransitionError) {
       await sendAuditEvent(
         'AIS_EVENT_TRANSITION_IGNORED',
         error.transition,
-        result,
+        eventMessage,
         sqs.sqsClient,
         sqs.txmaEgressQueueUrl,
         error.output,
       );
       try {
-        await persistIgnoredInterventionEvent(result, event, initialState, interventionEventsService);
+        await persistIgnoredInterventionEvent(eventMessage, eventType, initialState, interventionEventsService);
       } catch (error) {
         logger.error('Error caught whilst attempting to persist ignored event.', {
           errorMessage: (error as Error).message,

--- a/src/services/persist-intervention-events.ts
+++ b/src/services/persist-intervention-events.ts
@@ -52,7 +52,7 @@ export async function persistIgnoredInterventionEvent(
   event: EventsEnum,
   previousState: StateDetails | undefined,
   interventionEventsService: InterventionEventsService,
-) {
+): Promise<void> {
   const attemptedInterventions = config[event]
     .filter((u) => u.interventionState === InterventionState.ACTIVE)
     .map((u) => u.interventionName);
@@ -63,11 +63,15 @@ export async function persistIgnoredInterventionEvent(
     previousState,
   );
 
-  const updatedIntervention = attemptedInterventions
+  const updatedInterventions = attemptedInterventions
     .filter((name) => activeInterventions.includes(name))
     .map((name) => ({ interventionName: name, interventionState: InterventionState.IGNORED }));
 
-  const callWith = enrichEvents(updatedIntervention, message);
+  if (updatedInterventions.length === 0) {
+    return;
+  }
+
+  const callWith = enrichEvents(updatedInterventions, message);
 
   await interventionEventsService.appendEvents(callWith);
 }


### PR DESCRIPTION
## What

Check for zero events before trying persisting ignored intervention events.

## Why

We have a bunch of `ERROR` level [log lines in production](https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#log-analytics?active=%7E%27a&a.id=%7E%27718387f4-fab7-4d27-893d-60dcdcad1d01&a.pos=%7E%270&a.label=%7E%27Query*201&a.type=%7E%27query&a.query=%7E%27SOURCE*20*22arn*3aaws*3alogs*3aeu-west-2*3a324281879537*3alog-group*3a*2faws*2flambda*2fais-main-InterventionsProcessorFunction*22*20START*3d-10800s*20END*3d0s*20*7c*0afields*20*40timestamp*2c*20*40message*0a*7c*20filter*20level*20*3d*20*22ERROR*22*0a*7c*20sort*20*40timestamp*20desc*0a*7c*20limit*2010000) because we're trying to run a DynamoDB batch insert with an empty array - this adds a check for the empty array before the write gets called.

I also made some changes to variable names for clarity
