### PR TITLE
FPAD-8595: Improve intervention terminology

### DIFF
--- a/src/frontend/app.ts
+++ b/src/frontend/app.ts
@@ -5,7 +5,13 @@ import formbody from '@fastify/formbody';
 import nunjucks from 'nunjucks';
 import path from 'node:path';
 import { existsSync } from 'node:fs';
-import { AccountHistory, HistoryLine, InterventionClientInterface } from '@govuk-one-login/ais-status-sdk';
+import {
+  AccountHistory,
+  HistoryLine,
+  InterventionClientInterface,
+  InterventionName,
+  InterventionState,
+} from '@govuk-one-login/ais-status-sdk';
 import { APIGatewayProxyEvent, Context } from 'aws-lambda';
 import { FeatureFlags } from '../services/feature-flags';
 import cookie from '@fastify/cookie';
@@ -218,10 +224,34 @@ export function init(
   return server;
 }
 
+interface DisplayHistoryLine extends HistoryLine {
+  displayState: string;
+}
+
 interface HistoryTransaction extends Omit<HistoryLine, 'interventionName' | 'interventionState'> {
   tagId: string;
   sentAtFormatted: string;
-  interventionEvents: HistoryLine[];
+  interventionEvents: DisplayHistoryLine[];
+}
+
+export function getDisplayState(line: HistoryLine): string {
+  console.log('intervention state', line.interventionState)
+  console.log('intervention name', line.interventionName)
+  if (line.interventionState === InterventionState.MITIGATED &&
+      (line.interventionName !== InterventionName.TEMPORARY_SUSPENSION &&
+       line.interventionName !== InterventionName.PERMANENT_SUSPENSION)
+     ) {
+      return 'COMPLETED';
+  }
+  if (line.interventionState === InterventionState.REMOVED &&
+    (line.interventionName === InterventionName.TEMPORARY_SUSPENSION ||
+      line.interventionName === InterventionName.PERMANENT_SUSPENSION)
+  ) {
+    console.log('unsuspended')
+    return 'UNSUSPENDED'
+  }
+  console.log('always here')
+  return line.interventionState;
 }
 
 export const formatHistory = (history: AccountHistory): HistoryTransaction[] =>
@@ -233,9 +263,9 @@ export const formatHistory = (history: AccountHistory): HistoryTransaction[] =>
       result[line.tagId] = {
         ...rest,
         sentAtFormatted: formatDate(line.sentAt),
-        interventionEvents: [...(result[line.tagId]?.interventionEvents ?? []), line],
+        interventionEvents: [...(result[line.tagId]?.interventionEvents ?? []), { ...line, displayState: getDisplayState(line) }],
       };
-
+      // console.log(JSON.stringify(result))
       return result;
     }, {}),
   ).toSorted((a, b) => b.sentAt - a.sentAt);

--- a/src/frontend/app.ts
+++ b/src/frontend/app.ts
@@ -245,10 +245,8 @@ export function getDisplayState(line: HistoryLine): string {
     (line.interventionName === InterventionName.TEMPORARY_SUSPENSION ||
       line.interventionName === InterventionName.PERMANENT_SUSPENSION)
   ) {
-    console.log('unsuspended')
     return 'UNSUSPENDED'
   }
-  console.log('always here')
   return line.interventionState;
 }
 

--- a/src/frontend/app.ts
+++ b/src/frontend/app.ts
@@ -235,8 +235,6 @@ interface HistoryTransaction extends Omit<HistoryLine, 'interventionName' | 'int
 }
 
 export function getDisplayState(line: HistoryLine): string {
-  console.log('intervention state', line.interventionState)
-  console.log('intervention name', line.interventionName)
   if (line.interventionState === InterventionState.MITIGATED &&
       (line.interventionName !== InterventionName.TEMPORARY_SUSPENSION &&
        line.interventionName !== InterventionName.PERMANENT_SUSPENSION)
@@ -265,7 +263,6 @@ export const formatHistory = (history: AccountHistory): HistoryTransaction[] =>
         sentAtFormatted: formatDate(line.sentAt),
         interventionEvents: [...(result[line.tagId]?.interventionEvents ?? []), { ...line, displayState: getDisplayState(line) }],
       };
-      // console.log(JSON.stringify(result))
       return result;
     }, {}),
   ).toSorted((a, b) => b.sentAt - a.sentAt);

--- a/src/frontend/tests/app.test.ts
+++ b/src/frontend/tests/app.test.ts
@@ -1,4 +1,10 @@
-import { formatHistory, init, generateVerifyRequest, FrontendAppConfig, FrontendAppDependencies } from '../app';
+import { formatHistory,
+  init,
+  generateVerifyRequest,
+  FrontendAppConfig,
+  FrontendAppDependencies,
+  getDisplayState,
+} from '../app';
 import { InterventionStub, InterventionName, InterventionState } from '@govuk-one-login/ais-status-sdk';
 import { StubMessageService } from '../../services/message-service';
 import type { SendMessageCommandOutput } from '@aws-sdk/client-sqs';
@@ -42,6 +48,15 @@ interface ValidationErrorBody {
   error: string;
   message: string;
 }
+
+const makeLine = (interventionName: InterventionName, interventionState: InterventionState) => ({
+  sentAt: 1784021279000,
+  componentId: 'TEST',
+  interventionName,
+  interventionState,
+  interventionReason: 'Reason',
+  tagId: 'tag1',
+})
 
 // ---------------------------------------------------------------------------
 // generateVerifyRequest — unit tests (tests the exported hook factory directly)
@@ -687,6 +702,7 @@ describe('formatHistory', () => {
             interventionName: 'TEMPORARY_SUSPENSION',
             interventionReason: 'Reason',
             interventionState: 'REMOVED',
+            displayState: 'UNSUSPENDED',
             originatingComponent: 'TICF',
             requesterId: 'interventions@digital.cabinet-office.gov.uk',
             sentAt: 1784021279020,
@@ -698,6 +714,7 @@ describe('formatHistory', () => {
             interventionName: 'RESET_PASSWORD',
             interventionReason: 'Reason',
             interventionState: 'ACTIVE',
+            displayState: 'ACTIVE',
             originatingComponent: 'TICF',
             requesterId: 'interventions@digital.cabinet-office.gov.uk',
             sentAt: 1784021279020,
@@ -721,6 +738,7 @@ describe('formatHistory', () => {
             interventionName: 'TEMPORARY_SUSPENSION',
             interventionReason: 'Reason',
             interventionState: 'ACTIVE',
+            displayState: 'ACTIVE',
             originatingComponent: 'TICF',
             requesterId: 'interventions@digital.cabinet-office.gov.uk',
             sentAt: 1784021279000,
@@ -735,5 +753,39 @@ describe('formatHistory', () => {
         tagId: 'abc1234',
       },
     ]);
+  });
+});
+
+describe('getDisplayState', () => {
+  it('returns COMPLETED when RESET_PASSWORD is MITIGATED', () => {
+    expect(getDisplayState(makeLine(InterventionName.RESET_PASSWORD, InterventionState.MITIGATED))).toBe('COMPLETED');
+  });
+
+  it('returns COMPLETED when REPROVE_IDENTITY is MITIGATED', () => {
+    expect(getDisplayState(makeLine(InterventionName.REPROVE_IDENTITY, InterventionState.MITIGATED))).toBe('COMPLETED');
+  });
+
+  it('returns UNSUSPENDED when TEMPORARY_SUSPENSION is REMOVED', () => {
+    expect(getDisplayState(makeLine(InterventionName.TEMPORARY_SUSPENSION, InterventionState.REMOVED))).toBe('UNSUSPENDED');
+  });
+
+  it('returns UNSUSPENDED when PERMANENT_SUSPENSION is REMOVED', () => {
+    expect(getDisplayState(makeLine(InterventionName.PERMANENT_SUSPENSION, InterventionState.REMOVED))).toBe('UNSUSPENDED');
+  });
+
+  it('returns the original state when TEMPORARY_SUSPENSION is ACTIVE', () => {
+    expect(getDisplayState(makeLine(InterventionName.TEMPORARY_SUSPENSION, InterventionState.ACTIVE))).toBe('ACTIVE');
+  });
+
+  it('returns the original state when RESET_PASSWORD is REMOVED', () => {
+    expect(getDisplayState(makeLine(InterventionName.RESET_PASSWORD, InterventionState.REMOVED))).toBe('REMOVED');
+  });
+
+  it('returns the original state when TEMPORARY_SUSPENSION is SUPERSEDED', () => {
+    expect(getDisplayState(makeLine(InterventionName.TEMPORARY_SUSPENSION, InterventionState.SUPERSEDED))).toBe('SUPERSEDED');
+  });
+
+  it('returns the original state when RESET_PASSWORD is ACTIVE', () => {
+    expect(getDisplayState(makeLine(InterventionName.RESET_PASSWORD, InterventionState.ACTIVE))).toBe('ACTIVE');
   });
 });

--- a/src/frontend/views/user/_history.njk
+++ b/src/frontend/views/user/_history.njk
@@ -41,7 +41,7 @@
           {% endif %}
           {% set eventRows = eventRows.concat([{
               key: { text: event.interventionName },
-              value: { html: '<strong class="govuk-tag govuk-tag--' + stateColour + '">' + event.interventionState + '</strong>' }
+              value: { html: '<strong class="govuk-tag govuk-tag--' + stateColour + '">' + event.displayState + '</strong>' }
             }]) %}
         {% endfor %}
         {{ govukSummaryList({ classes: "govuk-!-margin-bottom-0 govuk-!-font-size-16", rows: eventRows }) }}


### PR DESCRIPTION
<!-- https://jml.io/posts/what-why-notes/ -->

## What
Improve intervention terminology as per user feedback:
- Non-suspension interventions which have been dealt with by the user should be COMPLETED (instead of MITIGATED)
- Suspension interventions which have been removed for any reason should use the verb UNSUSPENDED (instead of MITIGATED) - (mitigated is listed in the ticket but I think this should be instead of REMOVED?)

## Why
We want to use terminology that is familiar to our users 

## Notes

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [FPAD-8595](https://govukverify.atlassian.net/browse/FPAD-8595)


[FPAD-8595]: https://govukverify.atlassian.net/browse/FPAD-8595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ