### PR TITLE
Fpad 8632 move to app config

### DIFF
--- a/src/handlers/frontend-handler.ts
+++ b/src/handlers/frontend-handler.ts
@@ -8,20 +8,21 @@ import { InterventionClient } from '@govuk-one-login/ais-status-sdk';
 import { JwtAuthoriser } from '../frontend/authoriser';
 import { FeatureFlagsFromEnvironmentVariables } from '../services/feature-flags';
 import { SqsMessageService } from '../services/message-service';
+import { AppConfigService } from '../services/app-config-service';
 
 const subpath = process.env['SUBPATH'] ?? '';
-const statusApiUrl = process.env['STATUS_API_URL'];
-const txmaQueueUrl = process.env['TXMA_QUEUE_URL'];
+
+const config = AppConfigService.getInstance().getConfigObject(['statusApiUrl', 'txmaQueueUrl']);
 
 const featureFlags = FeatureFlagsFromEnvironmentVariables.getInstance();
 
 const authoriser = new JwtAuthoriser();
 
-const interventionClient = new InterventionClient(statusApiUrl, {
+const interventionClient = new InterventionClient(config.statusApiUrl, {
   logger,
 });
 
-const messageService = new SqsMessageService(txmaQueueUrl);
+const messageService = new SqsMessageService(config.txmaQueueUrl);
 
 const proxy = awsLambdaFastify(
   init(

--- a/src/services/app-config-service.ts
+++ b/src/services/app-config-service.ts
@@ -53,6 +53,14 @@ const CONFIG_ENVIRONMENT_MAPPING = {
     envVar: 'HISTORY_RETENTION_SECONDS',
     type: 'number' as const,
   },
+  statusApiUrl: {
+    envVar: 'STATUS_API_URL',
+    type: 'string' as const,
+  },
+  txmaQueueUrl: {
+    envVar: 'TXMA_QUEUE_URL',
+    type: 'string' as const,
+  },
 } satisfies Record<string, ConfigDefinition>;
 
 /** The valid keys of CONFIG_ENVIRONMENT_MAPPING, used to constrain getConfigObject input. */

--- a/src/services/test/app-config-service.test.ts
+++ b/src/services/test/app-config-service.test.ts
@@ -69,6 +69,8 @@ describe('AppConfigService', () => {
   });
 
   it('should return the value of all environment variables', () => {
+    vi.stubEnv('TXMA_QUEUE_URL', 'https://sqs.eu-west-2.amazonaws.com/111122223333/TxMAQueue');
+
     const appConfig = AppConfigService.getInstance();
     expect(appConfig.awsRegion).toEqual('aws_region');
     expect(appConfig.tableName).toEqual('table_name');

--- a/src/services/test/app-config-service.test.ts
+++ b/src/services/test/app-config-service.test.ts
@@ -68,19 +68,6 @@ describe('AppConfigService', () => {
     expect(logger.error).toHaveBeenCalledWith(expectedMessage);
   });
 
-  it('should return the value of all environment variables', () => {
-    vi.stubEnv('TXMA_QUEUE_URL', 'https://sqs.eu-west-2.amazonaws.com/111122223333/TxMAQueue');
-
-    const appConfig = AppConfigService.getInstance();
-    expect(appConfig.awsRegion).toEqual('aws_region');
-    expect(appConfig.tableName).toEqual('table_name');
-    expect(appConfig.cloudWatchMetricsWorkSpace).toEqual('test_namespace');
-    expect(appConfig.metricServiceName).toEqual('test');
-    expect(appConfig.maxRetentionSeconds).toEqual(12345);
-    expect(appConfig.txmaEgressQueueUrl).toEqual('https://sqs.eu-west-2.amazonaws.com/111122223333/TxMAQueue');
-    expect(appConfig.historyRetentionSeconds).toEqual(63072000);
-  });
-
   it('should throw an error if the environmental variable is not a number', () => {
     vi.stubEnv('DELETED_ACCOUNT_RETENTION_SECONDS', 'string');
     const expectedMessage =

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,7 +15,13 @@ export default defineConfig({
       reporter: ['text', 'lcov'],
       reportsDirectory: './coverage',
     },
-    exclude: ['**/node_modules/**', 'src/contract-testing/**', '.stryker-tmp/**', 'src/scripts/**', 'packages/ais-status-sdk/integration-tests/**'],
+    exclude: [
+      '**/node_modules/**',
+      'src/contract-testing/**',
+      '.stryker-tmp/**',
+      'src/scripts/**',
+      'packages/ais-status-sdk/integration-tests/**',
+    ],
     env: {
       CLOUDWATCH_METRICS_NAMESPACE: 'test_namespace',
       METRIC_SERVICE_NAME: 'test',
@@ -23,7 +29,6 @@ export default defineConfig({
       INTERVENTION_EVENTS_TABLE_NAME: 'intervention-events',
       AWS_REGION: 'aws_region',
       DELETED_ACCOUNT_RETENTION_SECONDS: '12345',
-      TXMA_QUEUE_URL: 'https://sqs.eu-west-2.amazonaws.com/111122223333/TxMAQueue',
       HISTORY_RETENTION_SECONDS: '63072000',
       ENABLE_AIS_FRONTEND: 'true',
       ENABLE_AIS_SEND_TXMA: 'true',


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What

Move `statusApiUrl` and `txmaQueueUrl` to app config

## Why

Single config object to inject app config

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-8632](https://govukverify.atlassian.net/browse/FPAD-8632)

[FPAD-8632]: https://govukverify.atlassian.net/browse/FPAD-8632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ