### PR TITLE
FPAD-8611: Add frontend snapshot testing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
       - id: end-of-file-fixer
         exclude: '\.json$|packages/ais-status-sdk/CHANGELOG.md'
       - id: trailing-whitespace
+        exclude: '\/__snapshots__\/.+'
       - id: detect-private-key
       - id: detect-aws-credentials
         args: [--allow-missing-credentials]

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "npm run test:unit",
     "test:unit": "vitest run --coverage",
     "test:unit:watch": "vitest --coverage",
+    "test:unit:update-snapshots": "vitest run --update",
     "test:types": "tsc --noEmit",
     "test:pact:provider": "vitest -c vitest.contract.config.ts src/contract-testing/provider/*",
     "test:pact:consumer": "vitest -c vitest.contract.config.ts src/contract-testing/consumer/*",

--- a/packages/ais-status-sdk/src/stub.ts
+++ b/packages/ais-status-sdk/src/stub.ts
@@ -1,4 +1,3 @@
-import { InterventionRequestFailed } from './errors';
 import { AccountHistory, AccountStatus, InterventionClientInterface, InterventionName } from './types';
 
 export interface InterventionStubConfig {
@@ -18,12 +17,11 @@ export class InterventionStub implements InterventionClientInterface {
         interventions: this.config.interventionNames.map((name) => ({ name })),
       });
 
-    throw new InterventionRequestFailed();
+    return Promise.resolve({ interventions: [] });
   }
 
   getAccountHistory(): Promise<AccountHistory> {
     if (this.config?.historyResult) return Promise.resolve(this.config.historyResult);
-
-    throw new InterventionRequestFailed();
+    return Promise.resolve({ lines: [] });
   }
 }

--- a/src/frontend/tests/__snapshots__/app.snapshot.test.ts.snap
+++ b/src/frontend/tests/__snapshots__/app.snapshot.test.ts.snap
@@ -1,0 +1,1079 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`rendered page snapshots > renders the index page 1`] = `
+"<!DOCTYPE html>
+<html lang="en" class="govuk-template">
+  <head>
+    <meta charset="utf-8">
+    <title>Account Interventions Service – GOV.UK</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="theme-color" content="#1d70b8">
+
+    
+  <link rel="stylesheet" href="/assets/govuk-frontend.min.css"/>
+
+
+    
+      <link rel="icon" sizes="48x48" href="/assets/images/favicon.ico">
+      <link rel="icon" sizes="any" href="/assets/images/favicon.svg" type="image/svg+xml">
+      <link rel="mask-icon" href="/assets/images/govuk-icon-mask.svg" color="#1d70b8">
+      <link rel="apple-touch-icon" href="/assets/images/govuk-icon-180.png">
+      <link rel="manifest" href="/assets/manifest.json">
+    
+    
+  </head>
+  <body class="govuk-template__body">
+    <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
+    
+
+    
+        <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+
+      
+
+    
+    
+
+    
+  
+
+
+
+
+<div class="govuk-header">
+  <div class="govuk-header__container govuk-width-container">
+    <div class="govuk-header__logo">
+      <a href="/" class="govuk-header__homepage-link">
+        
+          <svg
+            focusable="false"
+            role="img"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 324 60"
+            height="30"
+            width="162"
+            fill="currentcolor" class="govuk-header__logotype" aria-label="GOV.UK"
+          ><title>GOV.UK</title>
+            <g>
+                <circle cx="20" cy="17.6" r="3.7"/>
+                <circle cx="10.2" cy="23.5" r="3.7"/>
+                <circle cx="3.7" cy="33.2" r="3.7"/>
+                <circle cx="31.7" cy="30.6" r="3.7"/>
+                <circle cx="43.3" cy="17.6" r="3.7"/>
+                <circle cx="53.2" cy="23.5" r="3.7"/>
+                <circle cx="59.7" cy="33.2" r="3.7"/>
+                <circle cx="31.7" cy="30.6" r="3.7"/>
+                <path d="M33.1,9.8c.2-.1.3-.3.5-.5l4.6,2.4v-6.8l-4.6,1.5c-.1-.2-.3-.3-.5-.5l1.9-5.9h-6.7l1.9,5.9c-.2.1-.3.3-.5.5l-4.6-1.5v6.8l4.6-2.4c.1.2.3.3.5.5l-2.6,8c-.9,2.8,1.2,5.7,4.1,5.7h0c3,0,5.1-2.9,4.1-5.7l-2.6-8ZM37,37.9s-3.4,3.8-4.1,6.1c2.2,0,4.2-.5,6.4-2.8l-.7,8.5c-2-2.8-4.4-4.1-5.7-3.8.1,3.1.5,6.7,5.8,7.2,3.7.3,6.7-1.5,7-3.8.4-2.6-2-4.3-3.7-1.6-1.4-4.5,2.4-6.1,4.9-3.2-1.9-4.5-1.8-7.7,2.4-10.9,3,4,2.6,7.3-1.2,11.1,2.4-1.3,6.2,0,4,4.6-1.2-2.8-3.7-2.2-4.2.2-.3,1.7.7,3.7,3,4.2,1.9.3,4.7-.9,7-5.9-1.3,0-2.4.7-3.9,1.7l2.4-8c.6,2.3,1.4,3.7,2.2,4.5.6-1.6.5-2.8,0-5.3l5,1.8c-2.6,3.6-5.2,8.7-7.3,17.5-7.4-1.1-15.7-1.7-24.5-1.7h0c-8.8,0-17.1.6-24.5,1.7-2.1-8.9-4.7-13.9-7.3-17.5l5-1.8c-.5,2.5-.6,3.7,0,5.3.8-.8,1.6-2.3,2.2-4.5l2.4,8c-1.5-1-2.6-1.7-3.9-1.7,2.3,5,5.2,6.2,7,5.9,2.3-.4,3.3-2.4,3-4.2-.5-2.4-3-3.1-4.2-.2-2.2-4.6,1.6-6,4-4.6-3.7-3.7-4.2-7.1-1.2-11.1,4.2,3.2,4.3,6.4,2.4,10.9,2.5-2.8,6.3-1.3,4.9,3.2-1.8-2.7-4.1-1-3.7,1.6.3,2.3,3.3,4.1,7,3.8,5.4-.5,5.7-4.2,5.8-7.2-1.3-.2-3.7,1-5.7,3.8l-.7-8.5c2.2,2.3,4.2,2.7,6.4,2.8-.7-2.3-4.1-6.1-4.1-6.1h10.6,0Z"/>
+              </g>
+            
+              <circle class="govuk-logo-dot" cx="226" cy="36" r="7.3"/>
+              <path d="M93.94 41.25c.4 1.81 1.2 3.21 2.21 4.62 1 1.4 2.21 2.41 3.61 3.21s3.21 1.2 5.22 1.2 3.61-.4 4.82-1c1.4-.6 2.41-1.4 3.21-2.41.8-1 1.4-2.01 1.61-3.01s.4-2.01.4-3.01v.14h-10.86v-7.02h20.07v24.08h-8.03v-5.56c-.6.8-1.38 1.61-2.19 2.41-.8.8-1.81 1.2-2.81 1.81-1 .4-2.21.8-3.41 1.2s-2.41.4-3.81.4a18.56 18.56 0 0 1-14.65-6.63c-1.6-2.01-3.01-4.41-3.81-7.02s-1.4-5.62-1.4-8.83.4-6.02 1.4-8.83a20.45 20.45 0 0 1 19.46-13.65c3.21 0 4.01.2 5.82.8 1.81.4 3.61 1.2 5.02 2.01 1.61.8 2.81 2.01 4.01 3.21s2.21 2.61 2.81 4.21l-7.63 4.41c-.4-1-1-1.81-1.61-2.61-.6-.8-1.4-1.4-2.21-2.01-.8-.6-1.81-1-2.81-1.4-1-.4-2.21-.4-3.61-.4-2.01 0-3.81.4-5.22 1.2-1.4.8-2.61 1.81-3.61 3.21s-1.61 2.81-2.21 4.62c-.4 1.81-.6 3.71-.6 5.42s.8 5.22.8 5.22Zm57.8-27.9c3.21 0 6.22.6 8.63 1.81 2.41 1.2 4.82 2.81 6.62 4.82S170.2 24.39 171 27s1.4 5.62 1.4 8.83-.4 6.02-1.4 8.83-2.41 5.02-4.01 7.02-4.01 3.61-6.62 4.82-5.42 1.81-8.63 1.81-6.22-.6-8.63-1.81-4.82-2.81-6.42-4.82-3.21-4.41-4.01-7.02-1.4-5.62-1.4-8.83.4-6.02 1.4-8.83 2.41-5.02 4.01-7.02 4.01-3.61 6.42-4.82 5.42-1.81 8.63-1.81Zm0 36.73c1.81 0 3.61-.4 5.02-1s2.61-1.81 3.61-3.01 1.81-2.81 2.21-4.41c.4-1.81.8-3.61.8-5.62 0-2.21-.2-4.21-.8-6.02s-1.2-3.21-2.21-4.62c-1-1.2-2.21-2.21-3.61-3.01s-3.21-1-5.02-1-3.61.4-5.02 1c-1.4.8-2.61 1.81-3.61 3.01s-1.81 2.81-2.21 4.62c-.4 1.81-.8 3.61-.8 5.62 0 2.41.2 4.21.8 6.02.4 1.81 1.2 3.21 2.21 4.41s2.21 2.21 3.61 3.01c1.4.8 3.21 1 5.02 1Zm36.32 7.96-12.24-44.15h9.83l8.43 32.77h.4l8.23-32.77h9.83L200.3 58.04h-12.24Zm74.14-7.96c2.18 0 3.51-.6 3.51-.6 1.2-.6 2.01-1 2.81-1.81s1.4-1.81 1.81-2.81a13 13 0 0 0 .8-4.01V13.9h8.63v28.15c0 2.41-.4 4.62-1.4 6.62-.8 2.01-2.21 3.61-3.61 5.02s-3.41 2.41-5.62 3.21-4.62 1.2-7.02 1.2-5.02-.4-7.02-1.2c-2.21-.8-4.01-1.81-5.62-3.21s-2.81-3.01-3.61-5.02-1.4-4.21-1.4-6.62V13.9h8.63v26.95c0 1.61.2 3.01.8 4.01.4 1.2 1.2 2.21 2.01 2.81.8.8 1.81 1.4 2.81 1.81 0 0 1.34.6 3.51.6Zm34.22-36.18v18.92l15.65-18.92h10.82l-15.03 17.32 16.03 26.83h-10.21l-11.44-20.21-5.62 6.22v13.99h-8.83V13.9"/>
+            
+          </svg>
+          <span class="govuk-header__product-name">One Login Account Interventions Service</span>
+        
+      </a>
+    </div>
+  </div>
+</div>
+
+
+  
+
+  <div 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </div>
+
+
+
+
+    
+      <div class="govuk-width-container">
+        
+        
+        <main class="govuk-main-wrapper" id="main-content">
+          
+  <h1 class="govuk-heading-xl">Account Interventions Service</h1>
+  <form method="post" action="/search">
+    
+
+
+<div class="govuk-form-group">
+  <label class="govuk-label govuk-label--m" for="user-id">
+    GOV.UK One Login Subject Identifier
+  </label>
+
+  
+  
+  <div id="user-id-hint" class="govuk-hint">
+    For example, urn:fdc:gov.uk:2022:pgt1qOf7zW2tMCZg4V5LEu-mT-_GTSX7xqJ6RJekw9I
+  </div>
+
+
+  <input
+    
+        
+        
+      
+        
+      
+    
+        
+        
+      
+        
+      
+    
+        
+        
+      
+        
+      
+    
+        
+        
+      
+        
+      
+    
+        
+        
+      
+    
+        
+        
+    
+        
+        
+    
+        
+        
+      
+        
+      
+    
+        
+        
+      
+        
+      
+    
+        
+        
+    
+        
+        
+    
+        
+        
+    
+   class="govuk-input" id="user-id" name="userId" type="text" aria-describedby="user-id-hint" autocomplete="off">
+
+</div>
+
+    
+<button type="submit" class="govuk-button" data-module="govuk-button">
+  Submit
+</button>
+
+  </form>
+
+        </main>
+        
+        
+      </div>
+    
+
+    
+    
+
+    
+  <div class="govuk-footer">
+  <div class="govuk-width-container">
+  <svg
+    focusable="false"
+    role="presentation"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 64 60"
+    height="30"
+    width="32"
+    fill="currentcolor" class="govuk-footer__crown"
+  >
+    <g>
+        <circle cx="20" cy="17.6" r="3.7"/>
+        <circle cx="10.2" cy="23.5" r="3.7"/>
+        <circle cx="3.7" cy="33.2" r="3.7"/>
+        <circle cx="31.7" cy="30.6" r="3.7"/>
+        <circle cx="43.3" cy="17.6" r="3.7"/>
+        <circle cx="53.2" cy="23.5" r="3.7"/>
+        <circle cx="59.7" cy="33.2" r="3.7"/>
+        <circle cx="31.7" cy="30.6" r="3.7"/>
+        <path d="M33.1,9.8c.2-.1.3-.3.5-.5l4.6,2.4v-6.8l-4.6,1.5c-.1-.2-.3-.3-.5-.5l1.9-5.9h-6.7l1.9,5.9c-.2.1-.3.3-.5.5l-4.6-1.5v6.8l4.6-2.4c.1.2.3.3.5.5l-2.6,8c-.9,2.8,1.2,5.7,4.1,5.7h0c3,0,5.1-2.9,4.1-5.7l-2.6-8ZM37,37.9s-3.4,3.8-4.1,6.1c2.2,0,4.2-.5,6.4-2.8l-.7,8.5c-2-2.8-4.4-4.1-5.7-3.8.1,3.1.5,6.7,5.8,7.2,3.7.3,6.7-1.5,7-3.8.4-2.6-2-4.3-3.7-1.6-1.4-4.5,2.4-6.1,4.9-3.2-1.9-4.5-1.8-7.7,2.4-10.9,3,4,2.6,7.3-1.2,11.1,2.4-1.3,6.2,0,4,4.6-1.2-2.8-3.7-2.2-4.2.2-.3,1.7.7,3.7,3,4.2,1.9.3,4.7-.9,7-5.9-1.3,0-2.4.7-3.9,1.7l2.4-8c.6,2.3,1.4,3.7,2.2,4.5.6-1.6.5-2.8,0-5.3l5,1.8c-2.6,3.6-5.2,8.7-7.3,17.5-7.4-1.1-15.7-1.7-24.5-1.7h0c-8.8,0-17.1.6-24.5,1.7-2.1-8.9-4.7-13.9-7.3-17.5l5-1.8c-.5,2.5-.6,3.7,0,5.3.8-.8,1.6-2.3,2.2-4.5l2.4,8c-1.5-1-2.6-1.7-3.9-1.7,2.3,5,5.2,6.2,7,5.9,2.3-.4,3.3-2.4,3-4.2-.5-2.4-3-3.1-4.2-.2-2.2-4.6,1.6-6,4-4.6-3.7-3.7-4.2-7.1-1.2-11.1,4.2,3.2,4.3,6.4,2.4,10.9,2.5-2.8,6.3-1.3,4.9,3.2-1.8-2.7-4.1-1-3.7,1.6.3,2.3,3.3,4.1,7,3.8,5.4-.5,5.7-4.2,5.8-7.2-1.3-.2-3.7,1-5.7,3.8l-.7-8.5c2.2,2.3,4.2,2.7,6.4,2.8-.7-2.3-4.1-6.1-4.1-6.1h10.6,0Z"/>
+      </g>
+    
+  </svg>
+
+    
+    <div class="govuk-footer__meta">
+      <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+        
+        <h2 class="govuk-visually-hidden">Support links</h2>
+        
+        <ul class="govuk-footer__inline-list">
+        
+          <li class="govuk-footer__inline-list-item">
+            <a class="govuk-footer__link" href="https://signin.account.gov.uk/accessibility-statement">
+              Accessibility statement
+            </a>
+          </li>
+        
+          <li class="govuk-footer__inline-list-item">
+            <a class="govuk-footer__link" href="https://signin.account.gov.uk/cookies">
+              Cookies
+            </a>
+          </li>
+        
+          <li class="govuk-footer__inline-list-item">
+            <a class="govuk-footer__link" href="https://signin.account.gov.uk/terms-and-conditions">
+              Terms and conditions
+            </a>
+          </li>
+        
+          <li class="govuk-footer__inline-list-item">
+            <a class="govuk-footer__link" href="https://signin.account.gov.uk/privacy-notice">
+              Privacy notice
+            </a>
+          </li>
+        
+        </ul>
+        
+        
+        
+        
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            class="govuk-footer__licence-logo"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 483.2 195.7"
+            height="17"
+            width="41"
+          >
+            <path
+              fill="currentColor"
+              d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
+            />
+          </svg>
+          <span class="govuk-footer__licence-description">
+          
+            All content is available under the <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+          
+          </span>
+        
+      </div>
+      <div class="govuk-footer__meta-item">
+        <a
+          class="govuk-footer__link govuk-footer__copyright-logo"
+          href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
+        >
+        
+          © Crown copyright
+        
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+
+    
+  <script type="module" src="/assets/govuk-frontend.min.js" nonce=""></script>
+  <script type="module" nonce="">
+    import {initAll} from '/assets/govuk-frontend.min.js'
+    initAll()
+  </script>
+
+  </body>
+</html>
+"
+`;
+
+exports[`rendered page snapshots > renders the user details page with history 1`] = `
+"<!DOCTYPE html>
+<html lang="en" class="govuk-template">
+  <head>
+    <meta charset="utf-8">
+    <title>Account Interventions Service – GOV.UK</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="theme-color" content="#1d70b8">
+
+    
+  <link rel="stylesheet" href="/assets/govuk-frontend.min.css"/>
+
+
+    
+      <link rel="icon" sizes="48x48" href="/assets/images/favicon.ico">
+      <link rel="icon" sizes="any" href="/assets/images/favicon.svg" type="image/svg+xml">
+      <link rel="mask-icon" href="/assets/images/govuk-icon-mask.svg" color="#1d70b8">
+      <link rel="apple-touch-icon" href="/assets/images/govuk-icon-180.png">
+      <link rel="manifest" href="/assets/manifest.json">
+    
+    
+  </head>
+  <body class="govuk-template__body">
+    <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
+    
+
+    
+        <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+
+      
+
+    
+    
+
+    
+  
+
+
+
+
+<div class="govuk-header">
+  <div class="govuk-header__container govuk-width-container">
+    <div class="govuk-header__logo">
+      <a href="/" class="govuk-header__homepage-link">
+        
+          <svg
+            focusable="false"
+            role="img"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 324 60"
+            height="30"
+            width="162"
+            fill="currentcolor" class="govuk-header__logotype" aria-label="GOV.UK"
+          ><title>GOV.UK</title>
+            <g>
+                <circle cx="20" cy="17.6" r="3.7"/>
+                <circle cx="10.2" cy="23.5" r="3.7"/>
+                <circle cx="3.7" cy="33.2" r="3.7"/>
+                <circle cx="31.7" cy="30.6" r="3.7"/>
+                <circle cx="43.3" cy="17.6" r="3.7"/>
+                <circle cx="53.2" cy="23.5" r="3.7"/>
+                <circle cx="59.7" cy="33.2" r="3.7"/>
+                <circle cx="31.7" cy="30.6" r="3.7"/>
+                <path d="M33.1,9.8c.2-.1.3-.3.5-.5l4.6,2.4v-6.8l-4.6,1.5c-.1-.2-.3-.3-.5-.5l1.9-5.9h-6.7l1.9,5.9c-.2.1-.3.3-.5.5l-4.6-1.5v6.8l4.6-2.4c.1.2.3.3.5.5l-2.6,8c-.9,2.8,1.2,5.7,4.1,5.7h0c3,0,5.1-2.9,4.1-5.7l-2.6-8ZM37,37.9s-3.4,3.8-4.1,6.1c2.2,0,4.2-.5,6.4-2.8l-.7,8.5c-2-2.8-4.4-4.1-5.7-3.8.1,3.1.5,6.7,5.8,7.2,3.7.3,6.7-1.5,7-3.8.4-2.6-2-4.3-3.7-1.6-1.4-4.5,2.4-6.1,4.9-3.2-1.9-4.5-1.8-7.7,2.4-10.9,3,4,2.6,7.3-1.2,11.1,2.4-1.3,6.2,0,4,4.6-1.2-2.8-3.7-2.2-4.2.2-.3,1.7.7,3.7,3,4.2,1.9.3,4.7-.9,7-5.9-1.3,0-2.4.7-3.9,1.7l2.4-8c.6,2.3,1.4,3.7,2.2,4.5.6-1.6.5-2.8,0-5.3l5,1.8c-2.6,3.6-5.2,8.7-7.3,17.5-7.4-1.1-15.7-1.7-24.5-1.7h0c-8.8,0-17.1.6-24.5,1.7-2.1-8.9-4.7-13.9-7.3-17.5l5-1.8c-.5,2.5-.6,3.7,0,5.3.8-.8,1.6-2.3,2.2-4.5l2.4,8c-1.5-1-2.6-1.7-3.9-1.7,2.3,5,5.2,6.2,7,5.9,2.3-.4,3.3-2.4,3-4.2-.5-2.4-3-3.1-4.2-.2-2.2-4.6,1.6-6,4-4.6-3.7-3.7-4.2-7.1-1.2-11.1,4.2,3.2,4.3,6.4,2.4,10.9,2.5-2.8,6.3-1.3,4.9,3.2-1.8-2.7-4.1-1-3.7,1.6.3,2.3,3.3,4.1,7,3.8,5.4-.5,5.7-4.2,5.8-7.2-1.3-.2-3.7,1-5.7,3.8l-.7-8.5c2.2,2.3,4.2,2.7,6.4,2.8-.7-2.3-4.1-6.1-4.1-6.1h10.6,0Z"/>
+              </g>
+            
+              <circle class="govuk-logo-dot" cx="226" cy="36" r="7.3"/>
+              <path d="M93.94 41.25c.4 1.81 1.2 3.21 2.21 4.62 1 1.4 2.21 2.41 3.61 3.21s3.21 1.2 5.22 1.2 3.61-.4 4.82-1c1.4-.6 2.41-1.4 3.21-2.41.8-1 1.4-2.01 1.61-3.01s.4-2.01.4-3.01v.14h-10.86v-7.02h20.07v24.08h-8.03v-5.56c-.6.8-1.38 1.61-2.19 2.41-.8.8-1.81 1.2-2.81 1.81-1 .4-2.21.8-3.41 1.2s-2.41.4-3.81.4a18.56 18.56 0 0 1-14.65-6.63c-1.6-2.01-3.01-4.41-3.81-7.02s-1.4-5.62-1.4-8.83.4-6.02 1.4-8.83a20.45 20.45 0 0 1 19.46-13.65c3.21 0 4.01.2 5.82.8 1.81.4 3.61 1.2 5.02 2.01 1.61.8 2.81 2.01 4.01 3.21s2.21 2.61 2.81 4.21l-7.63 4.41c-.4-1-1-1.81-1.61-2.61-.6-.8-1.4-1.4-2.21-2.01-.8-.6-1.81-1-2.81-1.4-1-.4-2.21-.4-3.61-.4-2.01 0-3.81.4-5.22 1.2-1.4.8-2.61 1.81-3.61 3.21s-1.61 2.81-2.21 4.62c-.4 1.81-.6 3.71-.6 5.42s.8 5.22.8 5.22Zm57.8-27.9c3.21 0 6.22.6 8.63 1.81 2.41 1.2 4.82 2.81 6.62 4.82S170.2 24.39 171 27s1.4 5.62 1.4 8.83-.4 6.02-1.4 8.83-2.41 5.02-4.01 7.02-4.01 3.61-6.62 4.82-5.42 1.81-8.63 1.81-6.22-.6-8.63-1.81-4.82-2.81-6.42-4.82-3.21-4.41-4.01-7.02-1.4-5.62-1.4-8.83.4-6.02 1.4-8.83 2.41-5.02 4.01-7.02 4.01-3.61 6.42-4.82 5.42-1.81 8.63-1.81Zm0 36.73c1.81 0 3.61-.4 5.02-1s2.61-1.81 3.61-3.01 1.81-2.81 2.21-4.41c.4-1.81.8-3.61.8-5.62 0-2.21-.2-4.21-.8-6.02s-1.2-3.21-2.21-4.62c-1-1.2-2.21-2.21-3.61-3.01s-3.21-1-5.02-1-3.61.4-5.02 1c-1.4.8-2.61 1.81-3.61 3.01s-1.81 2.81-2.21 4.62c-.4 1.81-.8 3.61-.8 5.62 0 2.41.2 4.21.8 6.02.4 1.81 1.2 3.21 2.21 4.41s2.21 2.21 3.61 3.01c1.4.8 3.21 1 5.02 1Zm36.32 7.96-12.24-44.15h9.83l8.43 32.77h.4l8.23-32.77h9.83L200.3 58.04h-12.24Zm74.14-7.96c2.18 0 3.51-.6 3.51-.6 1.2-.6 2.01-1 2.81-1.81s1.4-1.81 1.81-2.81a13 13 0 0 0 .8-4.01V13.9h8.63v28.15c0 2.41-.4 4.62-1.4 6.62-.8 2.01-2.21 3.61-3.61 5.02s-3.41 2.41-5.62 3.21-4.62 1.2-7.02 1.2-5.02-.4-7.02-1.2c-2.21-.8-4.01-1.81-5.62-3.21s-2.81-3.01-3.61-5.02-1.4-4.21-1.4-6.62V13.9h8.63v26.95c0 1.61.2 3.01.8 4.01.4 1.2 1.2 2.21 2.01 2.81.8.8 1.81 1.4 2.81 1.81 0 0 1.34.6 3.51.6Zm34.22-36.18v18.92l15.65-18.92h10.82l-15.03 17.32 16.03 26.83h-10.21l-11.44-20.21-5.62 6.22v13.99h-8.83V13.9"/>
+            
+          </svg>
+          <span class="govuk-header__product-name">One Login Account Interventions Service</span>
+        
+      </a>
+    </div>
+  </div>
+</div>
+
+
+  
+
+  <div 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </div>
+
+
+
+
+    
+      <div class="govuk-width-container">
+        
+        
+        <main class="govuk-main-wrapper" id="main-content">
+          
+  <a href="/" class="govuk-back-link">Back</a>
+
+  
+  <h1 class="govuk-heading-xl">Account Status</h1>
+  <p class="govuk-body">User ID:
+    <strong>test-user-id</strong>
+  </p>
+  
+<h2 class="govuk-heading-l">Active Interventions</h1>
+
+  
+    
+    
+      
+    
+    
+
+  
+<dl class="govuk-summary-list">
+
+  
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      PERMANENT_SUSPENSION
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <strong class="govuk-tag govuk-tag--red">Active</strong>
+    </dd>
+    
+  </div>
+  
+
+</dl>
+
+  
+
+
+  
+<h2 class="govuk-heading-m">History</h2>
+
+  
+    <div class="govuk-inset-text govuk-!-margin-bottom-5">
+      <p class="govuk-body-xs govuk-hint govuk-!-margin-bottom-4">Sent at:
+        <strong>14 July 2026 at 09:27:59 UTC</strong>
+      </p>
+      
+      
+        
+      
+      
+        
+      
+      
+      
+        
+      
+      
+
+  
+
+  
+
+  
+
+  
+
+  
+<dl class="govuk-summary-list govuk-!-margin-bottom-4 govuk-!-font-size-16">
+
+  
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Component
+    </dt>
+    <dd class="govuk-summary-list__value">
+      TEST
+    </dd>
+    
+  </div>
+  
+
+  
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Reason
+    </dt>
+    <dd class="govuk-summary-list__value">
+      Reason
+    </dd>
+    
+  </div>
+  
+
+  
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Code
+    </dt>
+    <dd class="govuk-summary-list__value">
+      01
+    </dd>
+    
+  </div>
+  
+
+  
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Originating Component
+    </dt>
+    <dd class="govuk-summary-list__value">
+      TICF
+    </dd>
+    
+  </div>
+  
+
+  
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Requester ID
+    </dt>
+    <dd class="govuk-summary-list__value">
+      interventions@digital.cabinet-office.gov.uk
+    </dd>
+    
+  </div>
+  
+
+</dl>
+
+      
+        
+        
+          
+            
+          
+          
+        
+        
+
+  
+<dl class="govuk-summary-list govuk-!-margin-bottom-0 govuk-!-font-size-16">
+
+  
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      TEMPORARY_SUSPENSION
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <strong class="govuk-tag govuk-tag--red">ACTIVE</strong>
+    </dd>
+    
+  </div>
+  
+
+</dl>
+
+      
+    </div>
+  
+
+
+  
+
+
+  <h2 class="govuk-heading-m">Send Intervention</h2>
+  <form method="post" action="/send">
+    <input type="hidden" name="userId" value="test-user-id"/> 
+
+
+<div class="govuk-form-group">
+  <label class="govuk-label" for="intervention-code">
+    Intervention type
+  </label>
+
+
+
+  <select class="govuk-select" id="intervention-code" name="interventionCode">
+  
+    
+    <option value="01">01 - FRAUD_SUSPEND_ACCOUNT</option>
+    
+  
+    
+    <option value="02">02 - FRAUD_UNSUSPEND_ACCOUNT</option>
+    
+  
+    
+    <option value="03">03 - FRAUD_BLOCK_ACCOUNT</option>
+    
+  
+    
+    <option value="04">04 - FRAUD_FORCED_USER_PASSWORD_RESET</option>
+    
+  
+    
+    <option value="05">05 - FRAUD_FORCED_USER_IDENTITY_REVERIFICATION</option>
+    
+  
+    
+    <option value="06">06 - FRAUD_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_REVERIFICATION</option>
+    
+  
+    
+    <option value="07">07 - FRAUD_UNBLOCK_ACCOUNT</option>
+    
+  
+  </select>
+
+</div>
+
+    
+<button type="submit" class="govuk-button" data-module="govuk-button">
+  Send TxMA Message
+</button>
+
+  </form>
+
+
+
+        </main>
+        
+        
+      </div>
+    
+
+    
+    
+
+    
+  <div class="govuk-footer">
+  <div class="govuk-width-container">
+  <svg
+    focusable="false"
+    role="presentation"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 64 60"
+    height="30"
+    width="32"
+    fill="currentcolor" class="govuk-footer__crown"
+  >
+    <g>
+        <circle cx="20" cy="17.6" r="3.7"/>
+        <circle cx="10.2" cy="23.5" r="3.7"/>
+        <circle cx="3.7" cy="33.2" r="3.7"/>
+        <circle cx="31.7" cy="30.6" r="3.7"/>
+        <circle cx="43.3" cy="17.6" r="3.7"/>
+        <circle cx="53.2" cy="23.5" r="3.7"/>
+        <circle cx="59.7" cy="33.2" r="3.7"/>
+        <circle cx="31.7" cy="30.6" r="3.7"/>
+        <path d="M33.1,9.8c.2-.1.3-.3.5-.5l4.6,2.4v-6.8l-4.6,1.5c-.1-.2-.3-.3-.5-.5l1.9-5.9h-6.7l1.9,5.9c-.2.1-.3.3-.5.5l-4.6-1.5v6.8l4.6-2.4c.1.2.3.3.5.5l-2.6,8c-.9,2.8,1.2,5.7,4.1,5.7h0c3,0,5.1-2.9,4.1-5.7l-2.6-8ZM37,37.9s-3.4,3.8-4.1,6.1c2.2,0,4.2-.5,6.4-2.8l-.7,8.5c-2-2.8-4.4-4.1-5.7-3.8.1,3.1.5,6.7,5.8,7.2,3.7.3,6.7-1.5,7-3.8.4-2.6-2-4.3-3.7-1.6-1.4-4.5,2.4-6.1,4.9-3.2-1.9-4.5-1.8-7.7,2.4-10.9,3,4,2.6,7.3-1.2,11.1,2.4-1.3,6.2,0,4,4.6-1.2-2.8-3.7-2.2-4.2.2-.3,1.7.7,3.7,3,4.2,1.9.3,4.7-.9,7-5.9-1.3,0-2.4.7-3.9,1.7l2.4-8c.6,2.3,1.4,3.7,2.2,4.5.6-1.6.5-2.8,0-5.3l5,1.8c-2.6,3.6-5.2,8.7-7.3,17.5-7.4-1.1-15.7-1.7-24.5-1.7h0c-8.8,0-17.1.6-24.5,1.7-2.1-8.9-4.7-13.9-7.3-17.5l5-1.8c-.5,2.5-.6,3.7,0,5.3.8-.8,1.6-2.3,2.2-4.5l2.4,8c-1.5-1-2.6-1.7-3.9-1.7,2.3,5,5.2,6.2,7,5.9,2.3-.4,3.3-2.4,3-4.2-.5-2.4-3-3.1-4.2-.2-2.2-4.6,1.6-6,4-4.6-3.7-3.7-4.2-7.1-1.2-11.1,4.2,3.2,4.3,6.4,2.4,10.9,2.5-2.8,6.3-1.3,4.9,3.2-1.8-2.7-4.1-1-3.7,1.6.3,2.3,3.3,4.1,7,3.8,5.4-.5,5.7-4.2,5.8-7.2-1.3-.2-3.7,1-5.7,3.8l-.7-8.5c2.2,2.3,4.2,2.7,6.4,2.8-.7-2.3-4.1-6.1-4.1-6.1h10.6,0Z"/>
+      </g>
+    
+  </svg>
+
+    
+    <div class="govuk-footer__meta">
+      <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+        
+        <h2 class="govuk-visually-hidden">Support links</h2>
+        
+        <ul class="govuk-footer__inline-list">
+        
+          <li class="govuk-footer__inline-list-item">
+            <a class="govuk-footer__link" href="https://signin.account.gov.uk/accessibility-statement">
+              Accessibility statement
+            </a>
+          </li>
+        
+          <li class="govuk-footer__inline-list-item">
+            <a class="govuk-footer__link" href="https://signin.account.gov.uk/cookies">
+              Cookies
+            </a>
+          </li>
+        
+          <li class="govuk-footer__inline-list-item">
+            <a class="govuk-footer__link" href="https://signin.account.gov.uk/terms-and-conditions">
+              Terms and conditions
+            </a>
+          </li>
+        
+          <li class="govuk-footer__inline-list-item">
+            <a class="govuk-footer__link" href="https://signin.account.gov.uk/privacy-notice">
+              Privacy notice
+            </a>
+          </li>
+        
+        </ul>
+        
+        
+        
+        
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            class="govuk-footer__licence-logo"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 483.2 195.7"
+            height="17"
+            width="41"
+          >
+            <path
+              fill="currentColor"
+              d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
+            />
+          </svg>
+          <span class="govuk-footer__licence-description">
+          
+            All content is available under the <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+          
+          </span>
+        
+      </div>
+      <div class="govuk-footer__meta-item">
+        <a
+          class="govuk-footer__link govuk-footer__copyright-logo"
+          href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
+        >
+        
+          © Crown copyright
+        
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+
+    
+  <script type="module" src="/assets/govuk-frontend.min.js" nonce=""></script>
+  <script type="module" nonce="">
+    import {initAll} from '/assets/govuk-frontend.min.js'
+    initAll()
+  </script>
+
+  </body>
+</html>
+"
+`;
+
+exports[`rendered page snapshots > renders the user details page with no interventions 1`] = `
+"<!DOCTYPE html>
+<html lang="en" class="govuk-template">
+  <head>
+    <meta charset="utf-8">
+    <title>Account Interventions Service – GOV.UK</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="theme-color" content="#1d70b8">
+
+    
+  <link rel="stylesheet" href="/assets/govuk-frontend.min.css"/>
+
+
+    
+      <link rel="icon" sizes="48x48" href="/assets/images/favicon.ico">
+      <link rel="icon" sizes="any" href="/assets/images/favicon.svg" type="image/svg+xml">
+      <link rel="mask-icon" href="/assets/images/govuk-icon-mask.svg" color="#1d70b8">
+      <link rel="apple-touch-icon" href="/assets/images/govuk-icon-180.png">
+      <link rel="manifest" href="/assets/manifest.json">
+    
+    
+  </head>
+  <body class="govuk-template__body">
+    <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
+    
+
+    
+        <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+
+      
+
+    
+    
+
+    
+  
+
+
+
+
+<div class="govuk-header">
+  <div class="govuk-header__container govuk-width-container">
+    <div class="govuk-header__logo">
+      <a href="/" class="govuk-header__homepage-link">
+        
+          <svg
+            focusable="false"
+            role="img"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 324 60"
+            height="30"
+            width="162"
+            fill="currentcolor" class="govuk-header__logotype" aria-label="GOV.UK"
+          ><title>GOV.UK</title>
+            <g>
+                <circle cx="20" cy="17.6" r="3.7"/>
+                <circle cx="10.2" cy="23.5" r="3.7"/>
+                <circle cx="3.7" cy="33.2" r="3.7"/>
+                <circle cx="31.7" cy="30.6" r="3.7"/>
+                <circle cx="43.3" cy="17.6" r="3.7"/>
+                <circle cx="53.2" cy="23.5" r="3.7"/>
+                <circle cx="59.7" cy="33.2" r="3.7"/>
+                <circle cx="31.7" cy="30.6" r="3.7"/>
+                <path d="M33.1,9.8c.2-.1.3-.3.5-.5l4.6,2.4v-6.8l-4.6,1.5c-.1-.2-.3-.3-.5-.5l1.9-5.9h-6.7l1.9,5.9c-.2.1-.3.3-.5.5l-4.6-1.5v6.8l4.6-2.4c.1.2.3.3.5.5l-2.6,8c-.9,2.8,1.2,5.7,4.1,5.7h0c3,0,5.1-2.9,4.1-5.7l-2.6-8ZM37,37.9s-3.4,3.8-4.1,6.1c2.2,0,4.2-.5,6.4-2.8l-.7,8.5c-2-2.8-4.4-4.1-5.7-3.8.1,3.1.5,6.7,5.8,7.2,3.7.3,6.7-1.5,7-3.8.4-2.6-2-4.3-3.7-1.6-1.4-4.5,2.4-6.1,4.9-3.2-1.9-4.5-1.8-7.7,2.4-10.9,3,4,2.6,7.3-1.2,11.1,2.4-1.3,6.2,0,4,4.6-1.2-2.8-3.7-2.2-4.2.2-.3,1.7.7,3.7,3,4.2,1.9.3,4.7-.9,7-5.9-1.3,0-2.4.7-3.9,1.7l2.4-8c.6,2.3,1.4,3.7,2.2,4.5.6-1.6.5-2.8,0-5.3l5,1.8c-2.6,3.6-5.2,8.7-7.3,17.5-7.4-1.1-15.7-1.7-24.5-1.7h0c-8.8,0-17.1.6-24.5,1.7-2.1-8.9-4.7-13.9-7.3-17.5l5-1.8c-.5,2.5-.6,3.7,0,5.3.8-.8,1.6-2.3,2.2-4.5l2.4,8c-1.5-1-2.6-1.7-3.9-1.7,2.3,5,5.2,6.2,7,5.9,2.3-.4,3.3-2.4,3-4.2-.5-2.4-3-3.1-4.2-.2-2.2-4.6,1.6-6,4-4.6-3.7-3.7-4.2-7.1-1.2-11.1,4.2,3.2,4.3,6.4,2.4,10.9,2.5-2.8,6.3-1.3,4.9,3.2-1.8-2.7-4.1-1-3.7,1.6.3,2.3,3.3,4.1,7,3.8,5.4-.5,5.7-4.2,5.8-7.2-1.3-.2-3.7,1-5.7,3.8l-.7-8.5c2.2,2.3,4.2,2.7,6.4,2.8-.7-2.3-4.1-6.1-4.1-6.1h10.6,0Z"/>
+              </g>
+            
+              <circle class="govuk-logo-dot" cx="226" cy="36" r="7.3"/>
+              <path d="M93.94 41.25c.4 1.81 1.2 3.21 2.21 4.62 1 1.4 2.21 2.41 3.61 3.21s3.21 1.2 5.22 1.2 3.61-.4 4.82-1c1.4-.6 2.41-1.4 3.21-2.41.8-1 1.4-2.01 1.61-3.01s.4-2.01.4-3.01v.14h-10.86v-7.02h20.07v24.08h-8.03v-5.56c-.6.8-1.38 1.61-2.19 2.41-.8.8-1.81 1.2-2.81 1.81-1 .4-2.21.8-3.41 1.2s-2.41.4-3.81.4a18.56 18.56 0 0 1-14.65-6.63c-1.6-2.01-3.01-4.41-3.81-7.02s-1.4-5.62-1.4-8.83.4-6.02 1.4-8.83a20.45 20.45 0 0 1 19.46-13.65c3.21 0 4.01.2 5.82.8 1.81.4 3.61 1.2 5.02 2.01 1.61.8 2.81 2.01 4.01 3.21s2.21 2.61 2.81 4.21l-7.63 4.41c-.4-1-1-1.81-1.61-2.61-.6-.8-1.4-1.4-2.21-2.01-.8-.6-1.81-1-2.81-1.4-1-.4-2.21-.4-3.61-.4-2.01 0-3.81.4-5.22 1.2-1.4.8-2.61 1.81-3.61 3.21s-1.61 2.81-2.21 4.62c-.4 1.81-.6 3.71-.6 5.42s.8 5.22.8 5.22Zm57.8-27.9c3.21 0 6.22.6 8.63 1.81 2.41 1.2 4.82 2.81 6.62 4.82S170.2 24.39 171 27s1.4 5.62 1.4 8.83-.4 6.02-1.4 8.83-2.41 5.02-4.01 7.02-4.01 3.61-6.62 4.82-5.42 1.81-8.63 1.81-6.22-.6-8.63-1.81-4.82-2.81-6.42-4.82-3.21-4.41-4.01-7.02-1.4-5.62-1.4-8.83.4-6.02 1.4-8.83 2.41-5.02 4.01-7.02 4.01-3.61 6.42-4.82 5.42-1.81 8.63-1.81Zm0 36.73c1.81 0 3.61-.4 5.02-1s2.61-1.81 3.61-3.01 1.81-2.81 2.21-4.41c.4-1.81.8-3.61.8-5.62 0-2.21-.2-4.21-.8-6.02s-1.2-3.21-2.21-4.62c-1-1.2-2.21-2.21-3.61-3.01s-3.21-1-5.02-1-3.61.4-5.02 1c-1.4.8-2.61 1.81-3.61 3.01s-1.81 2.81-2.21 4.62c-.4 1.81-.8 3.61-.8 5.62 0 2.41.2 4.21.8 6.02.4 1.81 1.2 3.21 2.21 4.41s2.21 2.21 3.61 3.01c1.4.8 3.21 1 5.02 1Zm36.32 7.96-12.24-44.15h9.83l8.43 32.77h.4l8.23-32.77h9.83L200.3 58.04h-12.24Zm74.14-7.96c2.18 0 3.51-.6 3.51-.6 1.2-.6 2.01-1 2.81-1.81s1.4-1.81 1.81-2.81a13 13 0 0 0 .8-4.01V13.9h8.63v28.15c0 2.41-.4 4.62-1.4 6.62-.8 2.01-2.21 3.61-3.61 5.02s-3.41 2.41-5.62 3.21-4.62 1.2-7.02 1.2-5.02-.4-7.02-1.2c-2.21-.8-4.01-1.81-5.62-3.21s-2.81-3.01-3.61-5.02-1.4-4.21-1.4-6.62V13.9h8.63v26.95c0 1.61.2 3.01.8 4.01.4 1.2 1.2 2.21 2.01 2.81.8.8 1.81 1.4 2.81 1.81 0 0 1.34.6 3.51.6Zm34.22-36.18v18.92l15.65-18.92h10.82l-15.03 17.32 16.03 26.83h-10.21l-11.44-20.21-5.62 6.22v13.99h-8.83V13.9"/>
+            
+          </svg>
+          <span class="govuk-header__product-name">One Login Account Interventions Service</span>
+        
+      </a>
+    </div>
+  </div>
+</div>
+
+
+  
+
+  <div 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </div>
+
+
+
+
+    
+      <div class="govuk-width-container">
+        
+        
+        <main class="govuk-main-wrapper" id="main-content">
+          
+  <a href="/" class="govuk-back-link">Back</a>
+
+  
+  <h1 class="govuk-heading-xl">Account Status</h1>
+  <p class="govuk-body">User ID:
+    <strong>test-user-id</strong>
+  </p>
+  
+<h2 class="govuk-heading-l">Active Interventions</h1>
+
+  
+    <p class="govuk-body">There are no active interventions on this account.</p>
+  
+
+
+  
+<h2 class="govuk-heading-m">History</h2>
+
+  <p class="govuk-body-s">No history available for this account.</p>
+
+
+  
+
+
+  <h2 class="govuk-heading-m">Send Intervention</h2>
+  <form method="post" action="/send">
+    <input type="hidden" name="userId" value="test-user-id"/> 
+
+
+<div class="govuk-form-group">
+  <label class="govuk-label" for="intervention-code">
+    Intervention type
+  </label>
+
+
+
+  <select class="govuk-select" id="intervention-code" name="interventionCode">
+  
+    
+    <option value="01">01 - FRAUD_SUSPEND_ACCOUNT</option>
+    
+  
+    
+    <option value="02">02 - FRAUD_UNSUSPEND_ACCOUNT</option>
+    
+  
+    
+    <option value="03">03 - FRAUD_BLOCK_ACCOUNT</option>
+    
+  
+    
+    <option value="04">04 - FRAUD_FORCED_USER_PASSWORD_RESET</option>
+    
+  
+    
+    <option value="05">05 - FRAUD_FORCED_USER_IDENTITY_REVERIFICATION</option>
+    
+  
+    
+    <option value="06">06 - FRAUD_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_REVERIFICATION</option>
+    
+  
+    
+    <option value="07">07 - FRAUD_UNBLOCK_ACCOUNT</option>
+    
+  
+  </select>
+
+</div>
+
+    
+<button type="submit" class="govuk-button" data-module="govuk-button">
+  Send TxMA Message
+</button>
+
+  </form>
+
+
+
+        </main>
+        
+        
+      </div>
+    
+
+    
+    
+
+    
+  <div class="govuk-footer">
+  <div class="govuk-width-container">
+  <svg
+    focusable="false"
+    role="presentation"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 64 60"
+    height="30"
+    width="32"
+    fill="currentcolor" class="govuk-footer__crown"
+  >
+    <g>
+        <circle cx="20" cy="17.6" r="3.7"/>
+        <circle cx="10.2" cy="23.5" r="3.7"/>
+        <circle cx="3.7" cy="33.2" r="3.7"/>
+        <circle cx="31.7" cy="30.6" r="3.7"/>
+        <circle cx="43.3" cy="17.6" r="3.7"/>
+        <circle cx="53.2" cy="23.5" r="3.7"/>
+        <circle cx="59.7" cy="33.2" r="3.7"/>
+        <circle cx="31.7" cy="30.6" r="3.7"/>
+        <path d="M33.1,9.8c.2-.1.3-.3.5-.5l4.6,2.4v-6.8l-4.6,1.5c-.1-.2-.3-.3-.5-.5l1.9-5.9h-6.7l1.9,5.9c-.2.1-.3.3-.5.5l-4.6-1.5v6.8l4.6-2.4c.1.2.3.3.5.5l-2.6,8c-.9,2.8,1.2,5.7,4.1,5.7h0c3,0,5.1-2.9,4.1-5.7l-2.6-8ZM37,37.9s-3.4,3.8-4.1,6.1c2.2,0,4.2-.5,6.4-2.8l-.7,8.5c-2-2.8-4.4-4.1-5.7-3.8.1,3.1.5,6.7,5.8,7.2,3.7.3,6.7-1.5,7-3.8.4-2.6-2-4.3-3.7-1.6-1.4-4.5,2.4-6.1,4.9-3.2-1.9-4.5-1.8-7.7,2.4-10.9,3,4,2.6,7.3-1.2,11.1,2.4-1.3,6.2,0,4,4.6-1.2-2.8-3.7-2.2-4.2.2-.3,1.7.7,3.7,3,4.2,1.9.3,4.7-.9,7-5.9-1.3,0-2.4.7-3.9,1.7l2.4-8c.6,2.3,1.4,3.7,2.2,4.5.6-1.6.5-2.8,0-5.3l5,1.8c-2.6,3.6-5.2,8.7-7.3,17.5-7.4-1.1-15.7-1.7-24.5-1.7h0c-8.8,0-17.1.6-24.5,1.7-2.1-8.9-4.7-13.9-7.3-17.5l5-1.8c-.5,2.5-.6,3.7,0,5.3.8-.8,1.6-2.3,2.2-4.5l2.4,8c-1.5-1-2.6-1.7-3.9-1.7,2.3,5,5.2,6.2,7,5.9,2.3-.4,3.3-2.4,3-4.2-.5-2.4-3-3.1-4.2-.2-2.2-4.6,1.6-6,4-4.6-3.7-3.7-4.2-7.1-1.2-11.1,4.2,3.2,4.3,6.4,2.4,10.9,2.5-2.8,6.3-1.3,4.9,3.2-1.8-2.7-4.1-1-3.7,1.6.3,2.3,3.3,4.1,7,3.8,5.4-.5,5.7-4.2,5.8-7.2-1.3-.2-3.7,1-5.7,3.8l-.7-8.5c2.2,2.3,4.2,2.7,6.4,2.8-.7-2.3-4.1-6.1-4.1-6.1h10.6,0Z"/>
+      </g>
+    
+  </svg>
+
+    
+    <div class="govuk-footer__meta">
+      <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+        
+        <h2 class="govuk-visually-hidden">Support links</h2>
+        
+        <ul class="govuk-footer__inline-list">
+        
+          <li class="govuk-footer__inline-list-item">
+            <a class="govuk-footer__link" href="https://signin.account.gov.uk/accessibility-statement">
+              Accessibility statement
+            </a>
+          </li>
+        
+          <li class="govuk-footer__inline-list-item">
+            <a class="govuk-footer__link" href="https://signin.account.gov.uk/cookies">
+              Cookies
+            </a>
+          </li>
+        
+          <li class="govuk-footer__inline-list-item">
+            <a class="govuk-footer__link" href="https://signin.account.gov.uk/terms-and-conditions">
+              Terms and conditions
+            </a>
+          </li>
+        
+          <li class="govuk-footer__inline-list-item">
+            <a class="govuk-footer__link" href="https://signin.account.gov.uk/privacy-notice">
+              Privacy notice
+            </a>
+          </li>
+        
+        </ul>
+        
+        
+        
+        
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            class="govuk-footer__licence-logo"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 483.2 195.7"
+            height="17"
+            width="41"
+          >
+            <path
+              fill="currentColor"
+              d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
+            />
+          </svg>
+          <span class="govuk-footer__licence-description">
+          
+            All content is available under the <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+          
+          </span>
+        
+      </div>
+      <div class="govuk-footer__meta-item">
+        <a
+          class="govuk-footer__link govuk-footer__copyright-logo"
+          href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
+        >
+        
+          © Crown copyright
+        
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+
+    
+  <script type="module" src="/assets/govuk-frontend.min.js" nonce=""></script>
+  <script type="module" nonce="">
+    import {initAll} from '/assets/govuk-frontend.min.js'
+    initAll()
+  </script>
+
+  </body>
+</html>
+"
+`;

--- a/src/frontend/tests/__snapshots__/app.snapshot.test.ts.snap
+++ b/src/frontend/tests/__snapshots__/app.snapshot.test.ts.snap
@@ -468,21 +468,13 @@ data-module="govuk-service-navigation"
 
   
     <div class="govuk-inset-text govuk-!-margin-bottom-5">
-      <p class="govuk-body-xs govuk-hint govuk-!-margin-bottom-4">Sent at:
+      <p class="govuk-body-xs govuk-hint govuk-!-margin-bottom-4">
         <strong>14 July 2026 at 09:27:59 UTC</strong>
       </p>
       
       
-        
-      
-      
-        
-      
-      
-      
-        
-      
-      
+
+  
 
   
 
@@ -546,6 +538,18 @@ data-module="govuk-service-navigation"
   
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
+      Originator Reference ID
+    </dt>
+    <dd class="govuk-summary-list__value">
+      N/A
+    </dd>
+    
+  </div>
+  
+
+  
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
       Requester ID
     </dt>
     <dd class="govuk-summary-list__value">
@@ -587,6 +591,57 @@ data-module="govuk-service-navigation"
       
     </div>
   
+  <h2 class="govuk-heading-m govuk-!-margin-top-7">Field descriptions</h2>
+  
+
+  
+
+  
+
+  
+<dl class="govuk-summary-list">
+
+  
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Originating Component
+    </dt>
+    <dd class="govuk-summary-list__value">
+      The component id of the application in which the intervention originator, i.e., ticket, case, assessment, etc., that triggered the intervention.<br>
+                <a href="https://event-catalogue.internal.account.gov.uk/attributes/extensions-intervention-originating_component_id/" class="govuk-link">View in event catalogue</a>
+    </dd>
+    
+  </div>
+  
+
+  
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Originator Reference ID
+    </dt>
+    <dd class="govuk-summary-list__value">
+      The unique id of the ticket, case, risk assessment, etc., from which the intervention resulted.<br>
+                <a href="https://event-catalogue.internal.account.gov.uk/attributes/extensions-intervention-originator_reference_id/" class="govuk-link">View in event catalogue</a>
+    </dd>
+    
+  </div>
+  
+
+  
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Requester ID
+    </dt>
+    <dd class="govuk-summary-list__value">
+      The unique id used by the originating component to identify the user who triggered the intervention - will be a number or GUID, must not be personal identifying - must be provided if a manual intervention.<br>
+                <a href="https://event-catalogue.internal.account.gov.uk/attributes/extensions-intervention-requester_id/" class="govuk-link">View in event catalogue</a>
+    </dd>
+    
+  </div>
+  
+
+</dl>
+
 
 
   

--- a/src/frontend/tests/app.snapshot.test.ts
+++ b/src/frontend/tests/app.snapshot.test.ts
@@ -1,0 +1,93 @@
+import { init } from '../app';
+import { InterventionStub, InterventionName, InterventionState } from '@govuk-one-login/ais-status-sdk';
+import { StubAuthoriser } from '../authoriser';
+import type { APIGatewayProxyEvent, Context } from 'aws-lambda';
+
+vi.mock('@aws-lambda-powertools/logger');
+
+type InitArgs = Parameters<typeof init>;
+
+// Initialise the server with a StubAuthoriser and decorate awsLambda so that
+// server.inject() requests satisfy the onRequest auth hook without a real Lambda event.
+function initWithStubAuth(...args: InitArgs) {
+  const server = init(...args);
+  server.decorateRequest('awsLambda', {
+    getter: () =>
+      ({ event: { requestContext: { authorizer: {} } }, context: {} }) as {
+        event: APIGatewayProxyEvent;
+        context: Context;
+      },
+  });
+  return server;
+}
+
+// These snapshot tests pin the full rendered HTML of each page so that any
+// unintended change to a template (or the data threaded into it) is caught.
+// The output is deterministic in the test environment: STAGE_PREFIX/SUBPATH are
+// unset, no nonce is threaded through, and history dates are formatted in UTC.
+describe('rendered page snapshots', () => {
+  // Goal: pin the search/landing page markup. Method: request GET / and snapshot the body.
+  it('renders the index page', async () => {
+    const server = initWithStubAuth(
+      new InterventionStub({ result: { interventions: [] } }),
+      undefined,
+      undefined,
+      new StubAuthoriser(),
+    );
+
+    const response = await server.inject({ method: 'GET', url: '/' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toMatchSnapshot();
+  });
+
+  // Goal: pin the user-details page markup for an account with a single historical
+  // intervention. Method: stub the client with a fixed history line (fixed sentAt so
+  // the formatted date is stable) and snapshot the body.
+  it('renders the user details page with history', async () => {
+    const server = initWithStubAuth(
+      new InterventionStub({
+        interventionNames: [InterventionName.PERMANENT_SUSPENSION],
+        historyResult: {
+          lines: [
+            {
+              sentAt: 1784021279000,
+              componentId: 'TEST',
+              interventionName: InterventionName.TEMPORARY_SUSPENSION,
+              interventionState: InterventionState.ACTIVE,
+              interventionReason: 'Reason',
+              interventionCode: '01',
+              originatingComponent: 'TICF',
+              requesterId: 'interventions@digital.cabinet-office.gov.uk',
+              tagId: 'abc1234',
+            },
+          ],
+        },
+      }),
+      undefined,
+      undefined,
+      new StubAuthoriser(),
+    );
+
+    const response = await server.inject({ method: 'GET', url: '/user/test-user-id' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toMatchSnapshot();
+  });
+
+  // Goal: pin the user-details page markup for an account with no interventions and
+  // no history. Method: stub an empty account and snapshot the body.
+  it('renders the user details page with no interventions', async () => {
+    const server = initWithStubAuth(
+      new InterventionStub({ result: { interventions: [] }, historyResult: { lines: [] } }),
+      undefined,
+      undefined,
+      new StubAuthoriser(),
+    );
+
+    const response = await server.inject({ method: 'GET', url: '/user/test-user-id' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toMatchSnapshot();
+  });
+});

--- a/src/frontend/tests/app.snapshot.test.ts
+++ b/src/frontend/tests/app.snapshot.test.ts
@@ -1,25 +1,10 @@
 import { init } from '../app';
 import { InterventionStub, InterventionName, InterventionState } from '@govuk-one-login/ais-status-sdk';
 import { StubAuthoriser } from '../authoriser';
-import type { APIGatewayProxyEvent, Context } from 'aws-lambda';
+import { StubMessageService } from '../../services/message-service';
+import { FeatureFlagsStub } from '../../services/feature-flags';
 
 vi.mock('@aws-lambda-powertools/logger');
-
-type InitArgs = Parameters<typeof init>;
-
-// Initialise the server with a StubAuthoriser and decorate awsLambda so that
-// server.inject() requests satisfy the onRequest auth hook without a real Lambda event.
-function initWithStubAuth(...args: InitArgs) {
-  const server = init(...args);
-  server.decorateRequest('awsLambda', {
-    getter: () =>
-      ({ event: { requestContext: { authorizer: {} } }, context: {} }) as {
-        event: APIGatewayProxyEvent;
-        context: Context;
-      },
-  });
-  return server;
-}
 
 // These snapshot tests pin the full rendered HTML of each page so that any
 // unintended change to a template (or the data threaded into it) is caught.
@@ -28,11 +13,15 @@ function initWithStubAuth(...args: InitArgs) {
 describe('rendered page snapshots', () => {
   // Goal: pin the search/landing page markup. Method: request GET / and snapshot the body.
   it('renders the index page', async () => {
-    const server = initWithStubAuth(
-      new InterventionStub({ result: { interventions: [] } }),
-      undefined,
-      undefined,
-      new StubAuthoriser(),
+    const server = init(
+      {
+        interventionClient: new InterventionStub({ result: { interventions: [] } }),
+        messageService: new StubMessageService(),
+        authoriser: new StubAuthoriser(),
+      },
+      {
+        featureFlags: new FeatureFlagsStub({ aisFrontend: true, aisSendTxMA: true }),
+      },
     );
 
     const response = await server.inject({ method: 'GET', url: '/' });
@@ -45,28 +34,32 @@ describe('rendered page snapshots', () => {
   // intervention. Method: stub the client with a fixed history line (fixed sentAt so
   // the formatted date is stable) and snapshot the body.
   it('renders the user details page with history', async () => {
-    const server = initWithStubAuth(
-      new InterventionStub({
-        interventionNames: [InterventionName.PERMANENT_SUSPENSION],
-        historyResult: {
-          lines: [
-            {
-              sentAt: 1784021279000,
-              componentId: 'TEST',
-              interventionName: InterventionName.TEMPORARY_SUSPENSION,
-              interventionState: InterventionState.ACTIVE,
-              interventionReason: 'Reason',
-              interventionCode: '01',
-              originatingComponent: 'TICF',
-              requesterId: 'interventions@digital.cabinet-office.gov.uk',
-              tagId: 'abc1234',
-            },
-          ],
-        },
-      }),
-      undefined,
-      undefined,
-      new StubAuthoriser(),
+    const server = init(
+      {
+        interventionClient: new InterventionStub({
+          interventionNames: [InterventionName.PERMANENT_SUSPENSION],
+          historyResult: {
+            lines: [
+              {
+                sentAt: 1784021279000,
+                componentId: 'TEST',
+                interventionName: InterventionName.TEMPORARY_SUSPENSION,
+                interventionState: InterventionState.ACTIVE,
+                interventionReason: 'Reason',
+                interventionCode: '01',
+                originatingComponent: 'TICF',
+                requesterId: 'interventions@digital.cabinet-office.gov.uk',
+                tagId: 'abc1234',
+              },
+            ],
+          },
+        }),
+        messageService: new StubMessageService(),
+        authoriser: new StubAuthoriser(),
+      },
+      {
+        featureFlags: new FeatureFlagsStub({ aisFrontend: true, aisSendTxMA: true }),
+      },
     );
 
     const response = await server.inject({ method: 'GET', url: '/user/test-user-id' });
@@ -78,11 +71,15 @@ describe('rendered page snapshots', () => {
   // Goal: pin the user-details page markup for an account with no interventions and
   // no history. Method: stub an empty account and snapshot the body.
   it('renders the user details page with no interventions', async () => {
-    const server = initWithStubAuth(
-      new InterventionStub({ result: { interventions: [] }, historyResult: { lines: [] } }),
-      undefined,
-      undefined,
-      new StubAuthoriser(),
+    const server = init(
+      {
+        interventionClient: new InterventionStub({ result: { interventions: [] } }),
+        messageService: new StubMessageService(),
+        authoriser: new StubAuthoriser(),
+      },
+      {
+        featureFlags: new FeatureFlagsStub({ aisFrontend: true, aisSendTxMA: true }),
+      },
     );
 
     const response = await server.inject({ method: 'GET', url: '/user/test-user-id' });


### PR DESCRIPTION
## What

This adds some basic snapshot testing for the intervention history UI, and an npm script for updating the snapshots.

## Why

We have no actual testing for the output of the rendered HTML at the moment.

## Notes

### Issue tracking

- [FPAD-8611](https://govukverify.atlassian.net/browse/FPAD-8611)


[FPAD-8611]: https://govukverify.atlassian.net/browse/FPAD-8611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ